### PR TITLE
auto-select master lvol during volume creation when no modelID annota…

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -647,6 +647,15 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 		return nil, err
 	}
 
+	if createVolReq.ModelID == "" {
+		masterID, masterErr := selectMasterLvol(sbclient, poolName)
+		if masterErr != nil {
+			klog.Warningf("could not select master lvol, creating as new master: %v", masterErr)
+		} else {
+			createVolReq.ModelID = masterID
+		}
+	}
+
 	// Store the effective QoS values into VolumeContext so the PV spec records
 	// what was actually applied.
 	vol.VolumeContext["qos_rw_iops"] = createVolReq.MaxRWIOPS
@@ -663,6 +672,33 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 	klog.V(5).Info("successfully created volume from Simplyblock with Volume ID: ", vol.GetVolumeId())
 
 	return &vol, nil
+}
+
+func selectMasterLvol(sbclient *util.NodeNVMf, poolName string) (string, error) {
+	lvstores, err := sbclient.LvStores()
+	if err != nil {
+		return "", fmt.Errorf("failed to list pools: %w", err)
+	}
+	var poolUUID string
+	for _, lv := range lvstores {
+		if lv.Name == poolName {
+			poolUUID = lv.UUID
+			break
+		}
+	}
+	if poolUUID == "" {
+		return "", fmt.Errorf("pool %q not found", poolName)
+	}
+	masters, err := sbclient.GetMasterLvols(poolUUID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get master lvols: %w", err)
+	}
+	for _, m := range masters {
+		if m.Namespaces < m.MaxNamespaces {
+			return m.ID, nil
+		}
+	}
+	return "", nil
 }
 
 func getSPDKVol(csiVolumeID string) (*spdkVolume, error) {

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -684,7 +684,7 @@ func selectMasterLvol(sbclient *util.NodeNVMf, poolName string) (string, error) 
 		return "", fmt.Errorf("failed to get master lvols: %w", err)
 	}
 	for _, m := range masters {
-		if m.Namespaces < m.MaxNamespaces {
+		if m.Namespaces < m.MaxNamespaces-1 {
 			return m.ID, nil
 		}
 	}

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -675,19 +675,9 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 }
 
 func selectMasterLvol(sbclient *util.NodeNVMf, poolName string) (string, error) {
-	lvstores, err := sbclient.LvStores()
+	poolUUID, err := sbclient.GetPoolUUIDByName(poolName)
 	if err != nil {
-		return "", fmt.Errorf("failed to list pools: %w", err)
-	}
-	var poolUUID string
-	for _, lv := range lvstores {
-		if lv.Name == poolName {
-			poolUUID = lv.UUID
-			break
-		}
-	}
-	if poolUUID == "" {
-		return "", fmt.Errorf("pool %q not found", poolName)
+		return "", err
 	}
 	masters, err := sbclient.GetMasterLvols(poolUUID)
 	if err != nil {

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -366,13 +366,24 @@ func (client *RPCClient) getMasterLvols(poolUUID string) ([]MasterLvol, error) {
 	if err != nil {
 		return nil, err
 	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal master lvols response: %w", err)
+	if out == nil {
+		return []MasterLvol{}, nil
+	}
+	var b []byte
+	if str, ok := out.(string); ok {
+		b = []byte(str)
+	} else {
+		b, err = json.Marshal(out)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal master lvols response: %w", err)
+		}
 	}
 	var result []MasterLvol
 	if err := json.Unmarshal(b, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal master lvols response: %w", err)
+	}
+	if result == nil {
+		return []MasterLvol{}, nil
 	}
 	return result, nil
 }

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -335,6 +335,31 @@ func (client *RPCClient) deleteVolume(lvolID string) error {
 	return err
 }
 
+// getPoolUUIDByName returns the UUID of a pool by its name
+func (client *RPCClient) getPoolUUIDByName(poolName string) (string, error) {
+	out, err := client.CallSBCLI("GET", "/pool", nil)
+	if err != nil {
+		return "", err
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal pools response: %w", err)
+	}
+	var pools []struct {
+		PoolName string `json:"pool_name"`
+		UUID     string `json:"uuid"`
+	}
+	if err := json.Unmarshal(b, &pools); err != nil {
+		return "", fmt.Errorf("failed to unmarshal pools response: %w", err)
+	}
+	for _, p := range pools {
+		if p.PoolName == poolName {
+			return p.UUID, nil
+		}
+	}
+	return "", fmt.Errorf("pool %q not found", poolName)
+}
+
 // getMasterLvols returns master lvols for a pool
 func (client *RPCClient) getMasterLvols(poolUUID string) ([]MasterLvol, error) {
 	out, err := client.CallSBCLI("GET", "/pool/get-master-lvols/"+poolUUID, nil)

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -141,11 +141,8 @@ type RPCClient struct {
 
 // CSIPoolsResp is the response of /pool/get_pools
 type CSIPoolsResp struct {
-	FreeClusters  int64  `json:"free_clusters"`
-	ClusterSize   int64  `json:"cluster_size"`
-	TotalClusters int64  `json:"total_data_clusters"`
-	Name          string `json:"name"`
-	UUID          string `json:"uuid"`
+	Name string `json:"pool_name"`
+	UUID string `json:"uuid"`
 }
 
 // SnapshotResp is the response of /snapshot
@@ -178,6 +175,17 @@ type Error struct {
 	Message string `json:"message"`
 }
 
+// MasterLvol is the response of /pool/get-master-lvols/<pool_uuid>
+type MasterLvol struct {
+	ID            string `json:"Id"`
+	Name          string `json:"Name"`
+	Size          string `json:"Size"`
+	Hostname      string `json:"Hostname"`
+	Status        string `json:"Status"`
+	Namespaces    int    `json:"Namespaces"`
+	MaxNamespaces int    `json:"MaxNamespaces"`
+}
+
 func (client *RPCClient) info() string {
 	return client.ClusterID
 }
@@ -186,7 +194,7 @@ func (client *RPCClient) info() string {
 func (client *RPCClient) lvStores() ([]LvStore, error) {
 	var result []CSIPoolsResp
 
-	out, err := client.CallSBCLI("GET", "/pool/get_pools", nil)
+	out, err := client.CallSBCLI("GET", "/pool", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +209,6 @@ func (client *RPCClient) lvStores() ([]LvStore, error) {
 		r := &result[i]
 		lvs[i].Name = r.Name
 		lvs[i].UUID = r.UUID
-		lvs[i].TotalSizeMiB = r.TotalClusters * r.ClusterSize / 1024 / 1024
-		lvs[i].FreeSizeMiB = r.FreeClusters * r.ClusterSize / 1024 / 1024
 	}
 
 	return lvs, nil
@@ -327,6 +333,23 @@ func (client *RPCClient) deleteVolume(lvolID string) error {
 	}
 
 	return err
+}
+
+// getMasterLvols returns master lvols for a pool
+func (client *RPCClient) getMasterLvols(poolUUID string) ([]MasterLvol, error) {
+	out, err := client.CallSBCLI("GET", "/pool/get-master-lvols/"+poolUUID, nil)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal master lvols response: %w", err)
+	}
+	var result []MasterLvol
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal master lvols response: %w", err)
+	}
+	return result, nil
 }
 
 // resizeVolume resizes a volume

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -127,6 +127,11 @@ func (node *NodeNVMf) GetMasterLvols(poolUUID string) ([]MasterLvol, error) {
 	return node.Client.getMasterLvols(poolUUID)
 }
 
+// GetPoolUUIDByName returns the UUID of the pool with the given name
+func (node *NodeNVMf) GetPoolUUIDByName(poolName string) (string, error) {
+	return node.Client.getPoolUUIDByName(poolName)
+}
+
 // ResizeVolume resizes a volume
 func (node *NodeNVMf) ResizeVolume(lvolID string, newSize int64) (bool, error) {
 	return node.Client.resizeVolume(lvolID, newSize)

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -122,6 +122,11 @@ func (node *NodeNVMf) ListVolumes() ([]*BDev, error) {
 	return node.Client.listVolumes()
 }
 
+// GetMasterLvols returns master lvols for the given pool UUID
+func (node *NodeNVMf) GetMasterLvols(poolUUID string) ([]MasterLvol, error) {
+	return node.Client.getMasterLvols(poolUUID)
+}
+
 // ResizeVolume resizes a volume
 func (node *NodeNVMf) ResizeVolume(lvolID string, newSize int64) (bool, error) {
 	return node.Client.resizeVolume(lvolID, newSize)


### PR DESCRIPTION
…tion is set

- Automatically reuse an existing master lvol with available namespace capacity instead of always creating a new master

- Falls back to creating a new master if none available or on lookup error

- Fixes pool UUID lookup by parsing pool_name field directly (avoids broken type assertion in lvStores())


```
root@israel-ocp-installer-n92tt-worker-b-h7dhs:/app# sbctl lvol list
+--------------------------------------+------------------------------------------+---------+------+------------------------------------------------+----+------------+--------------------------------------+--------+---+--------+--------+-------+------+--------+---------------+
| Id                                   | Name                                     | Size    | Used | Hostname                                       | HA | BlobID     | LVolUUID                             | Status | M | IO Err | Health | NS ID | Mode | Policy | Replicated On |
+--------------------------------------+------------------------------------------+---------+------+------------------------------------------------+----+------------+--------------------------------------+--------+---+--------+--------+-------+------+--------+---------------+
| 3f63a8ee-8bf2-4c3f-b239-b1fa458a43b1 | pvc-9278fc61-e29d-4f02-9b53-ec65e6ca6e68 | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-xwzg4_8082 | ha | 4294967297 | 7961b353-f3c8-4e3a-b8eb-20d1e233740c | online |   | False  | True   | 1     | 1x1  |        |               |
| 51e5282b-99ab-4d91-b7cc-73197ee81a3b | pvc-f8b1160c-3f86-4be8-affd-f94260480fa3 | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-xwzg4_8082 | ha | 4294967298 | 04e9c5e3-b400-401a-a35e-fdd905e5ae51 | online |   | False  | True   | 2     | 1x1  |        |               |
| ff39748c-f8f8-4a35-9c13-adefca7ff5b4 | pvc-d1ba3c8e-5180-4410-8243-68cc517cebbc | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-xwzg4_8082 | ha | 4294967300 | bc0de9a7-2d0d-4e0a-8475-91c14c8714cf | online |   | False  | True   | 4     | 1x1  |        |               |
| 6d38ac70-cc21-4efb-aa7a-7b3a4cfce725 | pvc-f8b97de2-8159-4e04-9d2a-9d45f2a08d74 | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-xwzg4_8082 | ha | 4294967301 | 42577d8b-fdce-4583-a804-31fde695ee92 | online |   | False  | True   | 5     | 1x1  |        |               |
| f796a30f-0c52-49d0-858e-70d8b2c1c616 | pvc-10cf895d-6825-4213-a17c-c179d7a0c49b | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-br7t7_8080 | ha | 4294967297 | 09e9ba40-12d6-45de-bb21-3150be03ea5b | online |   | False  | True   | 1     | 1x1  |        |               |
| 17140b13-9314-4fa3-88a6-d9655334aad1 | pvc-a5920e8b-ffec-4e6c-a71f-41c3d93c89d1 | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-br7t7_8080 | ha | 4294967298 | 5fccfed8-7508-47b7-9a6a-6f0335138362 | online |   | False  | True   | 2     | 1x1  |        |               |
| 85872d86-a733-46ed-b326-25661f7ae3d6 | pvc-e0d46b6f-80d0-4c81-81f5-9963d559e6cd | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-xwzg4_8082 | ha | 4294967299 | e104147b-d63d-464f-b788-74fe5de4ea50 | online |   | False  | True   | 3     | 1x1  |        |               |
| 8b1bff53-86de-4d8c-a03a-5ae31f763107 | pvc-1bdc039d-e202-4a32-a761-53d690974b5d | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-br7t7_8080 | ha | 4294967299 | 8da54de7-257b-471e-af49-b8083af5e685 | online |   | False  | True   | 3     | 1x1  |        |               |
| e82c48f0-3d88-4ee9-9b3a-d526515a2d98 | pvc-2c6a127b-ddbf-49b2-a1c5-a424258245c9 | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-br7t7_8080 | ha | 4294967300 | da1be568-323c-418b-ae6b-63d8869f4e3b | online |   | False  | True   | 4     | 1x1  |        |               |
| aa94b37a-c15d-4ac7-b6dc-d281f971c0a3 | pvc-cf4bed9e-930f-48da-89f4-af2072303215 | 2.0 GiB | 0 B  | israel-ocp-installer-n92tt-worker-b-br7t7_8080 | ha | 4294967301 | 64785c3a-1932-4153-9f0b-4792fbf5d8d1 | online |   | False  | True   | 5     | 1x1  |        |               |
+--------------------------------------+------------------------------------------+---------+------+------------------------------------------------+----+------------+--------------------------------------+--------+---+--------+--------+-------+------+--------+---------------+
```