### PR TITLE
Adapt the helm chart to enable TLS deployments

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
+++ b/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
@@ -26,10 +26,6 @@ volumeMounts:
   - name: tls
     mountPath: /etc/simplyblock/tls
     readOnly: true
-  - name: certificate-authority
-    mountPath: /etc/simplyblock/tls/ca.crt
-    subPath: service-ca.crt
-    readOnly: true
 {{- end }}
 
 resources:

--- a/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
+++ b/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
@@ -22,6 +22,15 @@ volumeMounts:
   - name: fdb-cluster-file
     mountPath: /etc/foundationdb/fdb.cluster
     subPath: fdb.cluster
+{{- if .Values.tls.enabled }}
+  - name: tls
+    mountPath: /etc/simplyblock/tls
+    readOnly: true
+  - name: certificate-authority
+    mountPath: /etc/simplyblock/tls/ca.crt
+    subPath: service-ca.crt
+    readOnly: true
+{{- end }}
 
 resources:
   requests:

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane-cabundle.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane-cabundle.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.tls.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: simplyblock-certificate-authority
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+{{ end }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
@@ -87,6 +87,15 @@ spec:
         - name: fdb-cluster-file
           mountPath: /etc/foundationdb/fdb.cluster
           subPath: fdb.cluster
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          mountPath: /etc/simplyblock/tls
+          readOnly: true
+        - name: certificate-authority
+          mountPath: /etc/simplyblock/tls/ca.crt
+          subPath: service-ca.crt
+          readOnly: true
+        {{- end }}
         resources:
           requests:
             cpu: "200m"
@@ -101,6 +110,14 @@ spec:
           items:
             - key: cluster-file
               path: fdb.cluster
+      {{- if .Values.tls.enabled }}
+      - name: tls
+        secret:
+          secretName: simplyblock-webappapi-tls
+      - name: certificate-authority
+        configMap:
+          name: simplyblock-certificate-authority
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -194,6 +211,15 @@ spec:
         - name: fdb-cluster-file
           mountPath: /etc/foundationdb/fdb.cluster
           subPath: fdb.cluster
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          mountPath: /etc/simplyblock/tls
+          readOnly: true
+        - name: certificate-authority
+          mountPath: /etc/simplyblock/tls/ca.crt
+          subPath: service-ca.crt
+          readOnly: true
+        {{- end }}
         resources:
           requests:
             cpu: "200m"
@@ -208,6 +234,14 @@ spec:
           items:
             - key: cluster-file
               path: fdb.cluster
+      {{- if .Values.tls.enabled }}
+      - name: tls
+        secret:
+          secretName: simplyblock-webappapi-tls
+      - name: certificate-authority
+        configMap:
+          name: simplyblock-certificate-authority
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -430,6 +464,14 @@ spec:
             items:
               - key: cluster-file
                 path: fdb.cluster
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: simplyblock-webappapi-tls
+        - name: certificate-authority
+          configMap:
+            name: simplyblock-certificate-authority
+        {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -688,6 +730,14 @@ spec:
             items:
               - key: cluster-file
                 path: fdb.cluster
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: simplyblock-webappapi-tls
+        - name: certificate-authority
+          configMap:
+            name: simplyblock-certificate-authority
+        {{- end }}
 
 ---
 {{- if .Values.controlplane.observability.enabled }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
@@ -91,10 +91,6 @@ spec:
         - name: tls
           mountPath: /etc/simplyblock/tls
           readOnly: true
-        - name: certificate-authority
-          mountPath: /etc/simplyblock/tls/ca.crt
-          subPath: service-ca.crt
-          readOnly: true
         {{- end }}
         resources:
           requests:
@@ -112,11 +108,15 @@ spec:
               path: fdb.cluster
       {{- if .Values.tls.enabled }}
       - name: tls
-        secret:
-          secretName: simplyblock-webappapi-tls
-      - name: certificate-authority
-        configMap:
-          name: simplyblock-certificate-authority
+        projected:
+          sources:
+          - secret:
+              name: simplyblock-webappapi-tls
+          - configMap:
+              name: simplyblock-certificate-authority
+              items:
+              - key: service-ca.crt
+                path: ca.crt
       {{- end }}
 ---
 apiVersion: apps/v1
@@ -215,10 +215,6 @@ spec:
         - name: tls
           mountPath: /etc/simplyblock/tls
           readOnly: true
-        - name: certificate-authority
-          mountPath: /etc/simplyblock/tls/ca.crt
-          subPath: service-ca.crt
-          readOnly: true
         {{- end }}
         resources:
           requests:
@@ -236,11 +232,15 @@ spec:
               path: fdb.cluster
       {{- if .Values.tls.enabled }}
       - name: tls
-        secret:
-          secretName: simplyblock-webappapi-tls
-      - name: certificate-authority
-        configMap:
-          name: simplyblock-certificate-authority
+        projected:
+          sources:
+          - secret:
+              name: simplyblock-webappapi-tls
+          - configMap:
+              name: simplyblock-certificate-authority
+              items:
+              - key: service-ca.crt
+                path: ca.crt
       {{- end }}
 ---
 apiVersion: apps/v1
@@ -466,11 +466,15 @@ spec:
                 path: fdb.cluster
         {{- if .Values.tls.enabled }}
         - name: tls
-          secret:
-            secretName: simplyblock-webappapi-tls
-        - name: certificate-authority
-          configMap:
-            name: simplyblock-certificate-authority
+          projected:
+            sources:
+            - secret:
+                name: simplyblock-webappapi-tls
+            - configMap:
+                name: simplyblock-certificate-authority
+                items:
+                - key: service-ca.crt
+                  path: ca.crt
         {{- end }}
 ---
 apiVersion: apps/v1
@@ -732,11 +736,15 @@ spec:
                 path: fdb.cluster
         {{- if .Values.tls.enabled }}
         - name: tls
-          secret:
-            secretName: simplyblock-webappapi-tls
-        - name: certificate-authority
-          configMap:
-            name: simplyblock-certificate-authority
+          projected:
+            sources:
+            - secret:
+                name: simplyblock-webappapi-tls
+            - configMap:
+                name: simplyblock-certificate-authority
+                items:
+                - key: service-ca.crt
+                  path: ca.crt
         {{- end }}
 
 ---

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_svc.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_svc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{ if .Values.tls.enabled }}
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: webappapi-tls
+    service.beta.openshift.io/serving-cert-secret-name: simplyblock-webappapi-tls
   {{ end }}
 spec:
   selector:

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_svc.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_svc.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: simplyblock-webappapi
   namespace: {{ .Release.Namespace }}
+  {{ if .Values.tls.enabled }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webappapi-tls
+  {{ end }}
 spec:
   selector:
     app: simplyblock-webappapi

--- a/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
@@ -58,6 +58,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: TLS_ENABLED
+              value: {{ .Values.tls.enabled | quote }}
           resources:
             limits:
               cpu: 500m

--- a/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
@@ -313,6 +313,17 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
@@ -71,6 +71,12 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             privileged: false
+          {{- if .Values.tls.enabled }}
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/simplyblock/tls
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -83,6 +89,15 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+      {{- if .Values.tls.enabled }}
+      volumes:
+        - name: tls
+          configMap:
+            name: simplyblock-certificate-authority
+            items:
+              - key: service-ca.crt
+                path: ca.crt
+      {{- end }}
       terminationGracePeriodSeconds: 10
 
 ################# ROLE AND ROLE BINDING ##############################

--- a/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
@@ -92,11 +92,15 @@ spec:
             path: /lib/modules
         {{- if .Values.tls.enabled }}
         - name: tls
-          secret:
-           secretName: simplyblock-storage-node-api-tls
-        - name: certificate-authority
-          configMap:
-            name: simplyblock-certificate-authority
+          projected:
+            sources:
+            - secret:
+                name: simplyblock-storage-node-api-tls
+            - configMap:
+                name: simplyblock-certificate-authority
+                items:
+                - key: service-ca.crt
+                  path: ca.crt
         {{- end }}
       hostNetwork: true
       {{- if .tolerations.create }}
@@ -163,10 +167,6 @@ spec:
           {{- if .Values.tls.enabled }}
           - name: tls
             mountPath: /etc/simplyblock/tls
-            readOnly: true
-          - name: certificate-authority
-            mountPath: /etc/simplyblock/tls/ca.crt
-            subPath: service-ca.crt
             readOnly: true
           {{- end }}
         securityContext:

--- a/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
@@ -90,6 +90,14 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+           secretName: simplyblock-storage-node-api-tls
+        - name: certificate-authority
+          configMap:
+            name: simplyblock-certificate-authority
+        {{- end }}
       hostNetwork: true
       {{- if .tolerations.create }}
       tolerations:
@@ -152,6 +160,15 @@ spec:
             readOnly: true
           - name: host-mnt
             mountPath: /mnt
+          {{- if .Values.tls.enabled }}
+          - name: tls
+            mountPath: /etc/simplyblock/tls
+            readOnly: true
+          - name: certificate-authority
+            mountPath: /etc/simplyblock/tls/ca.crt
+            subPath: service-ca.crt
+            readOnly: true
+          {{- end }}
         securityContext:
           privileged: true
       containers:

--- a/charts/spdk-csi/latest/spdk-csi/templates/validate-tls-openshift.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/validate-tls-openshift.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.tls.enabled (not (.Capabilities.APIVersions.Has "config.openshift.io/v1/ClusterVersion")) -}}
+{{- fail "tls.enabled=true is only supported when installing this chart on an OpenShift cluster" -}}
+{{- end -}}

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -508,3 +508,6 @@ prometheus:
     prometheus:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
       tag: v0.72.0
+
+tls:
+  enabled: false

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -510,4 +510,5 @@ prometheus:
       tag: v0.72.0
 
 tls:
+  # TLS support currently depends on OpenShift service CA APIs.
   enabled: false


### PR DESCRIPTION
This behavior is enabled by a `tls.enabled` variable, which, for now, only supports OpenShift clusters.

The changes are:
- Adding an annotation to the webappapi service to request a certificate
- Mounting the certificate into all control-plane containers
- Propagating the TLS-mode to the operator
- Adding permissions to the operator role s.t. it can monitor the required components.