### PR TITLE
fix: use fresh host-iface from API instead of stale PV volume context

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -365,8 +365,12 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 				"-c", nvmf.reconnectDelay, "-i", nvmf.nrIoQueues,
 			}
 
-			if nvmf.hostIface != "" {
-				cmdLine = append(cmdLine, "-f", nvmf.hostIface)
+			hostIface := connections[i].HostIface
+			if hostIface == "" {
+				hostIface = nvmf.hostIface
+			}
+			if hostIface != "" {
+				cmdLine = append(cmdLine, "-f", hostIface)
 			}
 
 			err := execWithTimeoutRetry(cmdLine, 40, len(nvmf.connections))
@@ -814,6 +818,9 @@ func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo int) error {
 		"-l", strconv.Itoa(ctrlLossTmo),
 		"-c", strconv.Itoa(conn.ReconnectDelay),
 		"-i", strconv.Itoa(conn.NrIoQueues),
+	}
+	if conn.HostIface != "" {
+		cmd = append(cmd, "-f", conn.HostIface)
 	}
 	if err := execWithTimeoutRetry(cmd, 40, 1); err != nil {
 		klog.Errorf("nvme connect failed: %v", err)


### PR DESCRIPTION
When `cluster.client_data_nic` is changed (e.g. `eth1` → `tun0` after upgrading to 26.1.2), volumes created before the upgrade continue to use the old interface name in `nvme connect -f`. This is because `hostIface` is stored in the Kubernetes PV `VolumeContext` at creation time and is never refreshed.

New volumes work correctly because their PV is created after the cluster setting was updated.

## Root cause

`Connect()` calls `fetchLvolConnection()` on every mount, which returns the current `host-iface` from the sbcli API but the fresh value was discarded and the stale `nvmf.hostIface` (from PV context) was used instead.

`connectViaNVMe()` (the reconnect path) had `conn.HostIface` available in the struct but never appended `-f` at all.

## Fix

- `Connect()`: prefer `connections[i].HostIface` from the fresh API response; fall back to `nvmf.hostIface` only if the API returns empty
- `connectViaNVMe()`: append `-f conn.HostIface` when set

