### PR TITLE
add readiness and liveness probe for storagenode

### DIFF
--- a/charts/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node.yaml
@@ -116,6 +116,24 @@ spec:
           mountPath: /dev
         - name: etc-simplyblock
           mountPath: /etc/simplyblock
+        livenessProbe:
+          httpGet:
+            path: /snode/get_firewall
+            port: 5000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /snode/get_firewall
+            port: 5000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 3
 
 {{- end }}
 


### PR DESCRIPTION
adding liveness and readiness probe to make sure that there is no networking issue

<img width="679" alt="Screenshot 2025-04-03 at 11 39 42" src="https://github.com/user-attachments/assets/ef029695-cee5-4fa2-9697-8c9756f0fe6b" />


### Tested how

tested by upgrading a cluster: 

Observations:
* nodes are up, only after passing the readiness probe
* nodes are restarted if the liveness probe fails.


