### PR TITLE
migrate volume publish/unpublish to v2 API

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -589,9 +589,9 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 }
 
 func (cs *controllerServer) getExistingVolume(name, poolName string, sbclient *util.NodeNVMf, vol *csi.Volume) (*csi.Volume, error) {
-	volumeID, err := sbclient.GetVolume(name, poolName)
+	volume, err := sbclient.GetVolume(name, poolName)
 	if err == nil {
-		vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volumeID)
+		vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volume.UUID)
 		klog.V(5).Info("volume already exists", vol.GetVolumeId())
 		return vol, nil
 	}

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -126,11 +126,12 @@ type connectionInfo struct {
 	Port int    `json:"port"`
 }
 
-// BDev SPDK block device — field tags match v2 VolumeDTO
-type BDev struct {
+// LvolResp is the v2 VolumeDTO returned by the SimplyBlock API
+type LvolResp struct {
 	Name     string `json:"name"`
 	UUID     string `json:"id"`
 	LvolSize int64  `json:"size"`
+	Status   string `json:"status"`
 }
 
 // RPCClient holds the connection information to the SimplyBlock Cluster
@@ -267,7 +268,7 @@ func (client *RPCClient) createVolume(params *CreateLVolData) (string, error) {
 }
 
 // getVolumeByUUID fetches a single volume by its UUID
-func (client *RPCClient) getVolumeByUUID(lvolID string) (*BDev, error) {
+func (client *RPCClient) getVolumeByUUID(lvolID string) (*LvolResp, error) {
 	out, err := client.CallSBCLI("GET", client.v2volume(lvolID), nil)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSuchDevice) {
@@ -279,7 +280,7 @@ func (client *RPCClient) getVolumeByUUID(lvolID string) (*BDev, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal volume response: %w", err)
 	}
-	var result BDev
+	var result LvolResp
 	if err := json.Unmarshal(b, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal volume response: %w", err)
 	}
@@ -287,7 +288,7 @@ func (client *RPCClient) getVolumeByUUID(lvolID string) (*BDev, error) {
 }
 
 // getVolumeByName lists all volumes in the pool and returns the one with matching name
-func (client *RPCClient) getVolumeByName(name string) (*BDev, error) {
+func (client *RPCClient) getVolumeByName(name string) (*LvolResp, error) {
 	volumes, err := client.listVolumes()
 	if err != nil {
 		return nil, err
@@ -301,7 +302,7 @@ func (client *RPCClient) getVolumeByName(name string) (*BDev, error) {
 }
 
 // getVolume accepts either a UUID or a "poolName/volName" path (legacy callers)
-func (client *RPCClient) getVolume(lvolIDOrPath string) (*BDev, error) {
+func (client *RPCClient) getVolume(lvolIDOrPath string) (*LvolResp, error) {
 	if strings.Contains(lvolIDOrPath, "/") {
 		// "poolName/volName" — extract the volume name and search by name
 		parts := strings.SplitN(lvolIDOrPath, "/", 2)
@@ -311,7 +312,7 @@ func (client *RPCClient) getVolume(lvolIDOrPath string) (*BDev, error) {
 }
 
 // listVolumes returns all volumes in the pool
-func (client *RPCClient) listVolumes() ([]*BDev, error) {
+func (client *RPCClient) listVolumes() ([]*LvolResp, error) {
 	out, err := client.CallSBCLI("GET", client.v2volumes()+"/", nil)
 	if err != nil {
 		return nil, err
@@ -320,7 +321,7 @@ func (client *RPCClient) listVolumes() ([]*BDev, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal volumes response: %w", err)
 	}
-	var results []*BDev
+	var results []*LvolResp
 	if err := json.Unmarshal(b, &results); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal volumes response: %w", err)
 	}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -294,7 +294,7 @@ func (node *NodeNVMf) DeleteSnapshot(snapshotID string) error {
 
 // PublishVolume exports a volume through NVMf target
 func (node *NodeNVMf) PublishVolume(lvolID string) error {
-	_, err := node.Client.CallSBCLI("GET", "/lvol/"+lvolID, nil)
+	_, err := node.Client.CallSBCLI("GET", node.Client.v2volume(lvolID), nil)
 	if err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func (node *NodeNVMf) PublishVolume(lvolID string) error {
 
 // UnpublishVolume unexports a volume through NVMf target
 func (node *NodeNVMf) UnpublishVolume(lvolID string) error {
-	_, err := node.Client.CallSBCLI("GET", "/lvol/"+lvolID, nil)
+	_, err := node.Client.CallSBCLI("GET", node.Client.v2volume(lvolID), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -192,13 +192,9 @@ func (node *NodeNVMf) CreateVolume(params *CreateLVolData) (string, error) {
 	return lvolID, nil
 }
 
-// GetVolume returns the volume id of the given volume name and lvstore name. return error if not found.
-func (node *NodeNVMf) GetVolume(lvolName, poolName string) (string, error) {
-	lvol, err := node.Client.getVolume(fmt.Sprintf("%s/%s", poolName, lvolName))
-	if err != nil {
-		return "", err
-	}
-	return lvol.UUID, err
+// GetVolume returns the LvolResp for the given volume name and pool name. Returns error if not found.
+func (node *NodeNVMf) GetVolume(lvolName, poolName string) (*LvolResp, error) {
+	return node.Client.getVolume(fmt.Sprintf("%s/%s", poolName, lvolName))
 }
 
 // GetVolumeSize returns the size of the volume
@@ -213,7 +209,7 @@ func (node *NodeNVMf) GetVolumeSize(lvolID string) (string, error) {
 }
 
 // ListVolumes returns a list of volumes
-func (node *NodeNVMf) ListVolumes() ([]*BDev, error) {
+func (node *NodeNVMf) ListVolumes() ([]*LvolResp, error) {
 	return node.Client.listVolumes()
 }
 


### PR DESCRIPTION
This PR has 2 fixes:

* 503fd5d849e910e9900cc9cfbf2573356e62d367 --> uses v2 API as part of Publish/Unpublish API this was missed from API response. 

* 7cf63d010ae235a2b52e3b090a5fdd4b585bfddd --> add status field to LvolResp structure so that CSI driver can take decisions based on that. 


