### PR TITLE
fix e2e: provision pod+pvc at once

### DIFF
--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -29,20 +29,14 @@ var _ = ginkgo.Describe("SPDKCSI-NVMEOF", func() {
 
 		ginkgo.It("Test the flow for Dynamic volume provisioning", func() {
 			testPodName := "spdkcsi-test"
-			ginkgo.By("creating a PVC and verify dynamic PV", func() {
-				deployPVC()
-				defer deletePVC()
-				err := verifyDynamicPVCreation(f.ClientSet, "spdkcsi-pvc", 5*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
-
+			// WaitForFirstConsumer StorageClasses defer provisioning until a pod is scheduled.
+			// Deploy a pod alongside the PVC so the CSI provisioner is triggered, then verify
+			// the PV is created and the pod reaches Running before testing persistence.
 			ginkgo.By("creating a PVC and binding it to a pod", func() {
 				deployPVC()
 				deployTestPod()
 				defer deletePVCAndTestPod()
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName)
+				err := waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName)
 				if err != nil {
 					ginkgo.Fail(err.Error())
 				}


### PR DESCRIPTION
The Operator creates storage class of type: `WaitForFirstConsumer`. So creating pod+pvc at once. 

```
Will run 5 of 8 specs
•S•••S•S

Ran 5 of 8 Specs in 369.544 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 3 Skipped
--- PASS: TestE2E (369.55s)
PASS
ok  	github.com/spdk/spdk-csi/e2e	370.705s
```

Disabled NodeRestart tests as they will be converted in Operator e2e tests. So no need to include them in the CSI driver e2e tests.

All the tests passes now. 

