### PR TITLE
add permissions to get resource pod/exec

### DIFF
--- a/charts/latest/spdk-csi/templates/config-map.yaml
+++ b/charts/latest/spdk-csi/templates/config-map.yaml
@@ -106,7 +106,7 @@ data:
 
         print(f"Cluster not activated: Number of 'online' storage nodes is less than {total_value} after maximum retries.")
 
-    # Load environment variables
+    print("Loaded environment variables")
     action_type = os.getenv("ACTION_TYPE")
     uuid = os.getenv("SNODE_UUID", "")
     distr_ndcs = int(os.getenv("DISTR_NDCS", 1)) if os.getenv("DISTR_NDCS", "").isdigit() else 1
@@ -124,7 +124,7 @@ data:
         "Authorization": f"{cluster_uuid} {cluster_secret}"
     }
 
-    # Check the action type and perform the appropriate action
+    print(f"action type: {action_type}. performing appropriate action")
     if action_type == "cl_activate":
         # Check if we should activate the cluster
         activate_cluster_if_needed(cluster_ip, cluster_uuid, cluster_secret, distr_ndcs, distr_npcs)

--- a/charts/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node.yaml
@@ -12,7 +12,7 @@ metadata:
   name: storage-node-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "namespaces"]
+  resources: ["pods", "namespaces", "pods/exec"]
   verbs: ["list", "get", "create", "delete"]
 - apiGroups: ["apps"]
   resources: ["deployments"]


### PR DESCRIPTION
https://github.com/simplyblock-io/sbcli/blob/7851ed11714b7be87b4888369f0eb8c474a341c7/simplyblock_web/blueprints/snode_ops_k8s.py#L496-L504


Recently a change was introduced to exec SPDK Container and get the firewall information. But appropriate permissions are not added to helm charts. 


So adding them as a part of this PR.