### PR TITLE
pass pvc_name and pvc_namespace as a part of clone

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -669,8 +669,11 @@ func (cs *controllerServer) handleSnapshotSource(snapshot *csi.VolumeContentSour
 
 	klog.Infof("CreateSnapshot : snapshotID=%s", sbSnapshot.snapshotID)
 	snapshotName := req.GetName()
+	params := req.GetParameters()
+	pvcName, _ := params[CSIStorageNameKey]
+	pvcNamespace, _ := params[CSIStorageNamespaceKey]
 	newSize := fmt.Sprintf("%dM", sizeMiB)
-	volumeID, err := sbclient.CloneSnapshot(sbSnapshot.snapshotID, snapshotName, newSize)
+	volumeID, err := sbclient.CloneSnapshot(sbSnapshot.snapshotID, snapshotName, newSize, pvcName, pvcNamespace)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
@@ -690,6 +693,10 @@ func (cs *controllerServer) handleVolumeSource(srcVolume *csi.VolumeContentSourc
 	klog.Infof("srcVolumeID=%s", srcVolumeID)
 
 	snapshotName := req.GetName()
+	params := req.GetParameters()
+	pvcName, _ := params[CSIStorageNameKey]
+	pvcNamespace, _ := params[CSIStorageNamespaceKey]
+
 	spdkVol, err := getSPDKVol(srcVolumeID)
 	if err != nil {
 		klog.Errorf("failed to get spdk volume, srcVolumeID: %s err: %v", srcVolumeID, err)
@@ -715,7 +722,7 @@ func (cs *controllerServer) handleVolumeSource(srcVolume *csi.VolumeContentSourc
 		klog.Errorf("failed to get spdk snapshot, snapshotID: %s err: %v", snapshotID, err)
 		return nil, err
 	}
-	volumeID, err := sbclient.CloneSnapshot(snapshot.snapshotID, snapshotName, newSize)
+	volumeID, err := sbclient.CloneSnapshot(snapshot.snapshotID, snapshotName, newSize, pvcName, pvcNamespace)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -342,15 +342,17 @@ func (client *RPCClient) resizeVolume(lvolID string, size int64) (bool, error) {
 }
 
 // cloneSnapshot clones a snapshot
-func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize string) (string, error) {
+func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace string) (string, error) {
 	params := struct {
-		SnapshotID string `json:"snapshot_id"`
-		CloneName  string `json:"clone_name"`
-		//	NewSize    string `json:"new_size"`
+		SnapshotID   string `json:"snapshot_id"`
+		CloneName    string `json:"clone_name"`
+		PVCName      string `json:"pvc_name,omitempty"`
+		PVCNamespace string `json:"pvc_namespace,omitempty"`
 	}{
 		SnapshotID: snapshotID,
 		CloneName:  cloneName,
-		//	NewSize:    newSize,
+		PVCName: 	pvcName,
+		PVCNamespace: pvcNamespace,
 	}
 
 	klog.V(5).Infof("cloned volume size: %s", newSize)

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -129,8 +129,8 @@ func (node *NodeNVMf) ListSnapshots() ([]*SnapshotResp, error) {
 }
 
 // CloneSnapshot clones a snapshot to a new volume
-func (node *NodeNVMf) CloneSnapshot(snapshotID, cloneName, newSize string) (string, error) {
-	lvolID, err := node.Client.cloneSnapshot(snapshotID, cloneName, newSize)
+func (node *NodeNVMf) CloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace string) (string, error) {
+	lvolID, err := node.Client.cloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION

As a part of https://github.com/simplyblock-io/sbcli/pull/438, additional optional parameters are introduced so that CSI driver can pass pvc_name and pvc_namespace. 

