### PR TITLE
fix(server): per-RPC timeout interceptor and full ctx propagation to HTTP

### DIFF
--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -81,7 +81,7 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	}
 
 	opts := []grpc.ServerOption{
-		grpc.UnaryInterceptor(logGRPC),
+		grpc.ChainUnaryInterceptor(logGRPC, timeoutInterceptor),
 	}
 	server := grpc.NewServer(opts...)
 	s.server = server

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -20,12 +20,21 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc"
 	"k8s.io/klog"
 )
+
+const rpcTimeout = 120 * time.Second
+
+func timeoutInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	defer cancel()
+	return handler(ctx, req)
+}
 
 func parseEndpoint(ep string) (proto, addr string, _ error) {
 	if strings.HasPrefix(strings.ToLower(ep), "unix://") || strings.HasPrefix(strings.ToLower(ep), "tcp://") {

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -31,6 +31,9 @@ import (
 const rpcTimeout = 120 * time.Second
 
 func timeoutInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= rpcTimeout {
+		return handler(ctx, req)
+	}
 	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 	return handler(ctx, req)

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -587,7 +587,6 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 	return &createVolReq, nil
 }
 
-
 func (cs *controllerServer) getExistingVolume(ctx context.Context, name, poolName string, sbclient *util.NodeNVMf, vol *csi.Volume) (*csi.Volume, error) {
 	volume, err := sbclient.GetVolume(ctx, name, poolName)
 	if err == nil {

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -297,7 +297,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	poolName := req.GetParameters()["pool_name"]
-	sbClient, err := util.NewsimplyBlockClient(selection.clusterID, poolName)
+	sbClient, err := util.NewsimplyBlockClient(ctx, selection.clusterID, poolName)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +411,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		klog.Errorf("failed to get spdk volume, volumeID: %s err: %v", volumeID, err)
 		return nil, err
 	}
-	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -456,7 +456,7 @@ func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 		klog.Errorf("failed to get spdk snapshot, snapshotID: %s err: %v", csiSnapshotID, err)
 		return nil, err
 	}
-	sbclient, err := util.NewsimplyBlockClient(sbSnapshot.clusterID, sbSnapshot.poolID)
+	sbclient, err := util.NewsimplyBlockClient(ctx, sbSnapshot.clusterID, sbSnapshot.poolID)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -709,7 +709,7 @@ func (cs *controllerServer) deleteVolume(ctx context.Context, volumeID string) e
 	if err != nil {
 		return err
 	}
-	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 	if err != nil {
 		return err
 	}
@@ -721,7 +721,7 @@ func (cs *controllerServer) unpublishVolume(ctx context.Context, volumeID string
 	if err != nil {
 		return err
 	}
-	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 	if err != nil {
 		return err
 	}
@@ -740,7 +740,7 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		return nil, err
 	}
 
-	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 	if err != nil {
 		return nil, err
 	}
@@ -766,7 +766,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, _ *csi.ListSnapsh
 	}
 
 	for _, clusterID := range clusters {
-		sbclient, err := util.NewsimplyBlockClient(clusterID, "")
+		sbclient, err := util.NewsimplyBlockClient(ctx, clusterID, "")
 		if err != nil {
 			klog.Errorf("failed to create spdk client: %v", err)
 			return nil, status.Error(codes.Internal, err.Error())
@@ -852,7 +852,7 @@ func (cs *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 		return nil, err
 	}
 
-	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -922,7 +922,7 @@ func (cs *controllerServer) handleSnapshotSource(ctx context.Context, snapshot *
 		return nil, err
 	}
 	// Use destination pool (from StorageClass params), not source snapshot pool.
-	sbclient, err := util.NewsimplyBlockClient(sbSnapshot.clusterID, poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, sbSnapshot.clusterID, poolName)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -963,7 +963,7 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 		return nil, err
 	}
 	// Volume clone goes to the same pool as the source volume.
-	sbclient, err := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -308,7 +308,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	volumeInfo, err := cs.publishVolume(csiVolume.GetVolumeId(), sbClient)
+	volumeInfo, err := cs.publishVolume(ctx, csiVolume.GetVolumeId(), sbClient)
 	if err != nil {
 		klog.Errorf("failed to publish volume, volumeID: %s err: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -346,12 +346,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	return &csi.CreateVolumeResponse{Volume: csiVolume}, nil
 }
 
-func (cs *controllerServer) DeleteVolume(_ context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	unlock := cs.volumeLocks.Lock(volumeID)
 	defer unlock()
 	// no harm if volume already unpublished
-	err := cs.unpublishVolume(volumeID)
+	err := cs.unpublishVolume(ctx, volumeID)
 	switch {
 	case errors.Is(err, util.ErrVolumeUnpublished):
 		// unpublished but not deleted in last request?
@@ -365,7 +365,7 @@ func (cs *controllerServer) DeleteVolume(_ context.Context, req *csi.DeleteVolum
 	}
 
 	// no harm if volume already deleted
-	err = cs.deleteVolume(volumeID)
+	err = cs.deleteVolume(ctx, volumeID)
 	if errors.Is(err, util.ErrJSONNoSuchDevice) {
 		// deleted in previous request?
 		klog.Warningf("volume not exists: %s", volumeID)
@@ -377,7 +377,7 @@ func (cs *controllerServer) DeleteVolume(_ context.Context, req *csi.DeleteVolum
 	return &csi.DeleteVolumeResponse{}, nil
 }
 
-func (cs *controllerServer) ValidateVolumeCapabilities(_ context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	// make sure we support all requested caps
 	for _, cap := range req.GetVolumeCapabilities() {
 		supported := false
@@ -398,7 +398,7 @@ func (cs *controllerServer) ValidateVolumeCapabilities(_ context.Context, req *c
 	}, nil
 }
 
-func (cs *controllerServer) CreateSnapshot(_ context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	volumeID := req.GetSourceVolumeId()
 	klog.Infof("CreateSnapshot : volumeID=%s", volumeID)
 	unlock := cs.volumeLocks.Lock(volumeID)
@@ -417,14 +417,14 @@ func (cs *controllerServer) CreateSnapshot(_ context.Context, req *csi.CreateSna
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	snapshotID, err := sbclient.CreateSnapshot(spdkVol.lvolID, snapshotName)
+	snapshotID, err := sbclient.CreateSnapshot(ctx, spdkVol.lvolID, snapshotName)
 	klog.Infof("CreateSnapshot : snapshotID=%s", snapshotID)
 	if err != nil {
 		klog.Errorf("failed to create snapshot, volumeID: %s snapshotName: %s err: %v", volumeID, snapshotName, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	volSize, err := sbclient.GetVolumeSize(spdkVol.lvolID)
+	volSize, err := sbclient.GetVolumeSize(ctx, spdkVol.lvolID)
 	klog.Infof("CreateSnapshot : volSize=%s", volSize)
 	if err != nil {
 		klog.Errorf("failed to get volume info, volumeID: %s err: %v", volumeID, err)
@@ -449,7 +449,7 @@ func (cs *controllerServer) CreateSnapshot(_ context.Context, req *csi.CreateSna
 	}, nil
 }
 
-func (cs *controllerServer) DeleteSnapshot(_ context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	csiSnapshotID := req.GetSnapshotId()
 	sbSnapshot, err := getSnapshot(csiSnapshotID)
 	if err != nil {
@@ -467,7 +467,7 @@ func (cs *controllerServer) DeleteSnapshot(_ context.Context, req *csi.DeleteSna
 
 	klog.Infof("Deleting Snapshot : csiSnapshotID=%s sbSnapshotID=%s", csiSnapshotID, sbSnapshot.snapshotID)
 
-	err = sbclient.DeleteSnapshot(sbSnapshot.snapshotID)
+	err = sbclient.DeleteSnapshot(ctx, sbSnapshot.snapshotID)
 	if err != nil {
 		klog.Errorf("failed to delete snapshot, snapshotID: %s err: %v", csiSnapshotID, err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -587,8 +587,9 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 	return &createVolReq, nil
 }
 
-func (cs *controllerServer) getExistingVolume(name, poolName string, sbclient *util.NodeNVMf, vol *csi.Volume) (*csi.Volume, error) {
-	volume, err := sbclient.GetVolume(name, poolName)
+
+func (cs *controllerServer) getExistingVolume(ctx context.Context, name, poolName string, sbclient *util.NodeNVMf, vol *csi.Volume) (*csi.Volume, error) {
+	volume, err := sbclient.GetVolume(ctx, name, poolName)
 	if err == nil {
 		vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volume.UUID)
 		klog.V(5).Info("volume already exists", vol.GetVolumeId())
@@ -613,13 +614,13 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 
 	klog.V(5).Info("provisioning volume from SDK node..")
 	poolName := req.GetParameters()["pool_name"]
-	existingVolume, err := cs.getExistingVolume(req.GetName(), poolName, sbclient, &vol)
+	existingVolume, err := cs.getExistingVolume(ctx, req.GetName(), poolName, sbclient, &vol)
 	if err == nil {
 		return existingVolume, nil
 	}
 
 	if req.GetVolumeContentSource() != nil {
-		clonedVolume, clonedErr := cs.handleVolumeContentSource(req, poolName, &vol, capacityBytes)
+		clonedVolume, clonedErr := cs.handleVolumeContentSource(ctx, req, poolName, &vol, capacityBytes)
 		if clonedErr != nil {
 			return nil, clonedErr
 		}
@@ -640,7 +641,7 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 	vol.VolumeContext["qos_r_mbytes"] = createVolReq.MaxRmBytes
 	vol.VolumeContext["qos_w_mbytes"] = createVolReq.MaxWmBytes
 
-	volumeID, err := sbclient.CreateVolume(createVolReq)
+	volumeID, err := sbclient.CreateVolume(ctx, createVolReq)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
@@ -683,12 +684,12 @@ func getSnapshot(csiSnapshotID string) (*spdkSnapshot, error) {
 	}
 }
 
-func (cs *controllerServer) publishVolume(volumeID string, sbclient *util.NodeNVMf) (map[string]string, error) {
+func (cs *controllerServer) publishVolume(ctx context.Context, volumeID string, sbclient *util.NodeNVMf) (map[string]string, error) {
 	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
 		return nil, err
 	}
-	err = sbclient.PublishVolume(spdkVol.lvolID)
+	err = sbclient.PublishVolume(ctx, spdkVol.lvolID)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +697,7 @@ func (cs *controllerServer) publishVolume(volumeID string, sbclient *util.NodeNV
 	// hostNQN is not available in the controller path; pass empty string.
 	// If the volume has allowed_hosts configured, this call will fail and the
 	// node will re-fetch connection info at NodeStageVolume time using its own NQN.
-	volumeInfo, err := sbclient.VolumeInfo(spdkVol.lvolID, "")
+	volumeInfo, err := sbclient.VolumeInfo(ctx, spdkVol.lvolID, "")
 	if err != nil {
 		klog.Warningf("failed to get volume info for %s (will be fetched at stage time): %v", spdkVol.lvolID, err)
 		return map[string]string{}, nil
@@ -704,7 +705,7 @@ func (cs *controllerServer) publishVolume(volumeID string, sbclient *util.NodeNV
 	return volumeInfo, nil
 }
 
-func (cs *controllerServer) deleteVolume(volumeID string) error {
+func (cs *controllerServer) deleteVolume(ctx context.Context, volumeID string) error {
 	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
 		return err
@@ -713,10 +714,10 @@ func (cs *controllerServer) deleteVolume(volumeID string) error {
 	if err != nil {
 		return err
 	}
-	return sbclient.DeleteVolume(spdkVol.lvolID)
+	return sbclient.DeleteVolume(ctx, spdkVol.lvolID)
 }
 
-func (cs *controllerServer) unpublishVolume(volumeID string) error {
+func (cs *controllerServer) unpublishVolume(ctx context.Context, volumeID string) error {
 	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
 		return err
@@ -725,10 +726,10 @@ func (cs *controllerServer) unpublishVolume(volumeID string) error {
 	if err != nil {
 		return err
 	}
-	return sbclient.UnpublishVolume(spdkVol.lvolID)
+	return sbclient.UnpublishVolume(ctx, spdkVol.lvolID)
 }
 
-func (cs *controllerServer) ControllerExpandVolume(_ context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	updatedSize := req.GetCapacityRange().GetRequiredBytes()
 
@@ -745,7 +746,7 @@ func (cs *controllerServer) ControllerExpandVolume(_ context.Context, req *csi.C
 		return nil, err
 	}
 
-	_, err = sbclient.ResizeVolume(spdkVol.lvolID, capacityBytes)
+	_, err = sbclient.ResizeVolume(ctx, spdkVol.lvolID, capacityBytes)
 	if err != nil {
 		klog.Errorf("failed to resize lvol, LVolID: %s err: %v", spdkVol.lvolID, err)
 		return nil, err
@@ -757,7 +758,7 @@ func (cs *controllerServer) ControllerExpandVolume(_ context.Context, req *csi.C
 }
 
 // ListSnapshots lists all snapshots across all clusters
-func (cs *controllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+func (cs *controllerServer) ListSnapshots(ctx context.Context, _ *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 
 	var entries []*util.SnapshotResp
 	clusters, err := ListClusters()
@@ -772,7 +773,7 @@ func (cs *controllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshot
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 
-		snapshotEntries, err := sbclient.ListSnapshots()
+		snapshotEntries, err := sbclient.ListSnapshots(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -842,7 +843,7 @@ func ListClusters() (clusterIds []string, err error) {
 //		return nil, status.Error(codes.Unimplemented, "")
 //	}
 
-func (cs *controllerServer) ControllerGetVolume(_ context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+func (cs *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	unlock := cs.volumeLocks.Lock(volumeID)
 	defer unlock()
@@ -858,7 +859,7 @@ func (cs *controllerServer) ControllerGetVolume(_ context.Context, req *csi.Cont
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	volumeInfo, err := sbclient.VolumeInfo(spdkVol.lvolID, "")
+	volumeInfo, err := sbclient.VolumeInfo(ctx, spdkVol.lvolID, "")
 	if err != nil {
 		klog.Errorf("failed to get spdkVol for %s: %v", volumeID, err)
 
@@ -899,19 +900,19 @@ func newControllerServer(d *csicommon.CSIDriver) (*controllerServer, error) {
 	return &server, nil
 }
 
-func (cs *controllerServer) handleVolumeContentSource(req *csi.CreateVolumeRequest, poolName string, vol *csi.Volume, sizeBytes int64) (*csi.Volume, error) {
+func (cs *controllerServer) handleVolumeContentSource(ctx context.Context, req *csi.CreateVolumeRequest, poolName string, vol *csi.Volume, sizeBytes int64) (*csi.Volume, error) {
 	volumeSource := req.GetVolumeContentSource()
 	switch volumeSource.GetType().(type) {
 	case *csi.VolumeContentSource_Snapshot:
-		return cs.handleSnapshotSource(volumeSource.GetSnapshot(), req, poolName, vol, sizeBytes)
+		return cs.handleSnapshotSource(ctx, volumeSource.GetSnapshot(), req, poolName, vol, sizeBytes)
 	case *csi.VolumeContentSource_Volume:
-		return cs.handleVolumeSource(volumeSource.GetVolume(), req, poolName, vol, sizeBytes)
+		return cs.handleVolumeSource(ctx, volumeSource.GetVolume(), req, poolName, vol, sizeBytes)
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "%v not a proper volume source", volumeSource)
 	}
 }
 
-func (cs *controllerServer) handleSnapshotSource(snapshot *csi.VolumeContentSource_SnapshotSource, req *csi.CreateVolumeRequest, poolName string, vol *csi.Volume, sizeBytes int64) (*csi.Volume, error) {
+func (cs *controllerServer) handleSnapshotSource(ctx context.Context, snapshot *csi.VolumeContentSource_SnapshotSource, req *csi.CreateVolumeRequest, poolName string, vol *csi.Volume, sizeBytes int64) (*csi.Volume, error) {
 	if snapshot == nil {
 		return nil, nil
 	}
@@ -934,7 +935,7 @@ func (cs *controllerServer) handleSnapshotSource(snapshot *csi.VolumeContentSour
 	pvcName, _ := params[CSIStorageNameKey]
 	// Use raw bytes to avoid decimal/binary unit ambiguity in clone sizing.
 	newSize := strconv.FormatInt(sizeBytes, 10)
-	volumeID, err := sbclient.CloneSnapshot(sbSnapshot.snapshotID, snapshotName, newSize, pvcName)
+	volumeID, err := sbclient.CloneSnapshot(ctx, sbSnapshot.snapshotID, snapshotName, newSize, pvcName)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
@@ -945,7 +946,7 @@ func (cs *controllerServer) handleSnapshotSource(snapshot *csi.VolumeContentSour
 	return vol, nil
 }
 
-func (cs *controllerServer) handleVolumeSource(srcVolume *csi.VolumeContentSource_VolumeSource, req *csi.CreateVolumeRequest, poolName string, vol *csi.Volume, sizeBytes int64) (*csi.Volume, error) {
+func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *csi.VolumeContentSource_VolumeSource, req *csi.CreateVolumeRequest, poolName string, vol *csi.Volume, sizeBytes int64) (*csi.Volume, error) {
 	if srcVolume == nil {
 		return nil, nil
 	}
@@ -971,7 +972,7 @@ func (cs *controllerServer) handleVolumeSource(srcVolume *csi.VolumeContentSourc
 	// Use raw bytes to avoid decimal/binary unit ambiguity in clone sizing.
 	newSize := strconv.FormatInt(sizeBytes, 10)
 	klog.Infof("CloneVolume : cloneName=%s", cloneName)
-	volumeID, err := sbclient.CloneVolume(spdkVol.lvolID, cloneName, newSize, pvcName)
+	volumeID, err := sbclient.CloneVolume(ctx, spdkVol.lvolID, cloneName, newSize, pvcName)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -23,6 +23,7 @@ import (
 	osexec "os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"path/filepath"
 	"unsafe"
@@ -257,7 +258,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if vc["nqn"] == "" || vc["targetType"] == "" {
 		spdkVol, parseErr := getSPDKVol(volumeID)
 		if parseErr == nil {
-			sbcClient, clientErr := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
+			sbcClient, clientErr := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
 			if clientErr == nil {
 				connInfo, infoErr := sbcClient.VolumeInfo(ctx, spdkVol.lvolID, vc["hostNQN"])
 				if infoErr != nil {
@@ -329,7 +330,9 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		klog.Errorf("failed to create spdk initiator, volumeID: %s err: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	err = initiator.Disconnect(ctx) // idempotent
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+	defer cleanupCancel()
+	err = initiator.Disconnect(cleanupCtx) // idempotent
 	if err != nil {
 		klog.Errorf("failed to disconnect initiator, volumeID: %s err: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -218,7 +218,7 @@ func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	}, nil
 }
 
-func (ns *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
@@ -259,7 +259,7 @@ func (ns *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 		if parseErr == nil {
 			sbcClient, clientErr := util.NewsimplyBlockClient(spdkVol.clusterID, spdkVol.poolName)
 			if clientErr == nil {
-				connInfo, infoErr := sbcClient.VolumeInfo(spdkVol.lvolID, vc["hostNQN"])
+				connInfo, infoErr := sbcClient.VolumeInfo(ctx, spdkVol.lvolID, vc["hostNQN"])
 				if infoErr != nil {
 					klog.Errorf("failed to fetch volume connection info for %s: %v", volumeID, infoErr)
 				} else {
@@ -279,14 +279,14 @@ func (ns *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	devicePath, err := initiator.Connect() // idempotent
+	devicePath, err := initiator.Connect(ctx) // idempotent
 	if err != nil {
 		klog.Errorf("failed to connect initiator, volumeID: %s err: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer func() {
 		if err != nil {
-			initiator.Disconnect() //nolint:errcheck // ignore error
+			initiator.Disconnect(ctx) //nolint:errcheck // ignore error
 		}
 	}()
 	if err = ns.stageVolume(devicePath, stagingTargetPath, req, vc); err != nil { // idempotent
@@ -305,7 +305,7 @@ func (ns *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (ns *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
@@ -329,7 +329,7 @@ func (ns *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageV
 		klog.Errorf("failed to create spdk initiator, volumeID: %s err: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	err = initiator.Disconnect() // idempotent
+	err = initiator.Disconnect(ctx) // idempotent
 	if err != nil {
 		klog.Errorf("failed to disconnect initiator, volumeID: %s err: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -341,7 +341,7 @@ func (ns *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageV
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
-func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
@@ -359,7 +359,7 @@ func (ns *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (ns *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
@@ -412,7 +412,7 @@ func (ns *nodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapab
 	}, nil
 }
 
-func (ns *nodeServer) NodeExpandVolume(_ context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	klog.Infof("NodeExpandVolume: called with args %+v", *req)
 
 	volumeID := req.GetVolumeId()

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -490,7 +490,7 @@ func (g *Guardian) isClusterActiveByID(clusterID string) (ok bool, realStatus st
 	}
 
 	clusterPath := fmt.Sprintf("api/v2/clusters/%s/", clusterID)
-	resp, err := node.Client.CallSBCLI("GET", clusterPath, nil)
+	resp, err := node.Client.CallSBCLI(context.Background(), "GET", clusterPath, nil)
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -484,7 +484,7 @@ func (g *Guardian) tick(ctx context.Context) {
 }
 
 func (g *Guardian) isClusterActiveByID(clusterID string) (ok bool, realStatus string, err error) {
-	node, err := NewsimplyBlockClient(clusterID, "")
+	node, err := NewsimplyBlockClient(context.Background(), clusterID, "")
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -48,8 +48,8 @@ const (
 //   - Caller(node service) should serialize calls to same initiator
 //   - Implementation should be idempotent to duplicated requests
 type SpdkCsiInitiator interface {
-	Connect() (string, error)
-	Disconnect() error
+	Connect(ctx context.Context) (string, error)
+	Disconnect(ctx context.Context) error
 }
 
 // initiatorNVMf is an implementation of NVMf tcp initiator
@@ -171,7 +171,7 @@ func resolvePoolUUID(node *NodeNVMf, poolIDOrName string) (string, error) {
 	if isUUID(poolIDOrName) {
 		return poolIDOrName, nil
 	}
-	return node.GetPoolUUIDByName(poolIDOrName)
+	return node.GetPoolUUIDByName(context.Background(), poolIDOrName)
 }
 
 // isUUID reports whether s is a standard UUID (8-4-4-4-12 hex, with hyphens).
@@ -228,7 +228,7 @@ func execWithTimeoutRetry(cmdLine []string, timeout, retry int) (err error) {
 	return err
 }
 
-func (nvmf *initiatorNVMf) Connect() (string, error) {
+func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 	alreadyConnected, err := isNqnConnected(nvmf.nqn)
 	if err != nil {
 		klog.Errorf("Failed to check existing connections: %v", err)
@@ -242,7 +242,7 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 			klog.Errorf("failed to create SPDK client: %v", err)
 			return "", err
 		}
-		connections, err := fetchLvolConnection(sbcClient, lvolID, nvmf.hostNQN)
+		connections, err := fetchLvolConnection(ctx, sbcClient, lvolID, nvmf.hostNQN)
 		if err != nil {
 			klog.Errorf("Failed to get lvol connection: %v", err)
 			return "", err
@@ -287,7 +287,7 @@ func (nvmf *initiatorNVMf) Connect() (string, error) {
 	return devicePath, nil
 }
 
-func (nvmf *initiatorNVMf) Disconnect() error {
+func (nvmf *initiatorNVMf) Disconnect(_ context.Context) error {
 	//deviceGlob := fmt.Sprintf(DevDiskByID, nvmf.model)
 	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", nvmf.model))
 	devicePath, err := filepath.Glob(deviceGlob)
@@ -609,11 +609,11 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 	return nil
 }
 
-func fetchNodeInfo(spdkNode *NodeNVMf, lvolID string) (*NodeInfo, error) {
-	if err := spdkNode.Client.findPoolForVolume(lvolID); err != nil {
+func fetchNodeInfo(ctx context.Context, spdkNode *NodeNVMf, lvolID string) (*NodeInfo, error) {
+	if err := spdkNode.Client.findPoolForVolume(ctx, lvolID); err != nil {
 		return nil, fmt.Errorf("failed to resolve pool for volume %s: %v", lvolID, err)
 	}
-	resp, err := spdkNode.Client.CallSBCLI("GET", spdkNode.Client.v2volume(lvolID), nil)
+	resp, err := spdkNode.Client.CallSBCLI(ctx, "GET", spdkNode.Client.v2volume(lvolID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch node info: %v", err)
 	}
@@ -629,8 +629,8 @@ func fetchNodeInfo(spdkNode *NodeNVMf, lvolID string) (*NodeInfo, error) {
 	return &info, nil
 }
 
-func isNodeOnline(spdkNode *NodeNVMf, nodeID string) bool {
-	status, err := spdkNode.Client.getStorageNodeStatus(nodeID)
+func isNodeOnline(ctx context.Context, spdkNode *NodeNVMf, nodeID string) bool {
+	status, err := spdkNode.Client.getStorageNodeStatus(ctx, nodeID)
 	if err != nil {
 		klog.Errorf("failed to fetch node status for node %s: %v", nodeID, err)
 		return false
@@ -638,11 +638,11 @@ func isNodeOnline(spdkNode *NodeNVMf, nodeID string) bool {
 	return status == "online"
 }
 
-func fetchLvolConnection(spdkNode *NodeNVMf, lvolID string, hostNQN string) ([]*LvolConnectResp, error) {
-	if err := spdkNode.Client.findPoolForVolume(lvolID); err != nil {
+func fetchLvolConnection(ctx context.Context, spdkNode *NodeNVMf, lvolID string, hostNQN string) ([]*LvolConnectResp, error) {
+	if err := spdkNode.Client.findPoolForVolume(ctx, lvolID); err != nil {
 		return nil, fmt.Errorf("failed to resolve pool for volume %s: %v", lvolID, err)
 	}
-	connections, err := spdkNode.Client.getLvolConnections(lvolID, hostNQN)
+	connections, err := spdkNode.Client.getLvolConnections(ctx, lvolID, hostNQN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch connection: %v", err)
 	}
@@ -768,7 +768,7 @@ func resolveExpectedPathCount(nqn, clusterID, lvolID string, currentActive int) 
 		klog.Warningf("resolveExpectedPathCount: client error for NQN %s: %v", nqn, err)
 		return cached
 	}
-	conns, err := fetchLvolConnection(sbcClient, lvolID, "")
+	conns, err := fetchLvolConnection(context.Background(), sbcClient, lvolID, "")
 	if err != nil {
 		klog.Warningf("resolveExpectedPathCount: fetch error for NQN %s: %v", nqn, err)
 		return cached
@@ -790,12 +790,12 @@ func recoverPathsWithANA(clusterID, lvolID, devicePath string, activePaths []pat
 		return fmt.Errorf("failed to create SimplyBlock client: %w", err)
 	}
 
-	nodeInfo, err := fetchNodeInfo(sbcClient, lvolID)
+	nodeInfo, err := fetchNodeInfo(context.Background(), sbcClient, lvolID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch node info for lvol %s: %w", lvolID, err)
 	}
 
-	expectedConns, err := fetchLvolConnection(sbcClient, lvolID, "")
+	expectedConns, err := fetchLvolConnection(context.Background(), sbcClient, lvolID, "")
 	if err != nil {
 		return fmt.Errorf("failed to fetch connections for lvol %s: %w", lvolID, err)
 	}
@@ -839,7 +839,7 @@ func reconcileOptimizedPath(
 	ctrlLossTmo int,
 ) {
 	if len(active) == 0 {
-		if !isNodeOnline(sbcClient, nodeInfo.NodeID) {
+		if !isNodeOnline(context.Background(), sbcClient, nodeInfo.NodeID) {
 			klog.Infof("reconcileOptimizedPath: primary node %s not yet online, skipping", nodeInfo.NodeID)
 			return
 		}
@@ -855,7 +855,7 @@ func reconcileOptimizedPath(
 		return
 	}
 
-	if !isNodeOnline(sbcClient, nodeInfo.NodeID) {
+	if !isNodeOnline(context.Background(), sbcClient, nodeInfo.NodeID) {
 		klog.Infof("reconcileOptimizedPath: primary node %s not yet online, skipping IP change reconnect", nodeInfo.NodeID)
 		return
 	}
@@ -914,7 +914,7 @@ func reconcileNonOptimizedPaths(
 			continue // skip primary
 		}
 		totalSecondaries++
-		if isNodeOnline(sbcClient, nodeID) {
+		if isNodeOnline(context.Background(), sbcClient, nodeID) {
 			onlineSecondaries++
 		}
 	}

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -120,7 +120,7 @@ type ClustersInfo struct {
 // NewsimplyBlockClient creates a new Simplyblock client scoped to a cluster and optionally a pool.
 // poolIDOrName may be a pool UUID (used as-is) or a pool name (resolved via API), or empty
 // (no pool context — only cluster-level operations will work).
-func NewsimplyBlockClient(clusterID, poolIDOrName string) (*NodeNVMf, error) {
+func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (*NodeNVMf, error) {
 	secretFile := FromEnv("SPDKCSI_SECRET", "/etc/spdkcsi-secret/secret.json")
 	var clusters ClustersInfo
 	err := ParseJSONFile(secretFile, &clusters)
@@ -155,7 +155,7 @@ func NewsimplyBlockClient(clusterID, poolIDOrName string) (*NodeNVMf, error) {
 	}
 
 	if poolIDOrName != "" {
-		poolUUID, err := resolvePoolUUID(node, poolIDOrName)
+		poolUUID, err := resolvePoolUUID(ctx, node, poolIDOrName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve pool %q: %w", poolIDOrName, err)
 		}
@@ -167,11 +167,11 @@ func NewsimplyBlockClient(clusterID, poolIDOrName string) (*NodeNVMf, error) {
 
 // resolvePoolUUID returns poolIDOrName as-is if it is already a UUID,
 // otherwise looks up the pool UUID by name via the API.
-func resolvePoolUUID(node *NodeNVMf, poolIDOrName string) (string, error) {
+func resolvePoolUUID(ctx context.Context, node *NodeNVMf, poolIDOrName string) (string, error) {
 	if isUUID(poolIDOrName) {
 		return poolIDOrName, nil
 	}
-	return node.GetPoolUUIDByName(context.Background(), poolIDOrName)
+	return node.GetPoolUUIDByName(ctx, poolIDOrName)
 }
 
 // isUUID reports whether s is a standard UUID (8-4-4-4-12 hex, with hyphens).
@@ -237,7 +237,7 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 
 	if !alreadyConnected {
 		clusterID, lvolID := getLvolIDFromNQN(nvmf.nqn)
-		sbcClient, err := NewsimplyBlockClient(clusterID, "")
+		sbcClient, err := NewsimplyBlockClient(ctx, clusterID, "")
 		if err != nil {
 			klog.Errorf("failed to create SPDK client: %v", err)
 			return "", err
@@ -763,7 +763,7 @@ func resolveExpectedPathCount(nqn, clusterID, lvolID string, currentActive int) 
 		return cached
 	}
 
-	sbcClient, err := NewsimplyBlockClient(clusterID, "")
+	sbcClient, err := NewsimplyBlockClient(context.Background(), clusterID, "")
 	if err != nil {
 		klog.Warningf("resolveExpectedPathCount: client error for NQN %s: %v", nqn, err)
 		return cached
@@ -785,7 +785,7 @@ func resolveExpectedPathCount(nqn, clusterID, lvolID string, currentActive int) 
 }
 
 func recoverPathsWithANA(clusterID, lvolID, devicePath string, activePaths []path) error {
-	sbcClient, err := NewsimplyBlockClient(clusterID, "")
+	sbcClient, err := NewsimplyBlockClient(context.Background(), clusterID, "")
 	if err != nil {
 		return fmt.Errorf("failed to create SimplyBlock client: %w", err)
 	}

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -217,9 +217,9 @@ func NewSpdkCsiInitiator(volumeContext map[string]string) (SpdkCsiInitiator, err
 	}
 }
 
-func execWithTimeoutRetry(cmdLine []string, timeout, retry int) (err error) {
+func execWithTimeoutRetry(ctx context.Context, cmdLine []string, timeout, retry int) (err error) {
 	for retry > 0 {
-		err = execWithTimeout(cmdLine, timeout)
+		err = execWithTimeout(ctx, cmdLine, timeout)
 		if err == nil {
 			return nil
 		}
@@ -254,7 +254,7 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 		var lastErr error
 
 		for _, conn := range connections {
-			err := connectViaNVMe(conn, ctrlLossTmo, len(connections))
+			err := connectViaNVMe(ctx, conn, ctrlLossTmo, len(connections))
 			if err != nil {
 				klog.Errorf("nvme connect failed for %s:%d: %v", conn.IP, conn.Port, err)
 				lastErr = err
@@ -287,7 +287,7 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 	return devicePath, nil
 }
 
-func (nvmf *initiatorNVMf) Disconnect(_ context.Context) error {
+func (nvmf *initiatorNVMf) Disconnect(ctx context.Context) error {
 	//deviceGlob := fmt.Sprintf(DevDiskByID, nvmf.model)
 	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", nvmf.model))
 	devicePath, err := filepath.Glob(deviceGlob)
@@ -299,7 +299,7 @@ func (nvmf *initiatorNVMf) Disconnect(_ context.Context) error {
 		return nil
 
 	} else if len(devicePath) == 1 {
-		err = disconnectDevicePath(devicePath[0])
+		err = disconnectDevicePath(ctx, devicePath[0])
 
 		if err != nil {
 			return err
@@ -342,16 +342,16 @@ func waitForDeviceGone(deviceGlob string) error {
 }
 
 // exec shell command with timeout(in seconds)
-func execWithTimeout(cmdLine []string, timeout int) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+func execWithTimeout(ctx context.Context, cmdLine []string, timeout int) error {
+	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
 	klog.Infof("running command: %v", cmdLine)
 	//nolint:gosec // execWithTimeout assumes valid cmd arguments
-	cmd := exec.CommandContext(ctx, cmdLine[0], cmdLine[1:]...)
+	cmd := exec.CommandContext(execCtx, cmdLine[0], cmdLine[1:]...)
 	output, err := cmd.CombinedOutput()
 
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
 		return errors.New("timed out")
 	}
 	if output != nil {
@@ -363,7 +363,7 @@ func execWithTimeout(cmdLine []string, timeout int) error {
 	return err
 }
 
-func disconnectDevicePath(devicePath string) error {
+func disconnectDevicePath(ctx context.Context, devicePath string) error {
 	var paths []path
 
 	realPath, err := filepath.EvalSymlinks(devicePath)
@@ -397,7 +397,7 @@ func disconnectDevicePath(devicePath string) error {
 	for _, p := range paths {
 		klog.Infof("Disconnecting device %s", p.Name)
 		disconnectCmd := []string{"nvme", "disconnect", "-d", p.Name}
-		err := execWithTimeoutRetry(disconnectCmd, 40, 1)
+		err := execWithTimeoutRetry(ctx, disconnectCmd, 40, 1)
 		if err != nil {
 			klog.Errorf("Failed to disconnect device %s: %v", p.Name, err)
 		}
@@ -652,7 +652,7 @@ func fetchLvolConnection(ctx context.Context, spdkNode *NodeNVMf, lvolID string,
 	return connections, nil
 }
 
-func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo, retries int) error {
+func connectViaNVMe(ctx context.Context, conn *LvolConnectResp, ctrlLossTmo int, retries int) error {
 	cmd := []string{
 		"nvme", "connect", "-t", strings.ToLower(conn.TargetType),
 		"-a", conn.IP, "-s", strconv.Itoa(conn.Port),
@@ -664,19 +664,19 @@ func connectViaNVMe(conn *LvolConnectResp, ctrlLossTmo, retries int) error {
 	if conn.HostIface != "" {
 		cmd = append(cmd, "-f", conn.HostIface)
 	}
-	if err := execWithTimeoutRetry(cmd, 40, retries); err != nil {
+	if err := execWithTimeoutRetry(ctx, cmd, 40, retries); err != nil {
 		klog.Errorf("nvme connect failed: %v", err)
 		return err
 	}
 	return nil
 }
 
-func disconnectViaNVMe(devicePath string, path path) error {
+func disconnectViaNVMe(ctx context.Context, devicePath string, path path) error {
 	cmd := []string{
 		"nvme", "disconnect", "-d", path.Name,
 	}
 
-	if err := execWithTimeoutRetry(cmd, 40, 1); err != nil {
+	if err := execWithTimeoutRetry(ctx, cmd, 40, 1); err != nil {
 		klog.Errorf("nvme disconnect failed: %v", err)
 		return err
 	}
@@ -844,7 +844,7 @@ func reconcileOptimizedPath(
 			return
 		}
 		klog.Infof("reconcileOptimizedPath: connecting missing optimized path ip=%s", conn.IP)
-		if err := connectViaNVMe(conn, ctrlLossTmo, 1); err != nil {
+		if err := connectViaNVMe(context.Background(), conn, ctrlLossTmo, 1); err != nil {
 			klog.Errorf("reconcileOptimizedPath: connect to %s failed: %v", conn.IP, err)
 		}
 		return
@@ -860,11 +860,11 @@ func reconcileOptimizedPath(
 		return
 	}
 	klog.Infof("reconcileOptimizedPath: IP changed old=%s new=%s, reconnecting", activeIP, conn.IP)
-	if err := disconnectViaNVMe(devicePath, active[0]); err != nil {
+	if err := disconnectViaNVMe(context.Background(), devicePath, active[0]); err != nil {
 		klog.Errorf("reconcileOptimizedPath: disconnect stale %s failed: %v", activeIP, err)
 		return
 	}
-	if err := connectViaNVMe(conn, ctrlLossTmo, 1); err != nil {
+	if err := connectViaNVMe(context.Background(), conn, ctrlLossTmo, 1); err != nil {
 		klog.Errorf("reconcileOptimizedPath: connect to new IP %s failed: %v", conn.IP, err)
 	}
 }
@@ -900,7 +900,7 @@ func reconcileNonOptimizedPaths(
 	for ip, p := range activeIPMap {
 		if !expectedIPSet[ip] {
 			klog.Infof("reconcileNonOptimizedPaths: stale IP %s disconnecting", ip)
-			if err := disconnectViaNVMe(devicePath, p); err != nil {
+			if err := disconnectViaNVMe(context.Background(), devicePath, p); err != nil {
 				klog.Errorf("reconcileNonOptimizedPaths: disconnect stale %s failed: %v", ip, err)
 			}
 			delete(activeIPMap, ip)
@@ -928,7 +928,7 @@ func reconcileNonOptimizedPaths(
 			continue
 		}
 		klog.Infof("reconcileNonOptimizedPaths: connecting missing path ip=%s", conn.IP)
-		if err := connectViaNVMe(conn, ctrlLossTmo, 1); err != nil {
+		if err := connectViaNVMe(context.Background(), conn, ctrlLossTmo, 1); err != nil {
 			klog.Errorf("reconcileNonOptimizedPaths: connect to %s failed: %v", conn.IP, err)
 		}
 	}

--- a/pkg/util/initiator_test.go
+++ b/pkg/util/initiator_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -54,7 +55,7 @@ func TestExecWithTimeoutTimeout(t *testing.T) {
 
 func runExecWithTimeout(cmdLine []string, timeout int) (int, error) {
 	start := time.Now()
-	err := execWithTimeout(cmdLine, timeout)
+	err := execWithTimeout(context.Background(), cmdLine, timeout)
 	elapsed := int(time.Since(start) / time.Second)
 	return elapsed, err
 }

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -228,8 +229,8 @@ func (client *RPCClient) v2storageNode(nodeID string) string {
 // --- API methods ---
 
 // lvStores returns all available storage pools
-func (client *RPCClient) lvStores() ([]LvStore, error) {
-	out, err := client.CallSBCLI("GET", client.v2pools()+"/", nil)
+func (client *RPCClient) lvStores(ctx context.Context) ([]LvStore, error) {
+	out, err := client.CallSBCLI(ctx, "GET", client.v2pools()+"/", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -252,8 +253,8 @@ func (client *RPCClient) lvStores() ([]LvStore, error) {
 }
 
 // createVolume creates a logical volume and returns its UUID
-func (client *RPCClient) createVolume(params *CreateLVolData) (string, error) {
-	out, err := client.CallSBCLI("POST", client.v2volumes()+"/", params)
+func (client *RPCClient) createVolume(ctx context.Context, params *CreateLVolData) (string, error) {
+	out, err := client.CallSBCLI(ctx, "POST", client.v2volumes()+"/", params)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
@@ -268,8 +269,8 @@ func (client *RPCClient) createVolume(params *CreateLVolData) (string, error) {
 }
 
 // getVolumeByUUID fetches a single volume by its UUID
-func (client *RPCClient) getVolumeByUUID(lvolID string) (*LvolResp, error) {
-	out, err := client.CallSBCLI("GET", client.v2volume(lvolID), nil)
+func (client *RPCClient) getVolumeByUUID(ctx context.Context, lvolID string) (*LvolResp, error) {
+	out, err := client.CallSBCLI(ctx, "GET", client.v2volume(lvolID), nil)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSuchDevice) {
 			err = ErrJSONNoSuchDevice
@@ -288,8 +289,8 @@ func (client *RPCClient) getVolumeByUUID(lvolID string) (*LvolResp, error) {
 }
 
 // getVolumeByName lists all volumes in the pool and returns the one with matching name
-func (client *RPCClient) getVolumeByName(name string) (*LvolResp, error) {
-	volumes, err := client.listVolumes()
+func (client *RPCClient) getVolumeByName(ctx context.Context, name string) (*LvolResp, error) {
+	volumes, err := client.listVolumes(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -302,18 +303,18 @@ func (client *RPCClient) getVolumeByName(name string) (*LvolResp, error) {
 }
 
 // getVolume accepts either a UUID or a "poolName/volName" path (legacy callers)
-func (client *RPCClient) getVolume(lvolIDOrPath string) (*LvolResp, error) {
+func (client *RPCClient) getVolume(ctx context.Context, lvolIDOrPath string) (*LvolResp, error) {
 	if strings.Contains(lvolIDOrPath, "/") {
 		// "poolName/volName" — extract the volume name and search by name
 		parts := strings.SplitN(lvolIDOrPath, "/", 2)
-		return client.getVolumeByName(parts[1])
+		return client.getVolumeByName(ctx, parts[1])
 	}
-	return client.getVolumeByUUID(lvolIDOrPath)
+	return client.getVolumeByUUID(ctx, lvolIDOrPath)
 }
 
 // listVolumes returns all volumes in the pool
-func (client *RPCClient) listVolumes() ([]*LvolResp, error) {
-	out, err := client.CallSBCLI("GET", client.v2volumes()+"/", nil)
+func (client *RPCClient) listVolumes(ctx context.Context) ([]*LvolResp, error) {
+	out, err := client.CallSBCLI(ctx, "GET", client.v2volumes()+"/", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -329,8 +330,8 @@ func (client *RPCClient) listVolumes() ([]*LvolResp, error) {
 }
 
 // getVolumeInfo returns the NVMe connection info for a volume as a CSI VolumeContext map.
-func (client *RPCClient) getVolumeInfo(lvolID string, hostNQN string) (map[string]string, error) {
-	result, err := client.getLvolConnections(lvolID, hostNQN)
+func (client *RPCClient) getVolumeInfo(ctx context.Context, lvolID string, hostNQN string) (map[string]string, error) {
+	result, err := client.getLvolConnections(ctx, lvolID, hostNQN)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSuchDevice) {
 			err = ErrJSONNoSuchDevice
@@ -367,8 +368,8 @@ func (client *RPCClient) getVolumeInfo(lvolID string, hostNQN string) (map[strin
 }
 
 // deleteVolume deletes a volume by UUID
-func (client *RPCClient) deleteVolume(lvolID string) error {
-	_, err := client.CallSBCLI("DELETE", client.v2volume(lvolID), nil)
+func (client *RPCClient) deleteVolume(ctx context.Context, lvolID string) error {
+	_, err := client.CallSBCLI(ctx, "DELETE", client.v2volume(lvolID), nil)
 	if errorMatches(err, ErrJSONNoSuchDevice) {
 		err = ErrJSONNoSuchDevice
 	}
@@ -376,8 +377,8 @@ func (client *RPCClient) deleteVolume(lvolID string) error {
 }
 
 // getPoolUUIDByName resolves a pool name to its UUID
-func (client *RPCClient) getPoolUUIDByName(poolName string) (string, error) {
-	pools, err := client.lvStores()
+func (client *RPCClient) getPoolUUIDByName(ctx context.Context, poolName string) (string, error) {
+	pools, err := client.lvStores(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -390,9 +391,9 @@ func (client *RPCClient) getPoolUUIDByName(poolName string) (string, error) {
 }
 
 // getMasterLvols returns master lvols for a pool
-func (client *RPCClient) getMasterLvols(poolUUID string) ([]MasterLvol, error) {
+func (client *RPCClient) getMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error) {
 	path := client.v2pool(poolUUID) + "/master-lvols"
-	out, err := client.CallSBCLI("GET", path, nil)
+	out, err := client.CallSBCLI(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -414,8 +415,8 @@ func (client *RPCClient) getMasterLvols(poolUUID string) ([]MasterLvol, error) {
 }
 
 // resizeVolume resizes a volume
-func (client *RPCClient) resizeVolume(lvolID string, size int64) (bool, error) {
-	_, err := client.CallSBCLI("PUT", client.v2volume(lvolID), &ResizeVolReq{Size: size})
+func (client *RPCClient) resizeVolume(ctx context.Context, lvolID string, size int64) (bool, error) {
+	_, err := client.CallSBCLI(ctx, "PUT", client.v2volume(lvolID), &ResizeVolReq{Size: size})
 	if err != nil {
 		return false, err
 	}
@@ -423,7 +424,7 @@ func (client *RPCClient) resizeVolume(lvolID string, size int64) (bool, error) {
 }
 
 // cloneVolume clones a volume by UUID, returning the new volume's UUID
-func (client *RPCClient) cloneVolume(lvolID, cloneName, newSize, pvcName string) (string, error) {
+func (client *RPCClient) cloneVolume(ctx context.Context, lvolID, cloneName, newSize, pvcName string) (string, error) {
 	path := client.v2volume(lvolID) + "clone?clone_name=" + url.QueryEscape(cloneName)
 	if newSize != "" {
 		path += "&new_size=" + url.QueryEscape(newSize)
@@ -434,7 +435,7 @@ func (client *RPCClient) cloneVolume(lvolID, cloneName, newSize, pvcName string)
 
 	klog.V(5).Infof("cloneVolume size: %s", newSize)
 
-	out, err := client.CallSBCLI("POST", path, nil)
+	out, err := client.CallSBCLI(ctx, "POST", path, nil)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
@@ -449,7 +450,7 @@ func (client *RPCClient) cloneVolume(lvolID, cloneName, newSize, pvcName string)
 }
 
 // cloneSnapshot creates a new volume from a snapshot, returning the new volume's UUID
-func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName string) (string, error) {
+func (client *RPCClient) cloneSnapshot(ctx context.Context, snapshotID, cloneName, newSize, pvcName string) (string, error) {
 	params := struct {
 		Name       string `json:"name"`
 		SnapshotID string `json:"snapshot_id"`
@@ -464,7 +465,7 @@ func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName s
 
 	klog.V(5).Infof("cloneSnapshot size: %s", newSize)
 
-	out, err := client.CallSBCLI("POST", client.v2volumes()+"/", &params)
+	out, err := client.CallSBCLI(ctx, "POST", client.v2volumes()+"/", &params)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
@@ -479,8 +480,8 @@ func (client *RPCClient) cloneSnapshot(snapshotID, cloneName, newSize, pvcName s
 }
 
 // listSnapshots returns all snapshots in the pool
-func (client *RPCClient) listSnapshots() ([]*SnapshotResp, error) {
-	out, err := client.CallSBCLI("GET", client.v2snapshots()+"/", nil)
+func (client *RPCClient) listSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
+	out, err := client.CallSBCLI(ctx, "GET", client.v2snapshots()+"/", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -497,8 +498,8 @@ func (client *RPCClient) listSnapshots() ([]*SnapshotResp, error) {
 
 // listAllSnapshots iterates every pool in the cluster and collects all snapshots.
 // Used when PoolID is not set (e.g. ListSnapshots CSI RPC).
-func (client *RPCClient) listAllSnapshots() ([]*SnapshotResp, error) {
-	pools, err := client.lvStores()
+func (client *RPCClient) listAllSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
+	pools, err := client.lvStores(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +509,7 @@ func (client *RPCClient) listAllSnapshots() ([]*SnapshotResp, error) {
 
 	for _, pool := range pools {
 		client.PoolID = pool.UUID
-		snaps, err := client.listSnapshots()
+		snaps, err := client.listSnapshots(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -522,13 +523,13 @@ func (client *RPCClient) listAllSnapshots() ([]*SnapshotResp, error) {
 }
 
 // snapshot creates a snapshot of a volume and returns the snapshot UUID
-func (client *RPCClient) snapshot(lvolID, snapShotName string) (string, error) {
+func (client *RPCClient) snapshot(ctx context.Context, lvolID, snapShotName string) (string, error) {
 	params := struct {
 		Name string `json:"name"`
 	}{Name: snapShotName}
 
 	path := client.v2volume(lvolID) + "snapshots"
-	out, err := client.CallSBCLI("POST", path, &params)
+	out, err := client.CallSBCLI(ctx, "POST", path, &params)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
@@ -544,11 +545,11 @@ func (client *RPCClient) snapshot(lvolID, snapShotName string) (string, error) {
 
 // deleteSnapshot deletes a snapshot.
 // If PoolID is not set (legacy 2-part snapshot IDs), it scans all pools.
-func (client *RPCClient) deleteSnapshot(snapshotID string) error {
+func (client *RPCClient) deleteSnapshot(ctx context.Context, snapshotID string) error {
 	if client.PoolID == "" {
-		return client.deleteSnapshotScanPools(snapshotID)
+		return client.deleteSnapshotScanPools(ctx, snapshotID)
 	}
-	_, err := client.CallSBCLI("DELETE", client.v2snapshot(snapshotID), nil)
+	_, err := client.CallSBCLI(ctx, "DELETE", client.v2snapshot(snapshotID), nil)
 	if errorMatches(err, ErrJSONNoSuchDevice) {
 		err = ErrJSONNoSuchDevice
 	}
@@ -557,8 +558,8 @@ func (client *RPCClient) deleteSnapshot(snapshotID string) error {
 
 // deleteSnapshotScanPools finds a snapshot across all pools and deletes it.
 // Used for backward compat with legacy 2-part CSI snapshot IDs that have no pool info.
-func (client *RPCClient) deleteSnapshotScanPools(snapshotID string) error {
-	pools, err := client.lvStores()
+func (client *RPCClient) deleteSnapshotScanPools(ctx context.Context, snapshotID string) error {
+	pools, err := client.lvStores(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list pools while deleting snapshot %s: %w", snapshotID, err)
 	}
@@ -567,7 +568,7 @@ func (client *RPCClient) deleteSnapshotScanPools(snapshotID string) error {
 
 	for _, pool := range pools {
 		client.PoolID = pool.UUID
-		_, err := client.CallSBCLI("DELETE", client.v2snapshot(snapshotID), nil)
+		_, err := client.CallSBCLI(ctx, "DELETE", client.v2snapshot(snapshotID), nil)
 		if err == nil {
 			return nil
 		}
@@ -580,17 +581,17 @@ func (client *RPCClient) deleteSnapshotScanPools(snapshotID string) error {
 
 // findPoolForVolume scans all pools to find the one containing the given volume UUID,
 // then sets client.PoolID. No-op if PoolID is already set.
-func (client *RPCClient) findPoolForVolume(lvolID string) error {
+func (client *RPCClient) findPoolForVolume(ctx context.Context, lvolID string) error {
 	if client.PoolID != "" {
 		return nil
 	}
-	pools, err := client.lvStores()
+	pools, err := client.lvStores(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list pools while resolving pool for volume %s: %w", lvolID, err)
 	}
 	for _, pool := range pools {
 		client.PoolID = pool.UUID
-		_, err := client.getVolumeByUUID(lvolID)
+		_, err := client.getVolumeByUUID(ctx, lvolID)
 		if err == nil {
 			return nil
 		}
@@ -604,12 +605,12 @@ func (client *RPCClient) findPoolForVolume(lvolID string) error {
 }
 
 // getLvolConnections returns the raw NVMe-oF connection list for a volume.
-func (client *RPCClient) getLvolConnections(lvolID, hostNQN string) ([]*LvolConnectResp, error) {
+func (client *RPCClient) getLvolConnections(ctx context.Context, lvolID, hostNQN string) ([]*LvolConnectResp, error) {
 	path := client.v2volume(lvolID) + "connect"
 	if hostNQN != "" {
 		path += "?host_nqn=" + url.QueryEscape(hostNQN)
 	}
-	out, err := client.CallSBCLI("GET", path, nil)
+	out, err := client.CallSBCLI(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -625,8 +626,8 @@ func (client *RPCClient) getLvolConnections(lvolID, hostNQN string) ([]*LvolConn
 }
 
 // getStorageNodeStatus returns the status string for a storage node by UUID.
-func (client *RPCClient) getStorageNodeStatus(nodeID string) (string, error) {
-	out, err := client.CallSBCLI("GET", client.v2storageNode(nodeID), nil)
+func (client *RPCClient) getStorageNodeStatus(ctx context.Context, nodeID string) (string, error) {
+	out, err := client.CallSBCLI(ctx, "GET", client.v2storageNode(nodeID), nil)
 	if err != nil {
 		return "", err
 	}
@@ -644,7 +645,7 @@ func (client *RPCClient) getStorageNodeStatus(nodeID string) (string, error) {
 }
 
 // CallSBCLI is a generic function to call the SimplyBlock API v2
-func (client *RPCClient) CallSBCLI(method, path string, args interface{}) (interface{}, error) {
+func (client *RPCClient) CallSBCLI(ctx context.Context, method, path string, args interface{}) (interface{}, error) {
 	path = strings.TrimLeft(path, "/")
 
 	var bodyReader io.Reader
@@ -659,7 +660,7 @@ func (client *RPCClient) CallSBCLI(method, path string, args interface{}) (inter
 	requestURL := fmt.Sprintf("%s/%s", client.ClusterIP, path)
 	klog.Infof("Calling Simplyblock API v2: %s %s", method, requestURL)
 
-	req, err := http.NewRequest(method, requestURL, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", method, err)
 	}

--- a/pkg/util/jsonrpc_test.go
+++ b/pkg/util/jsonrpc_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -19,7 +20,7 @@ func TestCallSBCLIUsesBearerAuthForAPIV2(t *testing.T) {
 		})},
 	}
 
-	if _, err := client.CallSBCLI(http.MethodGet, "/api/v2/clusters/cluster-id/storage-pools/", nil); err != nil {
+	if _, err := client.CallSBCLI(context.Background(), http.MethodGet, "/api/v2/clusters/cluster-id/storage-pools/", nil); err != nil {
 		t.Fatalf("CallSBCLI: %v", err)
 	}
 	if gotAuth != "Bearer cluster-secret" {
@@ -39,7 +40,7 @@ func TestCallSBCLIUsesLegacyAuthOutsideAPIV2(t *testing.T) {
 		})},
 	}
 
-	if _, err := client.CallSBCLI(http.MethodGet, "/lvol/lvol-id", nil); err != nil {
+	if _, err := client.CallSBCLI(context.Background(), http.MethodGet, "/lvol/lvol-id", nil); err != nil {
 		t.Fatalf("CallSBCLI: %v", err)
 	}
 	if gotAuth != "cluster-id cluster-secret" {
@@ -70,7 +71,7 @@ func TestCloneVolumeUsesPostAndLocationHeader(t *testing.T) {
 		})},
 	}
 
-	cloneID, err := client.cloneVolume("source-id", "clone name", "1073741824", "default/my-pvc")
+	cloneID, err := client.cloneVolume(context.Background(), "source-id", "clone name", "1073741824", "default/my-pvc")
 	if err != nil {
 		t.Fatalf("cloneVolume: %v", err)
 	}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -147,15 +148,15 @@ func (node *NodeNVMf) Info() string {
 	return node.Client.info()
 }
 
-func (node *NodeNVMf) LvStores() ([]LvStore, error) {
-	return node.Client.lvStores()
+func (node *NodeNVMf) LvStores(ctx context.Context) ([]LvStore, error) {
+	return node.Client.lvStores(ctx)
 }
 
 // VolumeInfo returns a string:string map containing information necessary
 // for CSI node(initiator) to connect to this target and identify the disk.
 // hostNQN is passed to the sbcli API when the volume has allowed_hosts configured.
-func (node *NodeNVMf) VolumeInfo(lvolID string, hostNQN string) (map[string]string, error) {
-	return node.Client.getVolumeInfo(lvolID, hostNQN)
+func (node *NodeNVMf) VolumeInfo(ctx context.Context, lvolID string, hostNQN string) (map[string]string, error) {
+	return node.Client.getVolumeInfo(ctx, lvolID, hostNQN)
 }
 
 // CreateLVolData is the data structure for creating a logical volume
@@ -183,8 +184,8 @@ type CreateLVolData struct {
 }
 
 // CreateVolume creates a logical volume and returns volume ID
-func (node *NodeNVMf) CreateVolume(params *CreateLVolData) (string, error) {
-	lvolID, err := node.Client.createVolume(params)
+func (node *NodeNVMf) CreateVolume(ctx context.Context, params *CreateLVolData) (string, error) {
+	lvolID, err := node.Client.createVolume(ctx, params)
 	if err != nil {
 		return "", err
 	}
@@ -192,14 +193,14 @@ func (node *NodeNVMf) CreateVolume(params *CreateLVolData) (string, error) {
 	return lvolID, nil
 }
 
-// GetVolume returns the LvolResp for the given volume name and pool name. Returns error if not found.
-func (node *NodeNVMf) GetVolume(lvolName, poolName string) (*LvolResp, error) {
-	return node.Client.getVolume(fmt.Sprintf("%s/%s", poolName, lvolName))
+// GetVolume returns the volume id of the given volume name and lvstore name. return error if not found.
+func (node *NodeNVMf) GetVolume(ctx context.Context, lvolName, poolName string) (*LvolResp, error) {
+	return node.Client.getVolume(ctx, fmt.Sprintf("%s/%s", poolName, lvolName))
 }
 
 // GetVolumeSize returns the size of the volume
-func (node *NodeNVMf) GetVolumeSize(lvolID string) (string, error) {
-	lvol, err := node.Client.getVolume(lvolID)
+func (node *NodeNVMf) GetVolumeSize(ctx context.Context, lvolID string) (string, error) {
+	lvol, err := node.Client.getVolume(ctx, lvolID)
 	if err != nil {
 		return "", err
 	}
@@ -209,36 +210,37 @@ func (node *NodeNVMf) GetVolumeSize(lvolID string) (string, error) {
 }
 
 // ListVolumes returns a list of volumes
-func (node *NodeNVMf) ListVolumes() ([]*LvolResp, error) {
-	return node.Client.listVolumes()
+
+func (node *NodeNVMf) ListVolumes(ctx context.Context) ([]*LvolResp, error) {
+	return node.Client.listVolumes(ctx)
 }
 
 // GetMasterLvols returns master lvols for the given pool UUID
-func (node *NodeNVMf) GetMasterLvols(poolUUID string) ([]MasterLvol, error) {
-	return node.Client.getMasterLvols(poolUUID)
+func (node *NodeNVMf) GetMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error) {
+	return node.Client.getMasterLvols(ctx, poolUUID)
 }
 
 // GetPoolUUIDByName returns the UUID of the pool with the given name
-func (node *NodeNVMf) GetPoolUUIDByName(poolName string) (string, error) {
-	return node.Client.getPoolUUIDByName(poolName)
+func (node *NodeNVMf) GetPoolUUIDByName(ctx context.Context, poolName string) (string, error) {
+	return node.Client.getPoolUUIDByName(ctx, poolName)
 }
 
 // ResizeVolume resizes a volume
-func (node *NodeNVMf) ResizeVolume(lvolID string, newSize int64) (bool, error) {
-	return node.Client.resizeVolume(lvolID, newSize)
+func (node *NodeNVMf) ResizeVolume(ctx context.Context, lvolID string, newSize int64) (bool, error) {
+	return node.Client.resizeVolume(ctx, lvolID, newSize)
 }
 
 // ListSnapshots returns a list of snapshots. When PoolID is not set, iterates all pools.
-func (node *NodeNVMf) ListSnapshots() ([]*SnapshotResp, error) {
+func (node *NodeNVMf) ListSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
 	if node.Client.PoolID == "" {
-		return node.Client.listAllSnapshots()
+		return node.Client.listAllSnapshots(ctx)
 	}
-	return node.Client.listSnapshots()
+	return node.Client.listSnapshots(ctx)
 }
 
 // CloneSnapshot clones a snapshot to a new volume
-func (node *NodeNVMf) CloneSnapshot(snapshotID, cloneName, newSize, pvcName string) (string, error) {
-	lvolID, err := node.Client.cloneSnapshot(snapshotID, cloneName, newSize, pvcName)
+func (node *NodeNVMf) CloneSnapshot(ctx context.Context, snapshotID, cloneName, newSize, pvcName string) (string, error) {
+	lvolID, err := node.Client.cloneSnapshot(ctx, snapshotID, cloneName, newSize, pvcName)
 	if err != nil {
 		return "", err
 	}
@@ -247,8 +249,8 @@ func (node *NodeNVMf) CloneSnapshot(snapshotID, cloneName, newSize, pvcName stri
 }
 
 // CloneVolume clones a volume to a new volume
-func (node *NodeNVMf) CloneVolume(lvolID, cloneName, newSize, pvcName string) (string, error) {
-	lvolID, err := node.Client.cloneVolume(lvolID, cloneName, newSize, pvcName)
+func (node *NodeNVMf) CloneVolume(ctx context.Context, lvolID, cloneName, newSize, pvcName string) (string, error) {
+	lvolID, err := node.Client.cloneVolume(ctx, lvolID, cloneName, newSize, pvcName)
 	if err != nil {
 		return "", err
 	}
@@ -258,8 +260,8 @@ func (node *NodeNVMf) CloneVolume(lvolID, cloneName, newSize, pvcName string) (s
 
 // CreateSnapshot creates a snapshot of a volume.
 // Returns a 3-part CSI snapshot ID: {clusterID}:{poolID}:{snapshotUUID}
-func (node *NodeNVMf) CreateSnapshot(lvolID, snapshotName string) (string, error) {
-	snapshotID, err := node.Client.snapshot(lvolID, snapshotName)
+func (node *NodeNVMf) CreateSnapshot(ctx context.Context, lvolID, snapshotName string) (string, error) {
+	snapshotID, err := node.Client.snapshot(ctx, lvolID, snapshotName)
 	if err != nil {
 		return "", err
 	}
@@ -269,8 +271,8 @@ func (node *NodeNVMf) CreateSnapshot(lvolID, snapshotName string) (string, error
 }
 
 // DeleteVolume deletes a volume
-func (node *NodeNVMf) DeleteVolume(lvolID string) error {
-	err := node.Client.deleteVolume(lvolID)
+func (node *NodeNVMf) DeleteVolume(ctx context.Context, lvolID string) error {
+	err := node.Client.deleteVolume(ctx, lvolID)
 	if err != nil {
 		return err
 	}
@@ -279,8 +281,8 @@ func (node *NodeNVMf) DeleteVolume(lvolID string) error {
 }
 
 // DeleteSnapshot deletes a snapshot
-func (node *NodeNVMf) DeleteSnapshot(snapshotID string) error {
-	err := node.Client.deleteSnapshot(snapshotID)
+func (node *NodeNVMf) DeleteSnapshot(ctx context.Context, snapshotID string) error {
+	err := node.Client.deleteSnapshot(ctx, snapshotID)
 	if err != nil {
 		return err
 	}
@@ -289,7 +291,7 @@ func (node *NodeNVMf) DeleteSnapshot(snapshotID string) error {
 }
 
 // PublishVolume exports a volume through NVMf target
-func (node *NodeNVMf) PublishVolume(lvolID string) error {
+func (node *NodeNVMf) PublishVolume(ctx context.Context, lvolID string) error {
 	_, err := node.Client.CallSBCLI("GET", node.Client.v2volume(lvolID), nil)
 	if err != nil {
 		return err
@@ -299,8 +301,9 @@ func (node *NodeNVMf) PublishVolume(lvolID string) error {
 }
 
 // UnpublishVolume unexports a volume through NVMf target
-func (node *NodeNVMf) UnpublishVolume(lvolID string) error {
-	_, err := node.Client.CallSBCLI("GET", node.Client.v2volume(lvolID), nil)
+
+func (node *NodeNVMf) UnpublishVolume(ctx context.Context, lvolID string) error {
+	_, err := node.Client.CallSBCLI(ctx, "GET", node.Client.v2volume(lvolID), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -193,7 +193,7 @@ func (node *NodeNVMf) CreateVolume(ctx context.Context, params *CreateLVolData) 
 	return lvolID, nil
 }
 
-// GetVolume returns the volume id of the given volume name and lvstore name. return error if not found.
+// GetVolume returns the LvolResp for the given volume name and pool name. Returns error if not found.
 func (node *NodeNVMf) GetVolume(ctx context.Context, lvolName, poolName string) (*LvolResp, error) {
 	return node.Client.getVolume(ctx, fmt.Sprintf("%s/%s", poolName, lvolName))
 }
@@ -292,7 +292,7 @@ func (node *NodeNVMf) DeleteSnapshot(ctx context.Context, snapshotID string) err
 
 // PublishVolume exports a volume through NVMf target
 func (node *NodeNVMf) PublishVolume(ctx context.Context, lvolID string) error {
-	_, err := node.Client.CallSBCLI("GET", node.Client.v2volume(lvolID), nil)
+	_, err := node.Client.CallSBCLI(ctx, "GET", node.Client.v2volume(lvolID), nil)
 	if err != nil {
 		return err
 	}
@@ -301,7 +301,6 @@ func (node *NodeNVMf) PublishVolume(ctx context.Context, lvolID string) error {
 }
 
 // UnpublishVolume unexports a volume through NVMf target
-
 func (node *NodeNVMf) UnpublishVolume(ctx context.Context, lvolID string) error {
 	_, err := node.Client.CallSBCLI(ctx, "GET", node.Client.v2volume(lvolID), nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

Gap 3 of issue #159: the gRPC server had no per-RPC deadline enforcement, and `context.Context` was discarded (`_`) by every node/controller handler, meaning cancellation and deadline signals from the kubelet could never reach the outbound sbcli HTTP calls.

- **Timeout interceptor**: `timeoutInterceptor` (120s ceiling) is chained after `logGRPC`. If the incoming ctx already carries a shorter deadline (e.g. kubelet set 30s), that is preserved; otherwise the 120s cap prevents runaway handlers even against a misbehaving kubelet.
- **ctx threaded end-to-end**: every gRPC handler that was discarding `_ context.Context` now accepts and forwards `ctx`. `CallSBCLI` uses `http.NewRequestWithContext(ctx, ...)` — so when the RPC deadline fires or the kubelet disconnects and the gRPC keepalive closes the connection (PR #382), the in-flight sbcli HTTP call is cancelled rather than running for 90s against a now-useless session.
- **Interface updated**: `SpdkCsiInitiator.Connect` / `Disconnect`, all `NodeNVMf` public methods, all `RPCClient` private methods now accept `ctx` as their first parameter.
- **Background callers**: ANA recovery goroutines and the guardian health-check loop have no natural ctx and correctly use `context.Background()`.

**Files changed**: `pkg/csi-common/utils.go`, `pkg/csi-common/server.go`, `pkg/util/jsonrpc.go`, `pkg/util/nvmf.go`, `pkg/util/initiator.go`, `pkg/util/guardian.go`, `pkg/spdk/nodeserver.go`, `pkg/spdk/controllerserver.go`, `e2e/utils.go`, `pkg/util/jsonrpc_test.go`

Depends on / companion to PR #382 (keepalive + connection timeout).

Fixes simplyblock/simplyblock-operator#159
Fixes https://github.com/simplyblock/simplyblock-operator/issues/160
Fixes https://github.com/simplyblock/simplyblock-operator/issues/169

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass (verified locally).
- [ ] `go test ./pkg/util/...` passes.
- [ ] Simulate kubelet OOM-kill mid-`NodeStageVolume`; confirm the in-flight sbcli HTTP call is cancelled within the timeout window rather than running to 90s completion.
- [ ] Normal `NodeStageVolume` / `NodeUnstageVolume` / `CreateVolume` / `DeleteVolume` round-trips complete successfully end-to-end.
- [ ] Confirm a kubelet-supplied deadline shorter than 120s is respected (interceptor preserves min deadline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)