### PR TITLE
nvme connect: error handling and remove `hostnqn` parameter

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -420,9 +420,9 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 				cmdLine = append(cmdLine, "-f", nvmf.hostIface)
 			}
 
-			if nvmf.hostNQN != "" {
-				cmdLine = append(cmdLine, "--hostnqn="+nvmf.hostNQN)
-			}
+			// if nvmf.hostNQN != "" {
+			// 	cmdLine = append(cmdLine, "--hostnqn="+nvmf.hostNQN)
+			// }
 
 			err := execWithTimeoutRetry(cmdLine, 40, len(nvmf.connections))
 			if err != nil {

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -529,6 +529,9 @@ func execWithTimeout(cmdLine []string, timeout int) error {
 	if output != nil {
 		klog.Infof("command returned: %s", output)
 	}
+	if err != nil && len(output) > 0 {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
 	return err
 }
 


### PR DESCRIPTION
This PR: fixes 2 things
* PR https://github.com/simplyblock/simplyblock-csi/pull/345 has started using `--hostnqn` and is  passing `hostnqn` explicitly. Removing that parameter
* fixed error handling so that errors are shown properly


### testing

The above `--hostnqn` parameter is no longer passed.
`
nvme connect -t tcp -a 10.0.2.2 -s 4426 -n nqn.2023-02.io.simplyblock:72599d6c-d292-464a-9070-45e8869e4026:lvol:b80c2976-f270-4921-a46f-fa2dba3d725e -l 60 -c 2 -i 3
`


At the moment, when we fail to mount, we show this error on the PVC mount

`
kubelet                  MountVolume.MountDevice failed for volume "pvc-03204281-8e53-426e-841d-fc4cc49e3dd7" : rpc error: code = Internal desc = failed to connect to any NVMe path for NQN nqn.2023-02.io.simplyblock:3f94ff6a-4388-490d-b3a4-5e41ee378ce3:lvol:e59d023a-ba09-4aba-a03e-8503aab61aa7: error: exit status 1
`

and also
`
I0520 10:08:57.006324       1 initiator.go:487] command returned: could not add new controller: invalid arguments/configuration
I0520 10:08:57.006342       1 initiator.go:478] running command: [nvme connect -t tcp -a 10.57.1.9 -s 4420 -n nqn.2023-02.io.simplyblock:3f94ff6a-4388-490d-b3a4-5e41ee378ce3:lvol:66ef25fb-6b63-4a3c-889a-99c712d0ad0f -l 60 -c 2 -i 3 --hostnqn=nqn.2014-08.io.simplyblock:uuid:5aba5ff1-ac9a-41f3-aff1-60ef30ddc071]
I0520 10:08:57.029286       1 initiator.go:487] command returned: could not add new controller: invalid arguments/configuration
`



So that we see this error message

`failed to connect to any NVMe path for NQN nqn.2023-02...: error: exit status 1: Failed to write to /dev/nvme-fabrics: Connection refused
`

`MountVolume.MountDevice failed ... failed to connect to any NVMe path for NQN nqn.2023-02...: error: exit status 1: could not add new controller: invalid arguments/configuration`