### PR TITLE
e2e tests: take storage class as env variable

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/storageclass.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storageclass.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) Arm Limited and Contributors
 # Copyright (c) Intel Corporation
 
-{{- if .Values.storageclass.create -}}
+{{- if and .Values.storageclass.create (not .Values.operator.enabled) -}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/charts/spdk-csi/latest/spdk-csi/templates/storageclass.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storageclass.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) Arm Limited and Contributors
 # Copyright (c) Intel Corporation
 
-{{- if and .Values.storageclass.create (not .Values.operator.enabled) -}}
+{{- if .Values.storageclass.create -}}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -26,6 +26,7 @@ import (
 )
 
 var nameSpace string
+var storageClassName string
 
 const (
 
@@ -68,6 +69,29 @@ func init() {
 	if nameSpace == "" {
 		nameSpace = "default"
 	}
+	storageClassName = os.Getenv("STORAGE_CLASS_NAME")
+	if storageClassName == "" {
+		storageClassName = "simplyblock-csi-sc"
+	}
+}
+
+func applyTemplateWithStorageClass(ns, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	modified := strings.ReplaceAll(string(data), "simplyblock-csi-sc", storageClassName)
+	tmp, err := os.CreateTemp("", "e2e-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err = tmp.WriteString(modified); err != nil {
+		return err
+	}
+	tmp.Close()
+	_, err = e2ekubectl.RunKubectl(ns, "apply", "-f", tmp.Name())
+	return err
 }
 
 func deployTestPod() {
@@ -99,8 +123,7 @@ func deleteCacheTestPod() {
 }
 
 func deployPVC() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", pvcPath)
-	if err != nil {
+	if err := applyTemplateWithStorageClass(nameSpace, pvcPath); err != nil {
 		framework.Logf("failed to create pvc: %s", err)
 	}
 }
@@ -113,8 +136,7 @@ func deletePVC() {
 }
 
 func deploySnapshot() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodWithSnapshotPath)
-	if err != nil {
+	if err := applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath); err != nil {
 		framework.Logf("failed to deployed snapshot: %s", err)
 	}
 }
@@ -127,8 +149,7 @@ func deleteSnapshot() {
 }
 
 func deploySnapshot2() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodWithSnapshotPath2)
-	if err != nil {
+	if err := applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath2); err != nil {
 		framework.Logf("failed to deployed snapshot: %s", err)
 	}
 }
@@ -141,8 +162,7 @@ func deleteSnapshot2() {
 }
 
 func deployClone() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodWithClonePath)
-	if err != nil {
+	if err := applyTemplateWithStorageClass(nameSpace, testPodWithClonePath); err != nil {
 		framework.Logf("failed to deployed Cloned Volume: %s", err)
 	}
 }
@@ -160,8 +180,7 @@ func deletePVCAndTestPod() {
 }
 
 func deployCachePVC() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", cachepvcPath)
-	if err != nil {
+	if err := applyTemplateWithStorageClass(nameSpace, cachepvcPath); err != nil {
 		framework.Logf("failed to create cache pvc: %s", err)
 	}
 }
@@ -193,8 +212,7 @@ func deleteTestPodWithMultiPvcs() {
 }
 
 func deployMultiPvcs() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", multiPvcsPath)
