### PR TITLE
ci security.yaml: fix trivy-action version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,7 @@ jobs:
           tags: ${{ env.IMAGE_NAME }}:scan
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:scan
           format: sarif
@@ -60,7 +60,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Generate SBOM (CycloneDX)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.IMAGE_NAME }}:scan
           format: cyclonedx


### PR DESCRIPTION
https://github.com/simplyblock/simplyblock-csi/actions/runs/24652424370/job/72077936845
```
Error: Unable to resolve action `aquasecurity/trivy-action@0.28.0`, unable to find version `0.28.0`
```

Fixed this by updating the version
