### PR TITLE
removed function updateConnectionInfo

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -248,42 +248,7 @@ func execWithTimeoutRetry(cmdLine []string, timeout, retry int) (err error) {
 	return err
 }
 
-func (nvmf *initiatorNVMf) updateConnectionInfo() error {
-	parts := strings.Split(nvmf.nqn, ":")
-	if len(parts) < 4 || parts[2] != "lvol" {
-		return fmt.Errorf("invalid NQN format, lvol_id not found: %s", nvmf.nqn)
-	}
-	lvolID := parts[3]
-
-	resp, err := nvmf.client.CallSBCLI("GET", "/lvol/connect/"+lvolID, nil)
-	if err != nil {
-		klog.Errorf("failed to fetch connection details for lvol_id %s: %v", lvolID, err)
-		return err
-	}
-
-	var result []*LvolConnectResp
-	respBytes, err := json.Marshal(resp)
-	if err != nil {
-		return fmt.Errorf("failed to marshal response: %v", err)
-	}
-
-	if err := json.Unmarshal(respBytes, &result); err != nil {
-		return fmt.Errorf("failed to unmarshal connection details: %v", err)
-	}
-
-	for i := range nvmf.connections {
-		nvmf.connections[i].IP = result[i].IP
-	}
-	return nil
-}
-
 func (nvmf *initiatorNVMf) Connect() (string, error) {
-
-	if err := nvmf.updateConnectionInfo(); err != nil {
-		return "", fmt.Errorf("failed to update connection info: %v", err)
-	}
-
-	// nvme connect -t tcp -a 192.168.1.100 -s 4420 -n "nqn"
 	klog.Info("connections", nvmf.connections)
 	for i, conn := range nvmf.connections {
 		cmdLine := []string{


### PR DESCRIPTION
- We introduced a function that updated nvmf connection info when lvols moved to a new instance with a new IP we manually delete and add pod again to use new info.

- Currently we have connection monitor that automatically detects this and switches to the new connection info

- we removed the function in this PR as we no longer have need for this