### PR TITLE
mount TLS certs and create HTTPS Client when .Values.tls.enabled=true

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
@@ -134,6 +134,11 @@ spec:
         - name: csi-secret
           mountPath: /etc/spdkcsi-secret/
           readOnly: true
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          mountPath: /etc/simplyblock/tls
+          readOnly: true
+        {{- end }}
       volumes:
       - name: socket-dir
         emptyDir:
@@ -144,3 +149,11 @@ spec:
       - name: csi-secret
         secret:
           secretName: simplyblock-csi-secret-v2
+      {{- if .Values.tls.enabled }}
+      - name: tls
+        configMap:
+          name: simplyblock-certificate-authority
+          items:
+          - key: service-ca.crt
+            path: ca.crt
+      {{- end }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
@@ -134,6 +134,11 @@ spec:
           readOnly: true
         - name: guardian-state
           mountPath: /var/run/simplyblock/guardian
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          mountPath: /etc/simplyblock/tls
+          readOnly: true
+        {{- end }}
       volumes:
       - name: socket-dir
         hostPath:
@@ -178,3 +183,11 @@ spec:
       - name: csi-secret
         secret:
           secretName: simplyblock-csi-secret-v2
+      {{- if .Values.tls.enabled }}
+      - name: tls
+        configMap:
+          name: simplyblock-certificate-authority
+          items:
+          - key: service-ca.crt
+            path: ca.crt
+      {{- end }}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -29,7 +29,32 @@ import (
 	"k8s.io/klog"
 )
 
-const tlsCAFile = "/etc/simplyblock/tls/ca.crt"
+const (
+	tlsCAFile          = "/etc/simplyblock/tls/ca.crt"
+	namespaceFile      = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+)
+
+// tlsServerName returns the FQDN service name that matches the TLS certificate
+// SANs (e.g. "simplyblock-webappapi.simplyblock.svc") derived from the URL host
+// and the pod's own namespace. Falls back to the bare hostname on any error.
+func tlsServerName(clusterIP string) string {
+	// strip scheme and port to get just the hostname
+	host := clusterIP
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		host = host[:i]
+	}
+	// if already a FQDN (contains a dot), use as-is
+	if strings.Contains(host, ".") {
+		return host
+	}
+	ns, err := os.ReadFile(namespaceFile)
+	if err != nil {
+		return host
+	}
+	return fmt.Sprintf("%s.%s.svc", host, strings.TrimSpace(string(ns)))
+}
 
 type NodeNVMf struct {
 	Client *RPCClient
@@ -41,10 +66,11 @@ func NewNVMf(clusterID, clusterIP, clusterSecret string) *NodeNVMf {
 	if caData, err := os.ReadFile(tlsCAFile); err == nil {
 		pool := x509.NewCertPool()
 		pool.AppendCertsFromPEM(caData)
-		transport = &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: pool},
-		}
 		clusterIP = strings.Replace(clusterIP, "http://", "https://", 1)
+		serverName := tlsServerName(clusterIP)
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: serverName},
+		}
 	}
 	client := RPCClient{
 		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second, Transport: transport},

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/klog"
@@ -43,6 +44,7 @@ func NewNVMf(clusterID, clusterIP, clusterSecret string) *NodeNVMf {
 		transport = &http.Transport{
 			TLSClientConfig: &tls.Config{RootCAs: pool},
 		}
+		clusterIP = strings.Replace(clusterIP, "http://", "https://", 1)
 	}
 	client := RPCClient{
 		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second, Transport: transport},

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -17,13 +17,18 @@ limitations under the License.
 package util
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
 	"k8s.io/klog"
 )
+
+const tlsCAFile = "/etc/simplyblock/tls/ca.crt"
 
 type NodeNVMf struct {
 	Client *RPCClient
@@ -31,8 +36,16 @@ type NodeNVMf struct {
 
 // NewNVMf creates a new NVMf client
 func NewNVMf(clusterID, clusterIP, clusterSecret string) *NodeNVMf {
+	transport := http.DefaultTransport
+	if caData, err := os.ReadFile(tlsCAFile); err == nil {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(caData)
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		}
+	}
 	client := RPCClient{
-		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second},
+		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second, Transport: transport},
 		ClusterID:     clusterID,
 		ClusterIP:     clusterIP,
 		ClusterSecret: clusterSecret,


### PR DESCRIPTION
When `.Values.tls.enabled` is true, we mount the certificates as a part of the helm chart and create an HTTP clients. 