### PR TITLE
Revert "Logic to try again NodeRestart E2E tests on failure"

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
@@ -25,6 +25,7 @@ stringData:
 
 {{- end }}
 
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
@@ -917,11 +916,7 @@ func restartStorageNode(c kubernetes.Interface, nodeID string) error {
 	s := creds.Simplyblock
 	err = s.restartStorageNode(nodeID)
 	if err != nil {
-		klog.Infof("failed to restart storage node: %s. Trying again...", err)
-		err = s.restartStorageNode(nodeID)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Reverts simplyblock-io/simplyblock-csi#170

Kubernetes E2E tests have passed in GCP with the changes from this PR and https://github.com/simplyblock-io/sbcli/pull/479
