### PR TITLE
sync backup related containers in simplyblock-tasks

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
@@ -646,6 +646,41 @@ spec:
           resources:
 {{ toYaml .resources | nindent 12 }}
 {{- end }}
+
+        - name: tasks-runner-backup
+          image: "{{ .Values.image.simplyblock.repository }}:{{ .Values.image.simplyblock.tag }}"
+          command: ["python", "simplyblock_core/services/tasks_runner_backup.py"]
+          imagePullPolicy: "{{ .Values.image.simplyblock.pullPolicy }}"
+          env:
+            - name: PROMETHEUS_URL
+              value: "{{ .Values.prometheus.simplyblock.prometheusURL }}"
+            - name: PROMETHEUS_PORT
+              value: "{{ .Values.prometheus.simplyblock.prometheusPORT }}"
+{{- with (include "simplyblock.commonContainer" . | fromYaml) }}
+{{ toYaml .env | nindent 12 }}
+          volumeMounts:
+{{ toYaml .volumeMounts | nindent 12 }}
+          resources:
+{{ toYaml .resources | nindent 12 }}
+{{- end }}
+
+        - name: tasks-runner-backup-merge
+          image: "{{ .Values.image.simplyblock.repository }}:{{ .Values.image.simplyblock.tag }}"
+          command: ["python", "simplyblock_core/services/tasks_runner_backup_merge.py"]
+          imagePullPolicy: "{{ .Values.image.simplyblock.pullPolicy }}"
+          env:
+            - name: PROMETHEUS_URL
+              value: "{{ .Values.prometheus.simplyblock.prometheusURL }}"
+            - name: PROMETHEUS_PORT
+              value: "{{ .Values.prometheus.simplyblock.prometheusPORT }}"
+{{- with (include "simplyblock.commonContainer" . | fromYaml) }}
+{{ toYaml .env | nindent 12 }}
+          volumeMounts:
+{{ toYaml .volumeMounts | nindent 12 }}
+          resources:
+{{ toYaml .resources | nindent 12 }}
+{{- end }}
+
       volumes:
         - name: fdb-cluster-file
           configMap:

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_foundationdb.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_foundationdb.yaml
@@ -54,7 +54,7 @@ spec:
             - /manager
           args:
             - "--health-probe-bind-address=:9443"
-          image: foundationdb/fdb-kubernetes-operator:v2.13.0
+          image: foundationdb/fdb-kubernetes-operator:v2.18.0
           name: manager
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Syncing a few more charts which are missing

* Backup related tasks are missing from `simplyblock-tasks`. 
* FluentBit pod which collects logs
* updating the FDB image version