### PR TITLE
Enable mTLS

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
+++ b/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
@@ -18,6 +18,139 @@ http://simplyblock-webappapi.{{ .Release.Namespace }}.svc.cluster.local:5000
 {{- end -}}
 {{- end -}}
 
+{{/*
+Volume named "tls" holding the serving cert bundle for pods that terminate TLS.
+Args: dict "ctx" $root "secret" <serving-cert-secret-name>
+- openshift: project the serving Secret with the cabundle ConfigMap (renaming
+  service-ca.crt -> ca.crt) since the Secret carries only tls.crt/tls.key.
+- cert-manager: mount the Secret directly; it already contains ca.crt.
+Caller pipes through `nindent N`.
+*/}}
+{{- define "simplyblock.tlsVolume" -}}
+{{- $ctx := .ctx -}}
+{{- $secret := .secret -}}
+{{- if $ctx.Values.tls.enabled -}}
+{{- if eq $ctx.Values.tls.provider "openshift" }}
+- name: tls
+  projected:
+    sources:
+    - secret:
+        name: {{ $secret }}
+    - configMap:
+        name: simplyblock-certificate-authority
+        items:
+        - key: service-ca.crt
+          path: ca.crt
+{{- else if eq $ctx.Values.tls.provider "cert-manager" }}
+- name: tls
+  secret:
+    secretName: {{ $secret }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Volume named "tls" holding only ca.crt, for client-only consumers without mTLS.
+- openshift: cabundle ConfigMap (renamed key).
+- cert-manager: project ca.crt out of the chart's CA Secret
+  (simplyblock-certificate-authority-tls), populated by cert-manager from the
+  CA Certificate in controlplane_certificates.yaml.
+Caller pipes through `nindent N`.
+*/}}
+{{- define "simplyblock.caVolume" -}}
+{{- if .Values.tls.enabled -}}
+{{- if eq .Values.tls.provider "openshift" }}
+- name: tls
+  configMap:
+    name: simplyblock-certificate-authority
+    items:
+    - key: service-ca.crt
+      path: ca.crt
+{{- else if eq .Values.tls.provider "cert-manager" }}
+- name: tls
+  secret:
+    secretName: simplyblock-certificate-authority-tls
+    items:
+    - key: ca.crt
+      path: ca.crt
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Volume named "tls" for client pods, with optional mTLS.
+Args: dict "ctx" $root "clientSecret" <client-cert-secret-name>
+- mutual_enabled=false: delegate to simplyblock.caVolume (CA-only mount).
+- mutual_enabled=true: project the client cert Secret alongside the
+  per-provider CA bundle.
+Caller pipes through `nindent N`.
+*/}}
+{{- define "simplyblock.clientTlsVolume" -}}
+{{- $ctx := .ctx -}}
+{{- $clientSecret := .clientSecret -}}
+{{- if $ctx.Values.tls.enabled -}}
+{{- if not $ctx.Values.tls.mutual_enabled -}}
+{{- include "simplyblock.caVolume" $ctx }}
+{{- else if eq $ctx.Values.tls.provider "openshift" }}
+- name: tls
+  projected:
+    sources:
+    - secret:
+        name: {{ $clientSecret }}
+    - configMap:
+        name: simplyblock-certificate-authority
+        items:
+        - key: service-ca.crt
+          path: ca.crt
+{{- else if eq $ctx.Values.tls.provider "cert-manager" }}
+- name: tls
+  projected:
+    sources:
+    - secret:
+        name: {{ $clientSecret }}
+    - secret:
+        name: simplyblock-certificate-authority-tls
+        items:
+        - key: ca.crt
+          path: ca.crt
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Shared TLS volumeMount entry for the "tls" volume, gated on tls.enabled.
+Caller pipes through `nindent N` to land it inside a `volumeMounts:` list.
+*/}}
+{{- define "simplyblock.tlsVolumeMount" -}}
+{{- if .Values.tls.enabled }}
+- name: tls
+  mountPath: /etc/simplyblock/tls
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+TLS-related env vars for sbcli containers. Caller pipes through `nindent N`
+to land them at the right column inside an `env:` list.
+*/}}
+{{- define "simplyblock.tlsEnv" -}}
+{{- if .Values.tls.enabled }}
+- name: SB_TLS_SERVE
+  value: "1"
+- name: SB_TLS_PROVIDER
+  value: {{ .Values.tls.provider | quote }}
+{{- end }}
+{{- if .Values.tls.mutual_enabled }}
+- name: SB_TLS_CLIENT_AUTH
+  value: "required"
+- name: SB_TLS_CONNECT
+  value: "authenticated"
+{{- else if .Values.tls.enabled }}
+- name: SB_TLS_CONNECT
+  value: "anonymous"
+{{- end }}
+{{- end -}}
+
 {{- define "simplyblock.commonContainer" }}
 env:
   - name: SIMPLYBLOCK_LOG_LEVEL
