### PR TITLE
add permissions for nodes on simplyblock-storage-node-sa

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["create", "delete", "get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
 
 {{- if .Values.storagenode.openShiftCluster }}
 - apiGroups: ["machineconfiguration.openshift.io"]


### PR DESCRIPTION
Every spdk_process_start call fails with a Kubernetes 403 Forbidden:


```
nodes "gke-githubactions-gk-simplyblock-pool-7c1f19ed-fg1l" is forbidden:
User "system:serviceaccount:spdk-csi:simplyblock-storage-node-sa"
cannot get resource "nodes" in API group "" at the cluster scope
```