### PR TITLE
Support Modify Volume functionality to update volume attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/spdk/spdk-csi
 go 1.26.2
 
 require (
-	github.com/container-storage-interface/spec v1.8.0
+	github.com/container-storage-interface/spec v1.9.0
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/onsi/gomega v1.29.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
-github.com/container-storage-interface/spec v1.8.0 h1:D0vhF3PLIZwlwZEf2eNbpujGCNwspwTYf2idJRJx4xI=
-github.com/container-storage-interface/spec v1.8.0/go.mod h1:ROLik+GhPslwwWRNFF1KasPzroNARibH2rfz1rkg4H0=
+github.com/container-storage-interface/spec v1.9.0 h1:zKtX4STsq31Knz3gciCYCi1SXtO2HJDecIjDVboYavY=
+github.com/container-storage-interface/spec v1.9.0/go.mod h1:ZfDu+3ZRyeVqxZM0Ds19MVLkN2d1XJ5MAfi1L3VjlT0=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/pkg/csi-common/controllerserver-default.go
+++ b/pkg/csi-common/controllerserver-default.go
@@ -86,3 +86,7 @@ func (cs *DefaultControllerServer) ListSnapshots(ctx context.Context, req *csi.L
 func (cs *DefaultControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }
+
+func (cs *DefaultControllerServer) ControllerModifyVolume(ctx context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -795,6 +795,71 @@ func (cs *controllerServer) ControllerExpandVolume(_ context.Context, req *csi.C
 	}, nil
 }
 
+// ControllerModifyVolume applies mutable parameters (QoS) to an existing volume.
+// It is called by the external-resizer sidecar when a PVC's VolumeAttributesClass changes.
+// Supported mutable parameters: qos_rw_iops, qos_rw_mbytes, qos_r_mbytes, qos_w_mbytes.
+func (cs *controllerServer) ControllerModifyVolume(_ context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
+	volumeID := req.GetVolumeId()
+	if volumeID == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
+	}
+
+	params := req.GetMutableParameters()
+	if len(params) == 0 {
+		return &csi.ControllerModifyVolumeResponse{}, nil
+	}
+
+	spdkVol, err := getSPDKVol(volumeID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid volume ID %q: %v", volumeID, err)
+	}
+
+	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create client for cluster %s: %v", spdkVol.clusterID, err)
+	}
+
+	rwIOPS, err := parseQoSParam(params, "qos_rw_iops")
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "qos_rw_iops: %v", err)
+	}
+	rwMBytes, err := parseQoSParam(params, "qos_rw_mbytes")
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "qos_rw_mbytes: %v", err)
+	}
+	rMBytes, err := parseQoSParam(params, "qos_r_mbytes")
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "qos_r_mbytes: %v", err)
+	}
+	wMBytes, err := parseQoSParam(params, "qos_w_mbytes")
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "qos_w_mbytes: %v", err)
+	}
+
+	if err := sbclient.UpdateQoS(spdkVol.lvolID, rwIOPS, rwMBytes, rMBytes, wMBytes); err != nil {
+		klog.Errorf("ControllerModifyVolume: failed to update QoS for lvol %s: %v", spdkVol.lvolID, err)
+		return nil, status.Errorf(codes.Internal, "failed to update QoS: %v", err)
+	}
+
+	klog.V(4).Infof("ControllerModifyVolume: updated QoS for lvol %s (rw-iops=%d rw-mbytes=%d r-mbytes=%d w-mbytes=%d)",
+		spdkVol.lvolID, rwIOPS, rwMBytes, rMBytes, wMBytes)
+
+	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// parseQoSParam extracts a non-negative integer from params[key], returning 0 if the key is absent.
+func parseQoSParam(params map[string]string, key string) (int, error) {
+	val, ok := params[key]
+	if !ok || val == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(val)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("must be a non-negative integer, got %q", val)
+	}
+	return n, nil
+}
+
 // ListSnapshots lists all snapshots across all clusters
 func (cs *controllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 

--- a/pkg/spdk/driver.go
+++ b/pkg/spdk/driver.go
@@ -40,6 +40,7 @@ func Run(conf *util.Config) {
 			csi.ControllerServiceCapability_RPC_GET_VOLUME,
 			// csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION,
+			csi.ControllerServiceCapability_RPC_MODIFY_VOLUME,
 		}
 		volumeModes = []csi.VolumeCapability_AccessMode_Mode{
 			csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -401,6 +401,20 @@ func (client *RPCClient) resizeVolume(lvolID string, size int64) (bool, error) {
 	return true, nil
 }
 
+// UpdateQoSReq is the request body for PUT /lvol/{uuid}
+type UpdateQoSReq struct {
+	MaxRWIOPS   int `json:"max-rw-iops"`
+	MaxRWMBytes int `json:"max-rw-mbytes"`
+	MaxRMBytes  int `json:"max-r-mbytes"`
+	MaxWMBytes  int `json:"max-w-mbytes"`
+}
+
+// updateQoS updates QoS limits on an existing logical volume
+func (client *RPCClient) updateQoS(lvolID string, params *UpdateQoSReq) error {
+	_, err := client.CallSBCLI("PUT", "/lvol/"+lvolID, params)
+	return err
+}
+
 // cloneVolume clones a volume
 func (client *RPCClient) cloneVolume(lvolID, cloneName, newSize, pvcName string) (string, error) {
 	params := struct {

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -137,6 +137,16 @@ func (node *NodeNVMf) ResizeVolume(lvolID string, newSize int64) (bool, error) {
 	return node.Client.resizeVolume(lvolID, newSize)
 }
 
+// UpdateQoS updates QoS limits on an existing logical volume
+func (node *NodeNVMf) UpdateQoS(lvolID string, maxRWIOPS, maxRWMBytes, maxRMBytes, maxWMBytes int) error {
+	return node.Client.updateQoS(lvolID, &UpdateQoSReq{
+		MaxRWIOPS:   maxRWIOPS,
+		MaxRWMBytes: maxRWMBytes,
+		MaxRMBytes:  maxRMBytes,
+		MaxWMBytes:  maxWMBytes,
+	})
+}
+
 // ListSnapshots returns a list of snapshots
 func (node *NodeNVMf) ListSnapshots() ([]*SnapshotResp, error) {
 	return node.Client.listSnapshots()


### PR DESCRIPTION
Define QoS tiers as VolumeAttributesClass objects

```
apiVersion: storage.k8s.io/v1beta1
kind: VolumeAttributesClass
metadata:
  name: high-iops
driverName: simplyblock.csi.spdk.io
parameters:
  qos_rw_iops: "10000"
  qos_rw_mbytes: "500"
```

Apply at creation or change at runtime, or just patch the PVC

```
spec:
  volumeAttributesClass: high-iops
```

The external-resizer sidecar detects the change, calls ControllerModifyVolume, and updates pvc.status.currentVolumeAttributesClassName when it succeeds.