@@ -25,16 +158,13 @@ env:
       configMapKeyRef:
         name: simplyblock-config
         key: LOG_LEVEL
+  {{- include "simplyblock.tlsEnv" . | nindent 2 }}
 
 volumeMounts:
   - name: fdb-cluster-file
     mountPath: /etc/foundationdb/fdb.cluster
     subPath: fdb.cluster
-{{- if .Values.tls.enabled }}
-  - name: tls
-    mountPath: /etc/simplyblock/tls
-    readOnly: true
-{{- end }}
+  {{- include "simplyblock.tlsVolumeMount" . | nindent 2 }}
 
 resources:
   requests:

--- a/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
@@ -125,6 +125,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {{- include "simplyblock.tlsEnv" . | nindent 8 }}
         volumeMounts:
         - name: socket-dir
           mountPath: /csi
@@ -134,11 +135,7 @@ spec:
         - name: csi-secret
           mountPath: /etc/spdkcsi-secret/
           readOnly: true
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          mountPath: /etc/simplyblock/tls
-          readOnly: true
-        {{- end }}
+        {{- include "simplyblock.tlsVolumeMount" . | nindent 8 }}
       volumes:
       - name: socket-dir
         emptyDir:
@@ -149,11 +146,4 @@ spec:
       - name: csi-secret
         secret:
           secretName: simplyblock-csi-secret-v2
