### PR TITLE
fix(server): add gRPC keepalive and connection timeout to CSI server

### DIFF
--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -87,7 +87,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle:     5 * time.Minute,
 			MaxConnectionAge:      30 * time.Minute,
-			MaxConnectionAgeGrace: 5 * time.Second,
+			MaxConnectionAgeGrace: 2 * time.Minute,
 			Time:                  30 * time.Second,
 			Timeout:               10 * time.Second,
 		}),

--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -20,9 +20,11 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/klog"
 )
 
@@ -82,6 +84,18 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(logGRPC, timeoutInterceptor),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle:     5 * time.Minute,
+			MaxConnectionAge:      30 * time.Minute,
+			MaxConnectionAgeGrace: 5 * time.Second,
+			Time:                  30 * time.Second,
+			Timeout:               10 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
+		grpc.ConnectionTimeout(30 * time.Second),
 	}
 	server := grpc.NewServer(opts...)
 	s.server = server


### PR DESCRIPTION
## Summary

- **Gap 1 — No `ConnectionTimeout`**: added `grpc.ConnectionTimeout(30s)` to cap the initial TCP→HTTP/2 handshake.
- **Gap 2 — No keepalive enforcement**: added `grpc.KeepaliveParams` (30s ping interval, 10s ping timeout, 5m idle recycle, 30m max age) and `grpc.KeepaliveEnforcementPolicy` (MinTime 10s, PermitWithoutStream). Dead peers are now detected within ~40s instead of hours.

Without these, a kubelet OOM-kill or network partition left file descriptors and handler goroutines open indefinitely. In-flight sbcli HTTP calls would run to completion and produce orphaned volume state; the restarted kubelet would then re-issue the same RPCs against inconsistent sbcli state.

Note: Gap 3 (no per-RPC deadline / context not propagated to HTTP calls) is addressed in a follow-up PR.

Fixes simplyblock/simplyblock-operator#159

## Test plan

- [ ] Simulate kubelet OOM-kill mid-`NodeStageVolume`; confirm gRPC connection is closed within ~40s (check `ss -tp` on the node).
- [ ] Verify no regression: normal `NodeStageVolume` / `NodeUnstageVolume` round-trips complete successfully.
- [ ] Confirm `MaxConnectionIdle` recycles truly idle connections after 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)