-	if err != nil {
+	if err := applyTemplateWithStorageClass(nameSpace, multiPvcsPath); err != nil {
 		framework.Logf("failed to create pvcs: %s", err)
 	}
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -27,6 +27,8 @@ import (
 
 var nameSpace string
 var storageClassName string
+var operatorMode bool
+var systemNamespace string
 
 const (
 
@@ -72,6 +74,11 @@ func init() {
 	storageClassName = os.Getenv("STORAGE_CLASS_NAME")
 	if storageClassName == "" {
 		storageClassName = "simplyblock-csi-sc"
+	}
+	operatorMode = os.Getenv("OPERATOR_MODE") == "true"
+	systemNamespace = os.Getenv("CSI_SYSTEM_NAMESPACE")
+	if systemNamespace == "" {
+		systemNamespace = "simplyblock"
 	}
 }
 
@@ -468,6 +475,54 @@ type SimplyBlock struct {
 	Secret string `json:"secret"`
 }
 
+type csiClusterEntry struct {
+	ClusterID       string `json:"cluster_id"`
+	ClusterEndpoint string `json:"cluster_endpoint"`
+	ClusterSecret   string `json:"cluster_secret"`
+}
+
+type csiCredentialsV2 struct {
+	Clusters []csiClusterEntry `json:"clusters"`
+}
+
+// getSimplyBlockCreds returns cluster credentials from the appropriate source.
+// In operator mode it reads simplyblock-csi-secret-v2 from systemNamespace;
+// otherwise it reads simplyblock-csi-cm + simplyblock-csi-secret from nameSpace.
+func getSimplyBlockCreds(c kubernetes.Interface) (SimplyBlock, error) {
+	if operatorMode {
+		secret, err := c.CoreV1().Secrets(systemNamespace).Get(ctx, "simplyblock-csi-secret-v2", metav1.GetOptions{})
+		if err != nil {
+			return SimplyBlock{}, err
+		}
+		var creds csiCredentialsV2
+		if err := json.Unmarshal(secret.Data["secret.json"], &creds); err != nil {
+			return SimplyBlock{}, err
+		}
+		if len(creds.Clusters) == 0 {
+			return SimplyBlock{}, errors.New("no clusters found in simplyblock-csi-secret-v2")
+		}
+		c0 := creds.Clusters[0]
+		return SimplyBlock{IP: c0.ClusterEndpoint, UUID: c0.ClusterID, Secret: c0.ClusterSecret}, nil
+	}
+
+	cm, err := c.CoreV1().ConfigMaps(nameSpace).Get(ctx, "simplyblock-csi-cm", metav1.GetOptions{})
+	if err != nil {
+		return SimplyBlock{}, err
+	}
+	var creds simplyblockCreds
+	if err := json.Unmarshal([]byte(cm.Data["config.json"]), &creds); err != nil {
+		return SimplyBlock{}, err
+	}
+	secret, err := c.CoreV1().Secrets(nameSpace).Get(ctx, "simplyblock-csi-secret", metav1.GetOptions{})
+	if err != nil {
+		return SimplyBlock{}, err
+	}
+	if err := json.Unmarshal(secret.Data["secret.json"], &creds); err != nil {
+		return SimplyBlock{}, err
+	}
+	return creds.Simplyblock, nil
+}
+
 type StorageNodes struct {
 	Nodes []StorageNode `json:"results"`
 }
@@ -845,99 +900,26 @@ func createstorageClassWithHostID(c kubernetes.Interface, storageClassName, host
 }
 
 func getStorageNode(c kubernetes.Interface, random int) (string, string, error) {
-	// get the credentials from the configmap
-	// get the storage node from the simplyblock api
-	// return the storage node
-	cm, err := c.CoreV1().ConfigMaps(nameSpace).Get(ctx, "simplyblock-csi-cm", metav1.GetOptions{})
+	s, err := getSimplyBlockCreds(c)
 	if err != nil {
 		return "", "", err
 	}
-	value := cm.Data["config.json"]
-	var creds simplyblockCreds
-	err = json.Unmarshal([]byte(value), &creds)
-	if err != nil {
-		return "", "", err
-	}
-
-	// use k8s client go to get the value of the secret spdkcsi-secret
-	secret, err := c.CoreV1().Secrets(nameSpace).Get(ctx, "simplyblock-csi-secret", metav1.GetOptions{})
-	if err != nil {
-		return "", "", err
-	}
-	value = string(secret.Data["secret.json"])
-	err = json.Unmarshal([]byte(value), &creds)
-	if err != nil {
-		return "", "", err
-	}
-
-	s := creds.Simplyblock
-	sn, snid, err := s.getStoragenode(random)
-	if err != nil {
-		return "", "", err
-	}
-	return sn, snid, nil
+	return s.getStoragenode(random)
 }
 func numberOfNodes(c kubernetes.Interface) (int, error) {
-	cm, err := c.CoreV1().ConfigMaps(nameSpace).Get(ctx, "simplyblock-csi-cm", metav1.GetOptions{})
+	s, err := getSimplyBlockCreds(c)
 	if err != nil {
 		return 0, err
 	}
-	value := cm.Data["config.json"]
-	var creds simplyblockCreds
-	err = json.Unmarshal([]byte(value), &creds)
-	if err != nil {
-		return 0, err
-	}
-
-	// use k8s client go to get the value of the secret s pdkcsi-secret
-	secret, err := c.CoreV1().Secrets(nameSpace).Get(ctx, "simplyblock-csi-secret", metav1.GetOptions{})
-	if err != nil {
-		return 0, err
-	}
-	value = string(secret.Data["secret.json"])
-	err = json.Unmarshal([]byte(value), &creds)
-	if err != nil {
-		return 0, err
-	}
-
-	s := creds.Simplyblock
-	sn, err := s.numberOfNodes()
-
-	if err != nil {
-		return 0, err
-	}
-	return sn, nil
+	return s.numberOfNodes()
 }
 
 func restartStorageNode(c kubernetes.Interface, nodeID string) error {
-	cm, err := c.CoreV1().ConfigMaps(nameSpace).Get(ctx, "simplyblock-csi-cm", metav1.GetOptions{})
+	s, err := getSimplyBlockCreds(c)
 	if err != nil {
 		return err
 	}
-	value := cm.Data["config.json"]
-	var creds simplyblockCreds
-	err = json.Unmarshal([]byte(value), &creds)
-	if err != nil {
-		return err
-	}
-
-	// use k8s client go to get the value of the secret spdkcsi-secret
-	secret, err := c.CoreV1().Secrets(nameSpace).Get(ctx, "simplyblock-csi-secret", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	value = string(secret.Data["secret.json"])
-	err = json.Unmarshal([]byte(value), &creds)
-	if err != nil {
-		return err
-	}
-
-	s := creds.Simplyblock
-	err = s.restartStorageNode(nodeID)
-	if err != nil {
-		return err
-	}
-	return nil
+	return s.restartStorageNode(nodeID)
 }
 func writeDataToPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPath string) {
 	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, dataPath), nameSpace, opt)

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -237,8 +237,12 @@ func deleteMultiPvcsAndTestPodWithMultiPvcs() {
 }
 
 func waitForControllerReady(c kubernetes.Interface, timeout time.Duration) error {
+	ns := nameSpace
+	if operatorMode {
+		ns = systemNamespace
+	}
 	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		sts, err := c.AppsV1().StatefulSets(nameSpace).Get(ctx, controllerStsName, metav1.GetOptions{})
+		sts, err := c.AppsV1().StatefulSets(ns).Get(ctx, controllerStsName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -254,8 +258,12 @@ func waitForControllerReady(c kubernetes.Interface, timeout time.Duration) error
 }
 
 func waitForNodeServerReady(c kubernetes.Interface, timeout time.Duration) error {
+	ns := nameSpace
+	if operatorMode {
+		ns = systemNamespace
+	}
 	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		ds, err := c.AppsV1().DaemonSets(nameSpace).Get(ctx, nodeDsName, metav1.GetOptions{})
+		ds, err := c.AppsV1().DaemonSets(ns).Get(ctx, nodeDsName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
* e2e tests: take storage class as env variable
* Both `waitForControllerReady` and `waitForNodeServerReady` look in  `default`, But the CSI controller and node daemonset are in `simplyblock` in operator mode
