### PR TITLE
set simplyblock.clusterIP automatically when the operator is enabled

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
+++ b/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
@@ -10,6 +10,14 @@ labels:
   chartVersion: "{{ .Chart.Version }}"
 {{- end -}}
 
+{{- define "simplyblock.controlPlaneAddr" -}}
+{{- if .Values.csiConfig.simplybk.ip -}}
+{{ .Values.csiConfig.simplybk.ip }}
+{{- else if .Values.operator.enabled -}}
+http://simplyblock-webappapi.{{ .Release.Namespace }}.svc.cluster.local:5000
+{{- end -}}
+{{- end -}}
+
 {{- define "simplyblock.commonContainer" }}
 env:
   - name: SIMPLYBLOCK_LOG_LEVEL

--- a/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/secret.yaml
@@ -24,7 +24,7 @@ stringData:
 {{ toJson .Values.csiSecret | indent 4 }}
 
 ---
-{{- if and .Values.csiConfig.simplybk.uuid .Values.csiConfig.simplybk.ip .Values.csiSecret.simplybk.secret }}
+{{- if and .Values.csiConfig.simplybk.uuid .Values.csiSecret.simplybk.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -41,14 +41,14 @@ stringData:
         {{- if $i }},{{ end }}
         {
           "cluster_id": {{ required "storagenode.multiCluster.clusters[].cluster_id is required" $c.cluster_id | quote }},
-          "cluster_endpoint": "{{ $.Values.csiConfig.simplybk.ip }}",
+          "cluster_endpoint": "{{ include "simplyblock.controlPlaneAddr" $ }}",
           "cluster_secret": {{ required "storagenode.multiCluster.clusters[].secret is required" $c.secret | quote }}
         }
 {{- end }}
 {{- else }}
         {
           "cluster_id": {{ .Values.csiConfig.simplybk.uuid | quote }},
-          "cluster_endpoint": "{{ .Values.csiConfig.simplybk.ip }}",
+          "cluster_endpoint": "{{ include "simplyblock.controlPlaneAddr" . }}",
           "cluster_secret": {{ .Values.csiSecret.simplybk.secret | quote }}
         }
 {{- end }}


### PR DESCRIPTION
when both `controlplane.enabled=true` and `operator.enabled=true` are set we automatically infer webApp endpoint point. 

This will also work even if TLS enabled/disabled. Because we infer the protocol scheme automatically based on the availability of certificates. 