### PR TITLE
fix: skip filesystem resize for raw block volumes in NodeExpandVolume

### DIFF
--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -465,6 +465,16 @@ func (ns *nodeServer) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVol
 		return nil, status.Errorf(codes.Internal, "could not find device path for volume %s", volumeID)
 	}
 
+	// For raw block volumes, the block device has already been resized at the
+	// storage layer. Skipping filesystem resize is correct here because:
+	// - resize2fs (ext4) can operate on an unmounted raw device, so it worked accidentally
+	// - xfs_growfs requires a mounted filesystem path and cannot operate on raw block devices
+	// Neither tool should be invoked for block volumes.
+	if cap := req.GetVolumeCapability(); cap != nil && cap.GetBlock() != nil {
+		klog.Infof("NodeExpandVolume: volume %s is a block device, skipping filesystem resize", volumeID)
+		return &csi.NodeExpandVolumeResponse{}, nil
+	}
+
 	resizer := mount.NewResizeFs(exec.New())
 	needsResize, err := resizer.NeedResize(devicePath, volumeMountPath)
 	if err != nil {


### PR DESCRIPTION
Currently this is how resize for block devices works: 
* if the block device has no filesystem on it, we simply move forward and mark the resize as success. 
* if the block device has a filesystem on it:
   * if the filesystem is `ext4`, the drive resizes it. 
   * if the filesystem is `xfs` the driver attempts to resize and this is the error that's seen. 
   * `needs resizing: could not find block size of device`

```
cat <<EOF | kubectl apply -f -
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: spdkcsi-pvc
  annotations:
    simplybk/secret-name: simplyblock-pvc-keys
    simplybk/secret-namespace: default
    simplybk/qos-rw-iops: "123"
    simplybk/qos-rw-mbytes: "234"
    simplybk/qos-r-mbytes: "345"
    simplybk/qos-w-mbytes: "456"
spec:
  volumeMode: Block
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
  storageClassName: simplyblock-csi-sc

---
kind: Pod
apiVersion: v1
metadata:
  name: spdkcsi-test
spec:
  containers:
  - name: alpine
    image: alpine:3
    imagePullPolicy: IfNotPresent
    command: ["sleep", "365d"]
    volumeDevices:
    - name: spdk-volume
      devicePath: /dev/xvda
  volumes:
  - name: spdk-volume
    persistentVolumeClaim:
      claimName: spdkcsi-pvc
EOF
```

```
kubectl patch pvc spdkcsi-pvc-ext4test -p '{"spec":{"resources":{"requests":{"storage":"2Gi"}}}}'
```



For raw block volumes, the block device is already resized at the storage layer. So there is no need to resize it again on the CSI driver side. 