-      {{- if .Values.tls.enabled }}
-      - name: tls
-        configMap:
-          name: simplyblock-certificate-authority
-          items:
-          - key: service-ca.crt
-            path: ca.crt
-      {{- end }}
+      {{- include "simplyblock.clientTlsVolume" (dict "ctx" . "clientSecret" "simplyblock-csi-controller-client-tls") | nindent 6 }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane-cabundle.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane-cabundle.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.tls.enabled }}
+{{- if and .Values.tls.enabled (eq .Values.tls.provider "openshift") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: simplyblock-certificate-authority
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
-{{ end }}
+{{- end }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_certificates.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_certificates.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.tls.enabled (eq .Values.tls.provider "cert-manager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: simplyblock-certificate-authority
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: simplyblock-certificate-authority
+  secretName: simplyblock-certificate-authority-tls
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    kind: ClusterIssuer
+    name: {{ index .Values.tls "cert-manager" "cluster-issuer" | quote }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: simplyblock-certificate-authority-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: simplyblock-certificate-authority-tls
+{{- if .Values.tls.mutual_enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: simplyblock-operator-client
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: simplyblock-operator
+  secretName: simplyblock-operator-client-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: simplyblock-certificate-authority-issuer
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: simplyblock-csi-node-client
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: simplyblock-csi-node
+  secretName: simplyblock-csi-node-client-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: simplyblock-certificate-authority-issuer
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: simplyblock-csi-controller-client
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: simplyblock-csi-controller
+  secretName: simplyblock-csi-controller-client-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: simplyblock-certificate-authority-issuer
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
+{{- end }}
+{{- end }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_deploy.yaml
@@ -61,6 +61,7 @@ spec:
         imagePullPolicy: "{{ .Values.image.simplyblock.pullPolicy }}"
         command: ["/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"]
         env:
+        {{- include "simplyblock.tlsEnv" . | nindent 8 }}
         - name: LVOL_NVMF_PORT_START
           value: "{{ .Values.controlplane.ports.lvolNvmfPortStart }}"
         - name: PROMETHEUS_URL
@@ -87,11 +88,7 @@ spec:
         - name: fdb-cluster-file
           mountPath: /etc/foundationdb/fdb.cluster
           subPath: fdb.cluster
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          mountPath: /etc/simplyblock/tls
-          readOnly: true
-        {{- end }}
+        {{- include "simplyblock.tlsVolumeMount" . | nindent 8 }}
         resources:
           requests:
             cpu: "200m"
@@ -106,18 +103,7 @@ spec:
           items:
             - key: cluster-file
               path: fdb.cluster
-      {{- if .Values.tls.enabled }}
-      - name: tls
-        projected:
-          sources:
-          - secret:
-              name: simplyblock-webappapi-tls
-          - configMap:
-              name: simplyblock-certificate-authority
-              items:
-              - key: service-ca.crt
-                path: ca.crt
-      {{- end }}
+      {{- include "simplyblock.tlsVolume" (dict "ctx" . "secret" "simplyblock-webappapi-tls") | nindent 6 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -196,6 +182,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- include "simplyblock.tlsEnv" . | nindent 8 }}
 {{- if .Values.controlplane.observability.enabled }}
         - name: MONITORING_SECRET
           valueFrom:
@@ -211,11 +198,7 @@ spec:
         - name: fdb-cluster-file
           mountPath: /etc/foundationdb/fdb.cluster
           subPath: fdb.cluster
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          mountPath: /etc/simplyblock/tls
-          readOnly: true
-        {{- end }}
+        {{- include "simplyblock.tlsVolumeMount" . | nindent 8 }}
         resources:
           requests:
             cpu: "200m"
@@ -230,18 +213,7 @@ spec:
           items:
             - key: cluster-file
               path: fdb.cluster
-      {{- if .Values.tls.enabled }}
-      - name: tls
-        projected:
-          sources:
-          - secret:
-              name: simplyblock-webappapi-tls
-          - configMap:
-              name: simplyblock-certificate-authority
-              items:
-              - key: service-ca.crt
-                path: ca.crt
-      {{- end }}
+      {{- include "simplyblock.tlsVolume" (dict "ctx" . "secret" "simplyblock-webappapi-tls") | nindent 6 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -464,18 +436,7 @@ spec:
             items:
               - key: cluster-file
                 path: fdb.cluster
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          projected:
-            sources:
-            - secret:
-                name: simplyblock-webappapi-tls
-            - configMap:
-                name: simplyblock-certificate-authority
-                items:
-                - key: service-ca.crt
-                  path: ca.crt
-        {{- end }}
+        {{- include "simplyblock.tlsVolume" (dict "ctx" . "secret" "simplyblock-webappapi-tls") | nindent 8 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -734,18 +695,7 @@ spec:
             items:
               - key: cluster-file
                 path: fdb.cluster
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          projected:
-            sources:
-            - secret:
-                name: simplyblock-webappapi-tls
-            - configMap:
-                name: simplyblock-certificate-authority
-                items:
-                - key: service-ca.crt
-                  path: ca.crt
-        {{- end }}
+        {{- include "simplyblock.tlsVolume" (dict "ctx" . "secret" "simplyblock-webappapi-tls") | nindent 8 }}
 
 ---
 {{- if .Values.controlplane.observability.enabled }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_svc.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_svc.yaml
@@ -4,10 +4,10 @@ kind: Service
 metadata:
   name: simplyblock-webappapi
   namespace: {{ .Release.Namespace }}
-  {{ if .Values.tls.enabled }}
+  {{- if and .Values.tls.enabled (eq .Values.tls.provider "openshift") }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: simplyblock-webappapi-tls
-  {{ end }}
+  {{- end }}
 spec:
   selector:
     app: simplyblock-webappapi
@@ -15,6 +15,32 @@ spec:
   - name: http
     port: 5000
     targetPort: 5000
+
+{{- if and .Values.tls.enabled (eq .Values.tls.provider "cert-manager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: simplyblock-webappapi
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: simplyblock-webappapi-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: simplyblock-certificate-authority-issuer
+  {{- if .Values.tls.mutual_enabled }}
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  {{- end }}
+  dnsNames:
+    - simplyblock-webappapi
+    - simplyblock-webappapi.{{ .Release.Namespace }}
+    - simplyblock-webappapi.{{ .Release.Namespace }}.svc
+    - simplyblock-webappapi.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}
 
 ---
 {{- if .Values.controlplane.observability.enabled }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
@@ -92,6 +92,7 @@ spec:
               fieldPath: spec.nodeName
         - name: GUARDIAN_MIN_BROKEN_FOR
           value: "30s"
+        {{- include "simplyblock.tlsEnv" . | nindent 8 }}
         lifecycle:
           postStart:
             exec:
@@ -134,11 +135,7 @@ spec:
           readOnly: true
         - name: guardian-state
           mountPath: /var/run/simplyblock/guardian
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          mountPath: /etc/simplyblock/tls
-          readOnly: true
-        {{- end }}
+        {{- include "simplyblock.tlsVolumeMount" . | nindent 8 }}
       volumes:
       - name: socket-dir
         hostPath:
@@ -183,11 +180,4 @@ spec:
       - name: csi-secret
         secret:
           secretName: simplyblock-csi-secret-v2
-      {{- if .Values.tls.enabled }}
-      - name: tls
-        configMap:
-          name: simplyblock-certificate-authority
-          items:
-          - key: service-ca.crt
-            path: ca.crt
-      {{- end }}
+      {{- include "simplyblock.clientTlsVolume" (dict "ctx" . "clientSecret" "simplyblock-csi-node-client-tls") | nindent 6 }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/simplyblock-operator.yaml
@@ -60,8 +60,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: TLS_ENABLED
-              value: {{ .Values.tls.enabled | quote }}
+            {{- include "simplyblock.tlsEnv" . | nindent 12 }}
           resources:
             limits:
               cpu: 800m
@@ -75,9 +74,7 @@ spec:
             privileged: false
           {{- if .Values.tls.enabled }}
           volumeMounts:
-            - name: tls
-              mountPath: /etc/simplyblock/tls
-              readOnly: true
+            {{- include "simplyblock.tlsVolumeMount" . | nindent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -93,12 +90,7 @@ spec:
             periodSeconds: 10
       {{- if .Values.tls.enabled }}
       volumes:
-        - name: tls
-          configMap:
-            name: simplyblock-certificate-authority
-            items:
-              - key: service-ca.crt
-                path: ca.crt
+        {{- include "simplyblock.clientTlsVolume" (dict "ctx" . "clientSecret" "simplyblock-operator-client-tls") | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 10
 
@@ -212,6 +204,20 @@ rules:
   - patch
   - update
   - watch
+{{- if and .Values.tls.enabled (eq .Values.tls.provider "cert-manager") }}
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storage-node.yaml
@@ -93,18 +93,7 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
-        {{- if .Values.tls.enabled }}
-        - name: tls
-          projected:
-            sources:
-            - secret:
-                name: simplyblock-storage-node-api-tls
-            - configMap:
-                name: simplyblock-certificate-authority
-                items:
-                - key: service-ca.crt
-                  path: ca.crt
-        {{- end }}
+        {{- include "simplyblock.tlsVolume" (dict "ctx" $ "secret" "simplyblock-storage-node-api-tls") | nindent 8 }}
       hostNetwork: true
       {{- if .tolerations.create }}
       tolerations:
@@ -126,6 +115,7 @@ spec:
         image: "{{ $.Values.image.simplyblock.repository }}:{{ $.Values.image.simplyblock.tag }}"
         imagePullPolicy: "{{ $.Values.image.simplyblock.pullPolicy }}"
         env:
+        {{- include "simplyblock.tlsEnv" $ | nindent 8 }}
         - name: HOSTNAME
           valueFrom:
             fieldRef:
@@ -167,11 +157,7 @@ spec:
             readOnly: true
           - name: host-mnt
             mountPath: /mnt
-          {{- if .Values.tls.enabled }}
-          - name: tls
-            mountPath: /etc/simplyblock/tls
-            readOnly: true
-          {{- end }}
+          {{- include "simplyblock.tlsVolumeMount" $ | nindent 10 }}
         securityContext:
           privileged: true
       containers:
@@ -180,6 +166,7 @@ spec:
         imagePullPolicy: "{{ $.Values.image.simplyblock.pullPolicy }}"
         command: ["python", "simplyblock_web/node_webapp.py", "storage_node_k8s"]
         env:
+        {{- include "simplyblock.tlsEnv" $ | nindent 8 }}
         - name: CORE_ISOLATION
           value: "{{ $.Values.storagenode.isolateCores }}"
         - name: UBUNTU_HOST

--- a/charts/spdk-csi/latest/spdk-csi/templates/validate-tls-openshift.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/validate-tls-openshift.yaml
@@ -1,3 +1,0 @@
-{{- if and .Values.tls.enabled (not (.Capabilities.APIVersions.Has "config.openshift.io/v1/ClusterVersion")) -}}
-{{- fail "tls.enabled=true is only supported when installing this chart on an OpenShift cluster" -}}
-{{- end -}}

--- a/charts/spdk-csi/latest/spdk-csi/templates/validate-tls.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/validate-tls.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.tls.enabled -}}
+{{-   if eq .Values.tls.provider "openshift" -}}
+{{-     if not (.Capabilities.APIVersions.Has "config.openshift.io/v1/ClusterVersion") -}}
+{{-       fail "tls.provider=openshift requires installing on an OpenShift cluster" -}}
+{{-     end -}}
+{{-   else if eq .Values.tls.provider "cert-manager" -}}
+{{-     if not (.Capabilities.APIVersions.Has "cert-manager.io/v1") -}}
+{{-       fail "tls.provider=cert-manager requires cert-manager.io/v1 to be installed in the cluster" -}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}

--- a/charts/spdk-csi/latest/spdk-csi/values.schema.json
+++ b/charts/spdk-csi/latest/spdk-csi/values.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "tls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "provider": { "enum": ["openshift", "cert-manager"] },
+        "mutual_enabled": { "type": "boolean" },
+        "cert-manager": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "cluster-issuer": { "type": "string" }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["provider"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": { "const": true },
+              "provider": { "const": "cert-manager" }
+            },
+            "required": ["enabled", "provider"]
+          },
+          "then": {
+            "required": ["cert-manager"],
+            "properties": {
+              "cert-manager": {
+                "required": ["cluster-issuer"],
+                "properties": {
+                  "cluster-issuer": { "minLength": 1 }
+                }
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "mutual_enabled": { "const": false }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -526,5 +526,15 @@ prometheus:
       image: defaultbackend-amd64
       tag: "1.5"
 tls:
-  # TLS support currently depends on OpenShift service CA APIs.
   enabled: false
+
+  # Provider responsible for issuing serving certificates. One of: openshift, cert-manager. Required if enabled.
+  provider: cert-manager
+
+  # Required if provider == cert-manager. Names a pre-existing ClusterIssuer
+  # which is used to mint the chart's own CA Certificate.
+  cert-manager:
+    cluster-issuer: ""
+
+  # Mutual TLS (clients present and verify certificates). Only allowed when provider == cert-manager.
+  mutual_enabled: false

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -168,7 +168,7 @@ func NewsimplyBlockClient(clusterID string) (*NodeNVMf, error) {
 		clusterConfig.ClusterID,
 		clusterConfig.ClusterEndpoint,
 	)
-	return NewNVMf(clusterID, clusterConfig.ClusterEndpoint, clusterConfig.ClusterSecret), nil
+	return NewNVMf(clusterID, clusterConfig.ClusterEndpoint, clusterConfig.ClusterSecret)
 }
 
 // NewSpdkCsiInitiator creates a new SpdkCsiInitiator based on the target type

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -30,9 +30,45 @@ import (
 )
 
 const (
-	tlsCAFile          = "/etc/simplyblock/tls/ca.crt"
-	namespaceFile      = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	envTLSConnect = "SB_TLS_CONNECT"
+	envTLSCAFile  = "SB_TLS_CERTIFICATE_AUTHORITY"
+	envTLSCert    = "SB_TLS_CERTIFICATE"
+	envTLSKey     = "SB_TLS_KEY"
+
+	defaultTLSCAFile = "/etc/simplyblock/tls/ca.crt"
+	defaultTLSCert   = "/etc/simplyblock/tls/tls.crt"
+	defaultTLSKey    = "/etc/simplyblock/tls/tls.key"
+
+	namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 )
+
+type tlsMode int
+
+const (
+	tlsDisabled tlsMode = iota
+	tlsAnonymous
+	tlsAuthenticated
+)
+
+func parseTLSMode(s string) (tlsMode, error) {
+	switch s {
+	case "", "disabled":
+		return tlsDisabled, nil
+	case "anonymous":
+		return tlsAnonymous, nil
+	case "authenticated":
+		return tlsAuthenticated, nil
+	default:
+		return tlsDisabled, fmt.Errorf("invalid %s value %q (want disabled, anonymous, or authenticated)", envTLSConnect, s)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
 
 // tlsServerName returns the FQDN service name that matches the TLS certificate
 // SANs (e.g. "simplyblock-webappapi.simplyblock.svc") derived from the URL host
@@ -60,27 +96,51 @@ type NodeNVMf struct {
 	Client *RPCClient
 }
 
-// NewNVMf creates a new NVMf client
-func NewNVMf(clusterID, clusterIP, clusterSecret string) *NodeNVMf {
-	transport := http.DefaultTransport
-	if caData, err := os.ReadFile(tlsCAFile); err == nil {
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(caData)
-		clusterIP = strings.Replace(clusterIP, "http://", "https://", 1)
-		serverName := tlsServerName(clusterIP)
-		transport = &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: serverName},
-		}
+// NewNVMf creates a new NVMf client. The HTTP transport is selected by the
+// SB_TLS_CONNECT environment variable: "disabled" (or unset) uses plain HTTP;
+// "anonymous" uses HTTPS validated against SB_TLS_CERTIFICATE_AUTHORITY;
+// "authenticated" adds a client cert/key from SB_TLS_CERTIFICATE / SB_TLS_KEY.
+func NewNVMf(clusterID, clusterIP, clusterSecret string) (*NodeNVMf, error) {
+	mode, err := parseTLSMode(os.Getenv(envTLSConnect))
+	if err != nil {
+		return nil, err
 	}
+
+	transport := http.DefaultTransport
+	if mode != tlsDisabled {
+		caFile := envOr(envTLSCAFile, defaultTLSCAFile)
+		caData, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("read TLS CA %s: %w", caFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caData) {
+			return nil, fmt.Errorf("no certificates parsed from TLS CA %s", caFile)
+		}
+
+		clusterIP = strings.Replace(clusterIP, "http://", "https://", 1)
+		tlsCfg := &tls.Config{RootCAs: pool, ServerName: tlsServerName(clusterIP)}
+
+		if mode == tlsAuthenticated {
+			certFile := envOr(envTLSCert, defaultTLSCert)
+			keyFile := envOr(envTLSKey, defaultTLSKey)
+			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			if err != nil {
+				return nil, fmt.Errorf("load TLS client keypair (%s, %s): %w", certFile, keyFile, err)
+			}
+			tlsCfg.Certificates = []tls.Certificate{cert}
+		}
+
+		transport = &http.Transport{TLSClientConfig: tlsCfg}
+	}
+
 	client := RPCClient{
 		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second, Transport: transport},
 		ClusterID:     clusterID,
 		ClusterIP:     clusterIP,
 		ClusterSecret: clusterSecret,
 	}
-	return &NodeNVMf{
-		Client: &client,
-	}
+	return &NodeNVMf{Client: &client}, nil
 }
 
 func (node *NodeNVMf) Info() string {

--- a/pkg/util/nvmf_test.go
+++ b/pkg/util/nvmf_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) Arm Limited and Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// whitebox tests for TLS mode parsing and transport construction in nvmf.go
+package util
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseTLSMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    tlsMode
+		wantErr bool
+	}{
+		{"", tlsDisabled, false},
+		{"disabled", tlsDisabled, false},
+		{"anonymous", tlsAnonymous, false},
+		{"authenticated", tlsAuthenticated, false},
+		{"Anonymous", tlsDisabled, true},
+		{"on", tlsDisabled, true},
+		{"true", tlsDisabled, true},
+	}
+	for _, c := range cases {
+		got, err := parseTLSMode(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parseTLSMode(%q) err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if !c.wantErr && got != c.want {
+			t.Errorf("parseTLSMode(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func writeTestPEMs(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshalkey: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	caFile = filepath.Join(dir, "ca.crt")
+	certFile = filepath.Join(dir, "tls.crt")
+	keyFile = filepath.Join(dir, "tls.key")
+	for path, data := range map[string][]byte{caFile: certPEM, certFile: certPEM, keyFile: keyPEM} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return caFile, certFile, keyFile
+}
+
+func transportOf(t *testing.T, n *NodeNVMf) *http.Transport {
+	t.Helper()
+	tr, ok := n.Client.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", n.Client.HTTPClient.Transport)
+	}
+	return tr
+}
+
+func TestNewNVMfDisabled(t *testing.T) {
+	t.Setenv(envTLSConnect, "disabled")
+	n, err := NewNVMf("c", "http://api.example.com:5000", "s")
+	if err != nil {
+		t.Fatalf("NewNVMf: %v", err)
+	}
+	if n.Client.ClusterIP != "http://api.example.com:5000" {
+		t.Errorf("ClusterIP rewritten unexpectedly: %s", n.Client.ClusterIP)
+	}
+	if n.Client.HTTPClient.Transport != http.DefaultTransport {
+		t.Errorf("expected http.DefaultTransport, got %T", n.Client.HTTPClient.Transport)
+	}
+}
+
+func TestNewNVMfAnonymous(t *testing.T) {
+	caFile, _, _ := writeTestPEMs(t)
+	t.Setenv(envTLSConnect, "anonymous")
+	t.Setenv(envTLSCAFile, caFile)
+
+	n, err := NewNVMf("c", "http://api.example.com:5000", "s")
+	if err != nil {
+		t.Fatalf("NewNVMf: %v", err)
+	}
+	if n.Client.ClusterIP != "https://api.example.com:5000" {
+		t.Errorf("ClusterIP not rewritten to https: %s", n.Client.ClusterIP)
+	}
+	cfg := transportOf(t, n).TLSClientConfig
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatal("expected TLSClientConfig with RootCAs")
+	}
+	if len(cfg.Certificates) != 0 {
+		t.Errorf("anonymous mode should have no client certs, got %d", len(cfg.Certificates))
+	}
+}
+
+func TestNewNVMfAuthenticated(t *testing.T) {
+	caFile, certFile, keyFile := writeTestPEMs(t)
+	t.Setenv(envTLSConnect, "authenticated")
+	t.Setenv(envTLSCAFile, caFile)
+	t.Setenv(envTLSCert, certFile)
+	t.Setenv(envTLSKey, keyFile)
+
+	n, err := NewNVMf("c", "http://api.example.com:5000", "s")
+	if err != nil {
+		t.Fatalf("NewNVMf: %v", err)
+	}
+	cfg := transportOf(t, n).TLSClientConfig
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatal("expected TLSClientConfig with RootCAs")
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("authenticated mode should have 1 client cert, got %d", len(cfg.Certificates))
+	}
+}
+
+func TestNewNVMfInvalidMode(t *testing.T) {
+	t.Setenv(envTLSConnect, "bogus")
+	if _, err := NewNVMf("c", "http://api.example.com:5000", "s"); err == nil {
+		t.Fatal("expected error for invalid SB_TLS_CONNECT, got nil")
+	}
+}
+
+func TestNewNVMfMissingCA(t *testing.T) {
+	t.Setenv(envTLSConnect, "anonymous")
+	t.Setenv(envTLSCAFile, filepath.Join(t.TempDir(), "missing.crt"))
+	if _, err := NewNVMf("c", "http://api.example.com:5000", "s"); err == nil {
+		t.Fatal("expected error for missing CA file, got nil")
+	}
+}


### PR DESCRIPTION
This enables mTLS:
- the chart is adapted s.t. the components can be deployed via cert-manager as well
- the managed components are conditionally instructed to utilize mTLS
- the CSI Node provides client certificates is instructed to do so.

This PR corresponds to https://github.com/simplyblock/sbcli/pull/1026 and https://github.com/simplyblock/simplyblock-operator/pull/72.