### PR TITLE
always create simplyblock-csi-secret V2 secrets

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
@@ -23,7 +23,8 @@ stringData:
   secret.json: |-
 {{ toJson .Values.csiSecret | indent 4 -}}
 
----
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -41,4 +42,4 @@ stringData:
       ]
     }
 
-{{- end }}
+---


### PR DESCRIPTION
When trying to do deployment, it creates only `simplyblock-csi-secret-v2` but not `simplyblock-csi-secret`

making a change so that  simplyblock-csi-secret V2 secrets are always created




