### PR TITLE
use connections from `fetchLvolConnection` object rather than `nvmf.connection`

### DIFF
--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	osexec "os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"path/filepath"

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -59,7 +59,6 @@ type SpdkCsiInitiator interface {
 // initiatorNVMf is an implementation of NVMf tcp initiator
 type initiatorNVMf struct {
 	targetType     string
-	connections    []connectionInfo
 	nqn            string
 	reconnectDelay string
 	nrIoQueues     string
@@ -221,16 +220,8 @@ func NewSpdkCsiInitiator(volumeContext map[string]string) (SpdkCsiInitiator, err
 	klog.Infof("Simplyblock targetType created :%s", targetType)
 	switch targetType {
 	case TargetTypeTCP, TargetTypeRDMA:
-		var connections []connectionInfo
-
-		err := json.Unmarshal([]byte(volumeContext["connections"]), &connections)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshall connections. Error: %v", err.Error())
-		}
-
 		return &initiatorNVMf{
 			targetType:     volumeContext["targetType"],
-			connections:    connections,
 			nqn:            volumeContext["nqn"],
 			reconnectDelay: volumeContext["reconnectDelay"],
 			nrIoQueues:     volumeContext["nrIoQueues"],
@@ -381,8 +372,6 @@ func execWithTimeoutRetry(cmdLine []string, timeout, retry int) (err error) {
 }
 
 func (nvmf *initiatorNVMf) Connect() (string, error) {
-	klog.Info("connections", nvmf.connections)
-
 	alreadyConnected, err := isNqnConnected(nvmf.nqn)
 	if err != nil {
 		klog.Errorf("Failed to check existing connections: %v", err)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -105,7 +105,7 @@ type subsystemResponse struct {
 
 type NodeInfo struct {
 	NodeID string   `json:"storage_node_id"` // v2 VolumeDTO field
-	Nodes  []string `json:"nodes"`            // URL paths in v2; converted to UUIDs after parsing
+	Nodes  []string `json:"nodes"`           // URL paths in v2; converted to UUIDs after parsing
 	Status string   `json:"status"`
 }
 
@@ -391,37 +391,18 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			return "", err
 		}
 
-		ctrlLossTmo := 60
-		if len(connections) == 1 {
-			ctrlLossTmo *= 15
-		}
+		ctrlLossTmo := connections[0].CtrlLossTmo
 
 		connected := 0
 		var lastErr error
 
 		for _, conn := range connections {
-			cmdLine := []string{
-				"nvme", "connect", "-t", strings.ToLower(nvmf.targetType),
-				"-a", conn.IP, "-s", strconv.Itoa(conn.Port), "-n", nvmf.nqn, "-l", strconv.Itoa(ctrlLossTmo),
-				"-c", nvmf.reconnectDelay, "-i", nvmf.nrIoQueues,
-			}
-
-			if nvmf.hostIface != "" {
-				cmdLine = append(cmdLine, "-f", nvmf.hostIface)
-			}
-
-			// if nvmf.hostNQN != "" {
-			// 	cmdLine = append(cmdLine, "--hostnqn="+nvmf.hostNQN)
-			// }
-
-			err := execWithTimeoutRetry(cmdLine, 40, len(connections))
+			err := connectViaNVMe(conn, ctrlLossTmo)
 			if err != nil {
-				// go on checking device status in case caused by duplicated request
-				klog.Errorf("command %v failed: %s", cmdLine, err)
+				klog.Errorf("nvme connect failed for %s:%d: %v", conn.IP, conn.Port, err)
 				lastErr = err
 				continue
 			}
-
 			connected++
 		}
 		if connected == 0 {
@@ -816,12 +797,15 @@ func fetchLvolConnection(spdkNode *NodeNVMf, lvolID string, hostNQN string) ([]*
 
 func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo int) error {
 	cmd := []string{
-		"nvme", "connect", "-t", conn.TargetType,
+		"nvme", "connect", "-t", strings.ToLower(conn.TargetType),
 		"-a", conn.IP, "-s", strconv.Itoa(conn.Port),
 		"-n", conn.Nqn,
 		"-l", strconv.Itoa(ctrlLossTmo),
 		"-c", strconv.Itoa(conn.ReconnectDelay),
 		"-i", strconv.Itoa(conn.NrIoQueues),
+	}
+	if conn.HostIface != "" {
+		cmd = append(cmd, "-f", conn.HostIface)
 	}
 	if err := execWithTimeoutRetry(cmd, 40, 1); err != nil {
 		klog.Errorf("nvme connect failed: %v", err)
@@ -969,7 +953,7 @@ func recoverPathsWithANA(clusterID, lvolID, devicePath string, activePaths []pat
 	}
 	maxSeenMu.Unlock()
 
-	ctrlLossTmo := 60
+	ctrlLossTmo := expectedConns[0].CtrlLossTmo
 
 	optConn := expectedConns[0]
 	nonOptConns := expectedConns[1:]

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -397,7 +397,7 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 		var lastErr error
 
 		for _, conn := range connections {
-			err := connectViaNVMe(conn, ctrlLossTmo)
+			err := connectViaNVMe(conn, ctrlLossTmo, len(connections))
 			if err != nil {
 				klog.Errorf("nvme connect failed for %s:%d: %v", conn.IP, conn.Port, err)
 				lastErr = err
@@ -795,7 +795,7 @@ func fetchLvolConnection(spdkNode *NodeNVMf, lvolID string, hostNQN string) ([]*
 	return connections, nil
 }
 
-func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo int) error {
+func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo, retries int) error {
 	cmd := []string{
 		"nvme", "connect", "-t", strings.ToLower(conn.TargetType),
 		"-a", conn.IP, "-s", strconv.Itoa(conn.Port),
@@ -807,7 +807,7 @@ func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo int) error {
 	if conn.HostIface != "" {
 		cmd = append(cmd, "-f", conn.HostIface)
 	}
-	if err := execWithTimeoutRetry(cmd, 40, 1); err != nil {
+	if err := execWithTimeoutRetry(cmd, 40, retries); err != nil {
 		klog.Errorf("nvme connect failed: %v", err)
 		return err
 	}
@@ -987,7 +987,7 @@ func reconcileOptimizedPath(
 			return
 		}
 		klog.Infof("reconcileOptimizedPath: connecting missing optimized path ip=%s", conn.IP)
-		if err := connectViaNVMe(conn, ctrlLossTmo); err != nil {
+		if err := connectViaNVMe(conn, ctrlLossTmo, 1); err != nil {
 			klog.Errorf("reconcileOptimizedPath: connect to %s failed: %v", conn.IP, err)
 		}
 		return
@@ -1007,7 +1007,7 @@ func reconcileOptimizedPath(
 		klog.Errorf("reconcileOptimizedPath: disconnect stale %s failed: %v", activeIP, err)
 		return
 	}
-	if err := connectViaNVMe(conn, ctrlLossTmo); err != nil {
+	if err := connectViaNVMe(conn, ctrlLossTmo, 1); err != nil {
 		klog.Errorf("reconcileOptimizedPath: connect to new IP %s failed: %v", conn.IP, err)
 	}
 }
@@ -1071,7 +1071,7 @@ func reconcileNonOptimizedPaths(
 			continue
 		}
 		klog.Infof("reconcileNonOptimizedPaths: connecting missing path ip=%s", conn.IP)
-		if err := connectViaNVMe(conn, ctrlLossTmo); err != nil {
+		if err := connectViaNVMe(conn, ctrlLossTmo, 1); err != nil {
 			klog.Errorf("reconcileNonOptimizedPaths: connect to %s failed: %v", conn.IP, err)
 		}
 	}

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -382,10 +382,6 @@ func execWithTimeoutRetry(cmdLine []string, timeout, retry int) (err error) {
 
 func (nvmf *initiatorNVMf) Connect() (string, error) {
 	klog.Info("connections", nvmf.connections)
-	ctrlLossTmo := 60
-	if len(nvmf.connections) == 1 {
-		ctrlLossTmo *= 15
-	}
 
 	alreadyConnected, err := isNqnConnected(nvmf.nqn)
 	if err != nil {
@@ -406,13 +402,18 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			return "", err
 		}
 
+		ctrlLossTmo := 60
+		if len(connections) == 1 {
+			ctrlLossTmo *= 15
+		}
+
 		connected := 0
 		var lastErr error
 
-		for i, _ := range nvmf.connections {
+		for _, conn := range connections {
 			cmdLine := []string{
 				"nvme", "connect", "-t", strings.ToLower(nvmf.targetType),
-				"-a", connections[i].IP, "-s", strconv.Itoa(connections[i].Port), "-n", nvmf.nqn, "-l", strconv.Itoa(ctrlLossTmo),
+				"-a", conn.IP, "-s", strconv.Itoa(conn.Port), "-n", nvmf.nqn, "-l", strconv.Itoa(ctrlLossTmo),
 				"-c", nvmf.reconnectDelay, "-i", nvmf.nrIoQueues,
 			}
 
@@ -424,7 +425,7 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			// 	cmdLine = append(cmdLine, "--hostnqn="+nvmf.hostNQN)
 			// }
 
-			err := execWithTimeoutRetry(cmdLine, 40, len(nvmf.connections))
+			err := execWithTimeoutRetry(cmdLine, 40, len(connections))
 			if err != nil {
 				// go on checking device status in case caused by duplicated request
 				klog.Errorf("command %v failed: %s", cmdLine, err)


### PR DESCRIPTION
fixes: https://github.com/simplyblock/simplyblock-operator/issues/158
fixes: https://github.com/simplyblock/simplyblock-operator/issues/171

* updated logic in in `Connect()` function to use the already existing `connectViaNVMe` function. 
* since we get connections directly via `fetchLvolConnection` function, we no longer will require the field nvmf.connection.
* To preserve the same behaviour as we had previously, updated `connectViaNVMe` to support an additional parameter to pass in retries. 
* get the `ctrlLossTmo` from backend





