### PR TITLE
CVE fixes: remove python packages from base image

### DIFF
--- a/deploy/image/Dockerfile_base
+++ b/deploy/image/Dockerfile_base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi:10.1
+FROM registry.access.redhat.com/ubi10/ubi:10.2
 LABEL name="simplyblock"
 LABEL vendor="Simplyblock"
 LABEL version="1.0.0"
@@ -18,8 +18,9 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     fi
 
 RUN dnf update -y  --nogpgcheck
-RUN dnf install -y nvme-cli iscsi-initiator-utils e2fsprogs xfsprogs util-linux kmod wget sudo rpm --nogpgcheck
-
+RUN dnf install -y nvme-cli iscsi-initiator-utils e2fsprogs xfsprogs util-linux kmod wget sudo rpm --nogpgcheck && \
+    dnf remove -y python3-urllib3 python3-requests python3-idna --nogpgcheck && \
+    dnf clean all
 RUN useradd -ms /bin/bash simplyblock
 RUN echo "simplyblock  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER simplyblock


### PR DESCRIPTION
To fix the failing CVEs 

Adding this line to remove those packages which are practically not needed
```
dnf remove -y python3-urllib3 python3-requests python3-idna --nogpgcheck
```

https://github.com/simplyblock/simplyblock-csi/actions/runs/26286012259/job/77373716675