### PR TITLE
remove readiness & liveness probe for storage node

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
@@ -132,24 +132,6 @@ spec:
           mountPath: /etc/simplyblock
         - name: host-sys
           mountPath: /sys
-        livenessProbe:
-          httpGet:
-            path: /snode/get_firewall
-            port: 5000
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 60
-          timeoutSeconds: 5
-          failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /snode/get_firewall
-            port: 5000
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 60
-          timeoutSeconds: 5
-          failureThreshold: 3
 
 {{- end }}
 


### PR DESCRIPTION
With the changes in https://github.com/simplyblock-io/sbcli/pull/479 the APIs `/snode/get_firewall` are deprecated and no longer used. 