### PR TITLE
run docker container as a non root user

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
@@ -73,10 +73,10 @@ spec:
           mountPath: /registration
       - name: csi-node
         securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN", "SYS_MODULE"]
-          allowPrivilegeEscalation: true
+          privileged: true # Needs to run as root user to access kubelet plugins folder and to load kernel modules
+          runAsUser: 0
+          runAsGroup: 0
+          readOnlyRootFilesystem: true
         image: "{{ .Values.image.csi.repository }}:{{ .Values.image.csi.tag }}"
         imagePullPolicy: {{ .Values.image.csi.pullPolicy }}
         args:

--- a/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
@@ -75,6 +75,14 @@ spec:
           hostPath:
             path: /lib/modules
       hostNetwork: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
       {{- if .tolerations.create }}
       tolerations:
       {{- range .tolerations.list }}

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -4,14 +4,26 @@
 #
 # XXX: pin alpine to 3.8 with e2fsprogs-1.44
 # e2fsprogs-1.45+ crashes my test vm when running mkfs.ext4
-FROM alpine:3.18
+FROM alpine:3.22
 LABEL maintainers="SPDK-CSI Authors"
 LABEL description="SPDK-CSI Plugin"
 
-COPY spdkcsi /usr/local/bin/spdkcsi
+# Add a non-root system user
+RUN addgroup -S spdkcsi && adduser -S -G spdkcsi spdkcsi && \
+    apk add --no-cache \
+        blkid \
+        e2fsprogs \
+        e2fsprogs-extra \
+        nvme-cli \
+        open-iscsi \
+        util-linux \
+        xfsprogs \
+        xfsprogs-extra
 
-RUN apk update && \
-    apk add nvme-cli open-iscsi e2fsprogs xfsprogs blkid xfsprogs-extra e2fsprogs-extra util-linux
+COPY --chown=spdkcsi:spdkcsi spdkcsi /usr/local/bin/spdkcsi
+RUN chmod 0755 /usr/local/bin/spdkcsi
+
+# Drop to non-root user
+USER spdkcsi
 
 ENTRYPOINT ["/usr/local/bin/spdkcsi"]
-


### PR DESCRIPTION
All containers use root as their user, even unpriviledged ones, which is against Kubernetes best practices and doesn’t work on OpenShift

Also
Deployment descriptors do not define an SCC (security context constraint). This should at least be a valid variable to be passed into the template rendering for all containers.


Successful e2e test run: 
~https://github.com/simplyblock-io/simplyBlockDeployGCP/actions/runs/16492760187~