### PR TITLE
fix failing trivy security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,21 +23,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Build spdkcsi binary
-        run: CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o ./_out/spdkcsi ./cmd/
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build image for scanning (linux/amd64 only)
         uses: docker/build-push-action@v6
         with:
-          context: ./_out
+          context: .
           file: deploy/image/Dockerfile
           platforms: linux/amd64
           load: true


### PR DESCRIPTION
With the change in https://github.com/simplyblock/simplyblock-csi/pull/354 we've adopted multi stage docker build, so the binary is generated as a part of Docker Build itself. 

So its not required to build separate as a part of .github/workflows/security.yml