### PR TITLE
fixed issue with simplyblock-csi-secret

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
@@ -21,9 +21,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   secret.json: |-
-{{ toJson .Values.csiSecret | indent 4 -}}
-
-{{- end }}
+{{ toJson .Values.csiSecret | indent 4 }}
 
 ---
 apiVersion: v1
@@ -43,4 +41,4 @@ stringData:
       ]
     }
 
----
+{{- end }}


### PR DESCRIPTION
- Fixed issue with not installing **simplyblock-csi-secret** 
```
user@users-MacBook-Pro-2 ~ % kubectl -n spdk-csi get secret                               
NAME                                  TYPE                 DATA   AGE
sh.helm.release.v1.sb-controller.v1   helm.sh/release.v1   1      6m5s
sh.helm.release.v1.spdk-csi.v1        helm.sh/release.v1   1      8m15s
simplyblock-csi-secret                Opaque               1      8m14s
simplyblock-csi-secret-v2             Opaque               1      8m14s
simplyblock-pvc-keys                  Opaque               2      8m14s
```