### PR TITLE
remove namespace specification during clone

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -671,9 +671,8 @@ func (cs *controllerServer) handleSnapshotSource(snapshot *csi.VolumeContentSour
 	snapshotName := req.GetName()
 	params := req.GetParameters()
 	pvcName, _ := params[CSIStorageNameKey]
-	pvcNamespace, _ := params[CSIStorageNamespaceKey]
 	newSize := fmt.Sprintf("%dM", sizeMiB)
-	volumeID, err := sbclient.CloneSnapshot(sbSnapshot.snapshotID, snapshotName, newSize, pvcName, pvcNamespace)
+	volumeID, err := sbclient.CloneSnapshot(sbSnapshot.snapshotID, snapshotName, newSize, pvcName)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
@@ -695,7 +694,6 @@ func (cs *controllerServer) handleVolumeSource(srcVolume *csi.VolumeContentSourc
 	snapshotName := req.GetName()
 	params := req.GetParameters()
 	pvcName, _ := params[CSIStorageNameKey]
-	pvcNamespace, _ := params[CSIStorageNamespaceKey]
 
 	spdkVol, err := getSPDKVol(srcVolumeID)
 	if err != nil {
@@ -722,7 +720,7 @@ func (cs *controllerServer) handleVolumeSource(srcVolume *csi.VolumeContentSourc
 		klog.Errorf("failed to get spdk snapshot, snapshotID: %s err: %v", snapshotID, err)
 		return nil, err
 	}
-	volumeID, err := sbclient.CloneSnapshot(snapshot.snapshotID, snapshotName, newSize, pvcName, pvcNamespace)
+	volumeID, err := sbclient.CloneSnapshot(snapshot.snapshotID, snapshotName, newSize, pvcName)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -344,15 +344,13 @@ func (client *RPCClient) resizeVolume(lvolID string, size int64) (bool, error) {
 // cloneSnapshot clones a snapshot
 func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace string) (string, error) {
 	params := struct {
-		SnapshotID   string `json:"snapshot_id"`
-		CloneName    string `json:"clone_name"`
-		PVCName      string `json:"pvc_name,omitempty"`
-		PVCNamespace string `json:"pvc_namespace,omitempty"`
+		SnapshotID string `json:"snapshot_id"`
+		CloneName  string `json:"clone_name"`
+		PVCName    string `json:"pvc_name,omitempty"`
 	}{
 		SnapshotID: snapshotID,
 		CloneName:  cloneName,
-		PVCName: 	pvcName,
-		PVCNamespace: pvcNamespace,
+		PVCName:    pvcName,
 	}
 
 	klog.V(5).Infof("cloned volume size: %s", newSize)

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -342,7 +342,7 @@ func (client *RPCClient) resizeVolume(lvolID string, size int64) (bool, error) {
 }
 
 // cloneSnapshot clones a snapshot
-func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace string) (string, error) {
+func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName string) (string, error) {
 	params := struct {
 		SnapshotID string `json:"snapshot_id"`
 		CloneName  string `json:"clone_name"`

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -33,12 +33,12 @@ type NodeNVMf struct {
 func NewNVMf(clusterID, clusterIP, clusterSecret string) *NodeNVMf {
 	client := RPCClient{
 		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second},
-		ClusterID:    clusterID,
-		ClusterIP:    clusterIP,
+		ClusterID:     clusterID,
+		ClusterIP:     clusterIP,
 		ClusterSecret: clusterSecret,
 	}
 	return &NodeNVMf{
-		Client:        &client,
+		Client: &client,
 	}
 }
 
@@ -63,24 +63,24 @@ func (node *NodeNVMf) VolumeInfo(lvolID string) (map[string]string, error) {
 
 // CreateLVolData is the data structure for creating a logical volume
 type CreateLVolData struct {
-	LvolName     string `json:"name"`
-	Size         string `json:"size"`
-	LvsName      string `json:"pool"`
-	Compression  bool   `json:"comp"`
-	Encryption   bool   `json:"crypto"`
-	MaxRWIOPS    string `json:"max_rw_iops"`
-	MaxRWmBytes  string `json:"max_rw_mbytes"`
-	MaxRmBytes   string `json:"max_r_mbytes"`
-	MaxWmBytes   string `json:"max_w_mbytes"`
-	MaxSize      string `json:"max_size"`
-	DistNdcs     int    `json:"distr_ndcs"`
-	DistNpcs     int    `json:"distr_npcs"`
-	PriorClass   int    `json:"lvol_priority_class"`
-	CryptoKey1   string `json:"crypto_key1"`
-	CryptoKey2   string `json:"crypto_key2"`
-	HostID       string `json:"host_id"`
-	LvolID       string `json:"uid"`
-	PvcName      string `json:"pvc_name"`
+	LvolName    string `json:"name"`
+	Size        string `json:"size"`
+	LvsName     string `json:"pool"`
+	Compression bool   `json:"comp"`
+	Encryption  bool   `json:"crypto"`
+	MaxRWIOPS   string `json:"max_rw_iops"`
+	MaxRWmBytes string `json:"max_rw_mbytes"`
+	MaxRmBytes  string `json:"max_r_mbytes"`
+	MaxWmBytes  string `json:"max_w_mbytes"`
+	MaxSize     string `json:"max_size"`
+	DistNdcs    int    `json:"distr_ndcs"`
+	DistNpcs    int    `json:"distr_npcs"`
+	PriorClass  int    `json:"lvol_priority_class"`
+	CryptoKey1  string `json:"crypto_key1"`
+	CryptoKey2  string `json:"crypto_key2"`
+	HostID      string `json:"host_id"`
+	LvolID      string `json:"uid"`
+	PvcName     string `json:"pvc_name"`
 }
 
 // CreateVolume creates a logical volume and returns volume ID
@@ -129,8 +129,8 @@ func (node *NodeNVMf) ListSnapshots() ([]*SnapshotResp, error) {
 }
 
 // CloneSnapshot clones a snapshot to a new volume
-func (node *NodeNVMf) CloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace string) (string, error) {
-	lvolID, err := node.Client.cloneSnapshot(snapshotID, cloneName, newSize, pvcName, pvcNamespace)
+func (node *NodeNVMf) CloneSnapshot(snapshotID, cloneName, newSize, pvcName string) (string, error) {
+	lvolID, err := node.Client.cloneSnapshot(snapshotID, cloneName, newSize, pvcName)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- sending namespace as part of the request data breaks the volume creation as we did here https://github.com/simplyblock-io/simplyblock-csi/pull/165/files






