### PR TITLE
setup topology based scheduling for pool

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -735,10 +735,13 @@ func (cs *controllerServer) publishVolume(volumeID string, sbclient *util.NodeNV
 		return nil, err
 	}
 
-	volumeInfo, err := sbclient.VolumeInfo(spdkVol.lvolID)
+	// hostNQN is not available in the controller path; pass empty string.
+	// If the volume has allowed_hosts configured, this call will fail and the
+	// node will re-fetch connection info at NodeStageVolume time using its own NQN.
+	volumeInfo, err := sbclient.VolumeInfo(spdkVol.lvolID, "")
 	if err != nil {
-		cs.unpublishVolume(volumeID) //nolint:errcheck // we can do little
-		return nil, err
+		klog.Warningf("failed to get volume info for %s (will be fetched at stage time): %v", spdkVol.lvolID, err)
+		return map[string]string{}, nil
 	}
 	return volumeInfo, nil
 }
@@ -910,7 +913,7 @@ func (cs *controllerServer) ControllerGetVolume(_ context.Context, req *csi.Cont
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	volumeInfo, err := sbclient.VolumeInfo(spdkVol.lvolID)
+	volumeInfo, err := sbclient.VolumeInfo(spdkVol.lvolID, "")
 	if err != nil {
 		klog.Errorf("failed to get spdkVol for %s: %v", volumeID, err)
 

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	osexec "os/exec"
 	"strconv"
 	"time"
@@ -206,6 +207,12 @@ func (ns *nodeServer) buildAccessibleTopology(ctx context.Context) map[string]st
 		segments[topologyKeyRegionStable] = region
 	}
 
+	for key, val := range node.Labels {
+		if strings.HasPrefix(key, "simplyblock.io/pool.") && val == "allowed" {
+			segments[key] = val
+		}
+	}
+
 	if len(segments) == 0 {
 		return nil
 	}
@@ -309,6 +316,17 @@ func (ns *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 	vc := req.GetVolumeContext()
 
 	vc["stagingParentPath"] = stagingParentPath
+
+	if ns.kubeClient != nil {
+		nodeName := ns.Driver.GetNodeID()
+		node, nodeErr := ns.kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if nodeErr == nil {
+			vc["hostNQN"] = fmt.Sprintf("nqn.2014-08.io.simplyblock:uuid:%s", node.UID)
+		} else {
+			klog.Warningf("failed to get node %s for hostNQN: %v", nodeName, nodeErr)
+		}
+	}
+
 	initiator, err = util.NewSpdkCsiInitiator(vc)
 	if err != nil {
 		klog.Errorf("failed to create spdk initiator, volumeID: %s err: %v", volumeID, err)

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -327,6 +327,28 @@ func (ns *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 		}
 	}
 
+	// When the volume was provisioned against a pool with allowed_hosts, the controller
+	// couldn't fetch connection info (no host NQN available there). Re-fetch it here using
+	// the node's host NQN so that NewSpdkCsiInitiator gets the fields it needs.
+	if vc["nqn"] == "" || vc["targetType"] == "" {
+		spdkVol, parseErr := getSPDKVol(volumeID)
+		if parseErr == nil {
+			sbcClient, clientErr := util.NewsimplyBlockClient(spdkVol.clusterID)
+			if clientErr == nil {
+				connInfo, infoErr := sbcClient.VolumeInfo(spdkVol.lvolID, vc["hostNQN"])
+				if infoErr != nil {
+					klog.Errorf("failed to fetch volume connection info for %s: %v", volumeID, infoErr)
+				} else {
+					for k, v := range connInfo {
+						if vc[k] == "" {
+							vc[k] = v
+						}
+					}
+				}
+			}
+		}
+	}
+
 	initiator, err = util.NewSpdkCsiInitiator(vc)
 	if err != nil {
 		klog.Errorf("failed to create spdk initiator, volumeID: %s err: %v", volumeID, err)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -67,6 +67,7 @@ type initiatorNVMf struct {
 	model          string
 	nsId           string
 	hostIface      string
+	hostNQN        string
 }
 
 // initiatorCache is an implementation of NVMf cache initiator
@@ -194,6 +195,7 @@ func NewSpdkCsiInitiator(volumeContext map[string]string) (SpdkCsiInitiator, err
 			model:          volumeContext["model"],
 			nsId:           volumeContext["nsId"],
 			hostIface:      volumeContext["hostIface"],
+			hostNQN:        volumeContext["hostNQN"],
 		}, nil
 
 	case "cache":
@@ -355,7 +357,7 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			klog.Errorf("failed to create SPDK client: %v", err)
 			return "", err
 		}
-		connections, err := fetchLvolConnection(sbcClient, lvolID)
+		connections, err := fetchLvolConnection(sbcClient, lvolID, nvmf.hostNQN)
 		if err != nil {
 			klog.Errorf("Failed to get lvol connection: %v", err)
 			return "", err
@@ -373,6 +375,10 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 
 			if nvmf.hostIface != "" {
 				cmdLine = append(cmdLine, "-f", nvmf.hostIface)
+			}
+
+			if nvmf.hostNQN != "" {
+				cmdLine = append(cmdLine, "--hostnqn="+nvmf.hostNQN)
 			}
 
 			err := execWithTimeoutRetry(cmdLine, 40, len(nvmf.connections))
@@ -762,8 +768,12 @@ func isNodeOnline(spdkNode *NodeNVMf, nodeID string) bool {
 	return status[0].Status == "online"
 }
 
-func fetchLvolConnection(spdkNode *NodeNVMf, lvolID string) ([]*LvolConnectResp, error) {
-	resp, err := spdkNode.Client.CallSBCLI("GET", "/lvol/connect/"+lvolID, nil)
+func fetchLvolConnection(spdkNode *NodeNVMf, lvolID string, hostNQN string) ([]*LvolConnectResp, error) {
+	path := "/lvol/connect/" + lvolID
+	if hostNQN != "" {
+		path += "?host_nqn=" + hostNQN
+	}
+	resp, err := spdkNode.Client.CallSBCLI("GET", path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch connection: %v", err)
 	}
@@ -888,7 +898,7 @@ func resolveExpectedPathCount(nqn, clusterID, lvolID string, currentActive int) 
 		klog.Warningf("resolveExpectedPathCount: client error for NQN %s: %v", nqn, err)
 		return cached
 	}
-	conns, err := fetchLvolConnection(sbcClient, lvolID)
+	conns, err := fetchLvolConnection(sbcClient, lvolID, "")
 	if err != nil {
 		klog.Warningf("resolveExpectedPathCount: fetch error for NQN %s: %v", nqn, err)
 		return cached
@@ -915,7 +925,7 @@ func recoverPathsWithANA(clusterID, lvolID, devicePath string, activePaths []pat
 		return fmt.Errorf("failed to fetch node info for lvol %s: %w", lvolID, err)
 	}
 
-	expectedConns, err := fetchLvolConnection(sbcClient, lvolID)
+	expectedConns, err := fetchLvolConnection(sbcClient, lvolID, "")
 	if err != nil {
 		return fmt.Errorf("failed to fetch connections for lvol %s: %w", lvolID, err)
 	}

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -88,7 +88,7 @@ var (
 type SpdkNode interface {
 	Info() string
 	LvStores() ([]LvStore, error)
-	VolumeInfo(lvolID string) (map[string]string, error)
+	VolumeInfo(lvolID string, hostNQN string) (map[string]string, error)
 	CreateVolume(lvolName, lvsName string, sizeMiB int64) (string, error)
 	GetVolume(lvolName, lvsName string) (string, error)
 	DeleteVolume(lvolID string) error
@@ -276,10 +276,14 @@ func (client *RPCClient) listVolumes() ([]*BDev, error) {
 }
 
 // getVolumeInfo gets a volume along with its connection info
-func (client *RPCClient) getVolumeInfo(lvolID string) (map[string]string, error) {
+func (client *RPCClient) getVolumeInfo(lvolID string, hostNQN string) (map[string]string, error) {
 	var result []*LvolConnectResp
 
-	out, err := client.CallSBCLI("GET", "/lvol/connect/"+lvolID, nil)
+	path := "/lvol/connect/" + lvolID
+	if hostNQN != "" {
+		path += "?host_nqn=" + hostNQN
+	}
+	out, err := client.CallSBCLI("GET", path, nil)
 	if err != nil {
 		klog.Error(err)
 		if errorMatches(err, ErrJSONNoSuchDevice) {

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -153,13 +153,9 @@ func (node *NodeNVMf) LvStores() ([]LvStore, error) {
 
 // VolumeInfo returns a string:string map containing information necessary
 // for CSI node(initiator) to connect to this target and identify the disk.
-func (node *NodeNVMf) VolumeInfo(lvolID string) (map[string]string, error) {
-	lvol, err := node.Client.getVolumeInfo(lvolID)
-	if err != nil {
-		return nil, err
-	}
-
-	return lvol, nil
+// hostNQN is passed to the sbcli API when the volume has allowed_hosts configured.
+func (node *NodeNVMf) VolumeInfo(lvolID string, hostNQN string) (map[string]string, error) {
+	return node.Client.getVolumeInfo(lvolID, hostNQN)
 }
 
 // CreateLVolData is the data structure for creating a logical volume


### PR DESCRIPTION
Topology based scheduling in pool


### testing

```
kubectl apply -f - <<'EOF'
apiVersion: storage.simplyblock.io/v1alpha1
kind: Pool
metadata:
  name: pool5
  namespace: default
spec:
  name: pool5
  clusterName: simplyblock-cluster
  dhchap: true
  allowedNodes:
  - storage-node-1
EOF
```

when below CRD is applied, a label is added to the storage node
```
kubectl describe node storage-node-1 | grep "simplyblock.io/pool"
                    simplyblock.io/pool.default.simplyblock-cluster.pool5=allowed
```

--- And looking at the storage class, it can be observed that allowedTopologies are set:

```
kubectl get sc simplyblock-simplyblock-cluster-pool5 -oyaml
allowVolumeExpansion: true
allowedTopologies:
- matchLabelExpressions:
  - key: simplyblock.io/pool.default.simplyblock-cluster.pool5
    values:
    - allowed
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2026-05-11T10:30:01Z"
  name: simplyblock-simplyblock-cluster-pool5
  resourceVersion: "23798"
  uid: 2278279f-9e00-45b8-b0cd-10c9d3204915
parameters:
  cluster_id: 6abe4851-faf6-49d4-a8f4-83d2ebe85dc4
  compression: "False"
  csi.storage.k8s.io/fstype: ext4
  distr_ndcs: "1"
  distr_npcs: "1"
  encryption: "False"
  fabric: tcp
  lvol_priority_class: "0"
  max_namespace_per_subsys: "1"
  pool_name: pool5
  qos_r_mbytes: "0"
  qos_rw_iops: "0"
  qos_rw_mbytes: "0"
  qos_w_mbytes: "0"
  replicate: "False"
  tune2fs_reserved_blocks: "0"
provisioner: csi.simplyblock.io
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```

-----

On the SBCLI side the node is the lvol is created against `storage-node-1`
```
| allowed_hosts              | [{'nqn': 'nqn.2014-08.io.simplyblock:uuid:b76f61e0-2287-43ad-8a89-     |
[simplyblock@manohar-storage-node-3 app]$ sbctl lvol get 057e9341-aa95-4ea1-af9d-6227932bcfab | grep hostname
| hostname                   | storage-node-1_8080                                            |
[simplyblock@storage-node-3 app]$ 
```

on k8s side, the pod is scheduled on `storage-node-1`
