### PR TITLE
fix(initiator): iterate fresh API slice in NVMe connect loop

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -405,11 +405,18 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			klog.Errorf("Failed to get lvol connection: %v", err)
 			return "", err
 		}
+		if len(connections) == 0 {
+			return "", fmt.Errorf("no NVMe paths returned by API for NQN %s", nvmf.nqn)
+		}
+		if len(connections) != len(nvmf.connections) {
+			klog.Warningf("NVMe path count mismatch for NQN %s: VolumeContext has %d path(s), API returned %d path(s); using live API result",
+				nvmf.nqn, len(nvmf.connections), len(connections))
+		}
 
 		connected := 0
 		var lastErr error
 
-		for i, _ := range nvmf.connections {
+		for i := range connections {
 			cmdLine := []string{
 				"nvme", "connect", "-t", strings.ToLower(nvmf.targetType),
 				"-a", connections[i].IP, "-s", strconv.Itoa(connections[i].Port), "-n", nvmf.nqn, "-l", strconv.Itoa(ctrlLossTmo),
@@ -424,7 +431,7 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			// 	cmdLine = append(cmdLine, "--hostnqn="+nvmf.hostNQN)
 			// }
 
-			err := execWithTimeoutRetry(cmdLine, 40, len(nvmf.connections))
+			err := execWithTimeoutRetry(cmdLine, 40, len(connections))
 			if err != nil {
 				// go on checking device status in case caused by duplicated request
 				klog.Errorf("command %v failed: %s", cmdLine, err)


### PR DESCRIPTION
## Summary

- **Root cause**: `initiatorNVMf.Connect()` ranged over `nvmf.connections` (stale VolumeContext slice) while indexing into the freshly fetched `connections` slice from the API. When the live path count was smaller than the stale count (e.g. after a replica node was decommissioned), `connections[i]` panicked with *index out of range*, crashing the CSI node daemon and leaving all volumes on that node unmountable until the pod restarted.
- **Fix**: range over `connections` (the authoritative live API result) instead of `nvmf.connections`.
- **Also fixed**: retry count in `execWithTimeoutRetry` now uses `len(connections)` rather than `len(nvmf.connections)`.
- **Added**: empty-slice guard returning a typed error, and a `Warning` log when stale vs. live path counts differ to aid operator diagnosis.

Fixes simplyblock/simplyblock-operator#158

## Test plan

- [ ] Create a volume with 3 NVMe paths; verify PV VolumeContext has 3 entries.
- [ ] Decommission one storage node so the API returns 2 paths for that volume.
- [ ] Delete the consuming pod and reschedule to a clean node; confirm `NodeStageVolume` succeeds without panic.
- [ ] Verify the warning log line appears when counts differ.
- [ ] Verify an error is returned (not a panic) when the API returns 0 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)