### PR TITLE
Adapt to support a cluster issuer

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
+++ b/charts/spdk-csi/latest/spdk-csi/templates/_helpers.tpl
@@ -52,9 +52,9 @@ Caller pipes through `nindent N`.
 {{/*
 Volume named "tls" holding only ca.crt, for client-only consumers without mTLS.
 - openshift: cabundle ConfigMap (renamed key).
-- cert-manager: project ca.crt out of the chart's CA Secret
-  (simplyblock-certificate-authority-tls), populated by cert-manager from the
-  CA Certificate in controlplane_certificates.yaml.
+- cert-manager: project ca.crt out of simplyblock-ca-bundle-tls, a Certificate
+  issued by the chart's ClusterIssuer into the release namespace. The root CA
+  secret lives in the cert-manager namespace and cannot be mounted directly.
 Caller pipes through `nindent N`.
 */}}
 {{- define "simplyblock.caVolume" -}}
@@ -69,7 +69,10 @@ Caller pipes through `nindent N`.
 {{- else if eq .Values.tls.provider "cert-manager" }}
 - name: tls
   secret:
-    secretName: simplyblock-certificate-authority-tls
+    # simplyblock-ca-bundle-tls is issued in the release namespace by the chart's
+    # ClusterIssuer, so pods can mount it. The CA secret itself lives in the
+    # cert-manager namespace and is not directly mountable from here.
+    secretName: simplyblock-ca-bundle-tls
     items:
     - key: ca.crt
       path: ca.crt
@@ -104,15 +107,10 @@ Caller pipes through `nindent N`.
           path: ca.crt
 {{- else if eq $ctx.Values.tls.provider "cert-manager" }}
 - name: tls
-  projected:
-    sources:
-    - secret:
-        name: {{ $clientSecret }}
-    - secret:
-        name: simplyblock-certificate-authority-tls
-        items:
-        - key: ca.crt
-          path: ca.crt
+  secret:
+    # cert-manager populates the client cert secret with tls.crt, tls.key, and
+    # ca.crt, so a projected volume is not needed.
+    secretName: {{ $clientSecret }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controlplane_certificates.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controlplane_certificates.yaml
@@ -1,10 +1,13 @@
 {{- if and .Values.tls.enabled (eq .Values.tls.provider "cert-manager") }}
 ---
+# The CA Certificate must live in the cert-manager namespace so that the
+# ClusterIssuer below can read its backing secret. ClusterIssuers always look
+# for CA secrets in the namespace where cert-manager itself is running.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: simplyblock-certificate-authority
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ index .Values.tls "cert-manager" "namespace" }}
 spec:
   isCA: true
   commonName: simplyblock-certificate-authority
@@ -16,14 +19,32 @@ spec:
     kind: ClusterIssuer
     name: {{ index .Values.tls "cert-manager" "cluster-issuer" | quote }}
 ---
+# ClusterIssuer is cluster-scoped; namespace in metadata is ignored.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: simplyblock-certificate-authority-issuer
-  namespace: {{ .Release.Namespace }}
 spec:
   ca:
     secretName: simplyblock-certificate-authority-tls
+---
+# CA bundle certificate in the release namespace. Pods cannot mount secrets
+# across namespaces, so this certificate (issued by the ClusterIssuer above)
+# places a secret containing ca.crt into the release namespace for volume mounts.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: simplyblock-ca-bundle
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: simplyblock-ca-bundle-tls
+  commonName: simplyblock-ca-bundle
+  issuerRef:
+    kind: ClusterIssuer
+    name: simplyblock-certificate-authority-issuer
+  usages:
+    - digital signature
+    - key encipherment
 {{- if .Values.tls.mutual_enabled }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/spdk-csi/latest/spdk-csi/values.schema.json
+++ b/charts/spdk-csi/latest/spdk-csi/values.schema.json
@@ -15,7 +15,8 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "cluster-issuer": { "type": "string" }
+            "cluster-issuer": { "type": "string" },
+            "namespace": { "type": "string" }
           }
         }
       },

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -535,6 +535,10 @@ tls:
   # which is used to mint the chart's own CA Certificate.
   cert-manager:
     cluster-issuer: ""
+    # Namespace where cert-manager is installed. The chart's CA secret is placed
+    # here so that the ClusterIssuer can locate it (ClusterIssuers always read CA
+    # secrets from the cert-manager controller namespace).
+    namespace: cert-manager
 
   # Mutual TLS (clients present and verify certificates). Only allowed when provider == cert-manager.
   mutual_enabled: false


### PR DESCRIPTION
This adapts the cert-manager part of the chart to use a `ClusterIssuer` instead of a `Issuer` to support CRDs across namespaces. Currently this deployment mode does fail for unrelated reasons, so it cannot be fully tested. 