### PR TITLE
replace volume context stash with OS-level NVMe discovery

### DIFF
--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -23,7 +23,6 @@ import (
 	osexec "os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"path/filepath"
 	"unsafe"
@@ -287,7 +286,14 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 	defer func() {
 		if err != nil {
-			initiator.Disconnect(ctx) //nolint:errcheck // ignore error
+			// Unmount before disconnecting
+			if umountErr := ns.deleteMountPoint(stagingTargetPath); umountErr != nil {
+				klog.Warningf("failed to unmount staging path during NodeStageVolume cleanup, volumeID: %s err: %v", volumeID, umountErr)
+			}
+			// use a non-cancellable context for nvme disconnect because the current ctx is already cancelled
+			if discErr := initiator.Disconnect(context.WithoutCancel(ctx)); discErr != nil {
+				klog.Warningf("failed to disconnect initiator during NodeStageVolume cleanup, volumeID: %s err: %v", volumeID, discErr)
+			}
 		}
 	}()
 	if err = ns.stageVolume(devicePath, stagingTargetPath, req, vc); err != nil { // idempotent
@@ -295,14 +301,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	vc["devicePath"] = devicePath
-	// stash VolumeContext to stagingParentPath (useful during Unstage as it has no
-	// VolumeContext passed to the RPC as per the CSI spec)
-	err = util.StashVolumeContext(req.GetVolumeContext(), stagingParentPath)
-	if err != nil {
-		klog.Errorf("failed to stash volume context, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Internal, err.Error())
-	}
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
@@ -311,7 +309,6 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
 
-	stagingParentPath := req.GetStagingTargetPath()
 	stagingTargetPath := getStagingTargetPath(req)
 
 	err := ns.deleteMountPoint(stagingTargetPath) // idempotent
@@ -320,25 +317,16 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return nil, status.Errorf(codes.Internal, "unstage volume %s failed: %s", volumeID, err)
 	}
 
-	volumeContext, err := util.LookupVolumeContext(stagingParentPath)
+	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
-		klog.Errorf("failed to lookup volume context, volumeID: %s err: %v", volumeID, err)
+		klog.Errorf("failed to parse volumeID %s: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	initiator, err := util.NewSpdkCsiInitiator(volumeContext)
-	if err != nil {
-		klog.Errorf("failed to create spdk initiator, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
-	defer cleanupCancel()
-	err = initiator.Disconnect(cleanupCtx) // idempotent
-	if err != nil {
-		klog.Errorf("failed to disconnect initiator, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if err := util.CleanUpVolumeContext(stagingParentPath); err != nil {
-		klog.Errorf("failed to clean up volume context, volumeID: %s err: %v", volumeID, err)
+	// Disconnect by discovering the NVMe device directly from the OS
+	// (/dev/disk/by-id/*<lvolID>*). This is idempotent: returns nil when
+	// the device is already gone (never connected or already disconnected).
+	if err := util.DisconnectByLvolID(ctx, spdkVol.lvolID); err != nil {
+		klog.Errorf("failed to disconnect NVMe device for volumeID %s: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return &csi.NodeUnstageVolumeResponse{}, nil
@@ -421,15 +409,16 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	volumeID := req.GetVolumeId()
 	volumeMountPath := req.GetVolumePath()
 
-	stagingParentPath := req.GetStagingTargetPath()
-	volumeContext, err := util.LookupVolumeContext(stagingParentPath)
+	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to retrieve volume context for volume %s: %v", volumeID, err)
+		return nil, status.Errorf(codes.Internal, "failed to parse volumeID %s: %v", volumeID, err)
 	}
-
-	devicePath, ok := volumeContext["devicePath"]
-	if !ok || devicePath == "" {
-		return nil, status.Errorf(codes.Internal, "could not find device path for volume %s", volumeID)
+	devicePath, err := util.FindDeviceByLvolID(spdkVol.lvolID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to find NVMe device for volume %s: %v", volumeID, err)
+	}
+	if devicePath == "" {
+		return nil, status.Errorf(codes.Internal, "NVMe device not found for volume %s (not connected?)", volumeID)
 	}
 
 	// For raw block volumes, the block device has already been resized at the
@@ -565,15 +554,16 @@ func (ns *nodeServer) publishVolume(stagingPath string, req *csi.NodePublishVolu
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
 
 	if req.GetVolumeCapability().GetBlock() != nil {
-		stagingParentPath := req.GetStagingTargetPath()
-		volumeContext, err := util.LookupVolumeContext(stagingParentPath)
+		spdkVol, err := getSPDKVol(req.GetVolumeId())
 		if err != nil {
-			return status.Errorf(codes.Internal, "failed to retrieve volume context for volume %s: %v", req.GetVolumeId(), err)
+			return status.Errorf(codes.Internal, "failed to parse volumeID %s: %v", req.GetVolumeId(), err)
 		}
-
-		devicePath, ok := volumeContext["devicePath"]
-		if !ok || devicePath == "" {
-			return status.Errorf(codes.Internal, "could not find device path for volume %s", req.GetVolumeId())
+		devicePath, err := util.FindDeviceByLvolID(spdkVol.lvolID)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to find NVMe device for volume %s: %v", req.GetVolumeId(), err)
+		}
+		if devicePath == "" {
+			return status.Errorf(codes.Internal, "NVMe device not found for volume %s (not connected?)", req.GetVolumeId())
 		}
 		stagingPath = devicePath
 

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -314,7 +314,7 @@ func (nvmf *initiatorNVMf) Disconnect(ctx context.Context) error {
 		}
 	}
 
-	return waitForDeviceGone(deviceGlob)
+	return waitForDeviceGone(ctx, deviceGlob)
 }
 
 // when timeout is set as 0, try to find the device file immediately
@@ -339,7 +339,7 @@ func waitForDeviceReady(ctx context.Context, deviceGlob string, seconds int) (st
 }
 
 // wait for device file gone or timeout
-func waitForDeviceGone(deviceGlob string) error {
+func waitForDeviceGone(ctx context.Context, deviceGlob string) error {
 	for i := 0; i <= 20; i++ {
 		matches, err := filepath.Glob(deviceGlob)
 		if err != nil {
@@ -348,7 +348,11 @@ func waitForDeviceGone(deviceGlob string) error {
 		if len(matches) == 0 {
 			return nil
 		}
-		time.Sleep(time.Second)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled waiting for device gone %s: %w", deviceGlob, ctx.Err())
+		}
 	}
 	return fmt.Errorf("timed out waiting device gone: %s", deviceGlob)
 }
@@ -513,6 +517,43 @@ func getSubsystemsForDevice(devicePath string) ([]subsystemResponse, error) {
 	}
 
 	return subsystems, nil
+}
+
+// FindDeviceByLvolID returns the /dev/disk/by-id symlink path for the NVMe
+// block device associated with lvolID, or ("", nil) if not connected.
+// The lvolID is used as the device model name by the simplyblock storage layer.
+func FindDeviceByLvolID(lvolID string) (string, error) {
+	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", lvolID))
+	matches, err := filepath.Glob(deviceGlob)
+	if err != nil {
+		return "", fmt.Errorf("glob %s: %w", deviceGlob, err)
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	if len(matches) > 1 {
+		klog.Warningf("FindDeviceByLvolID: multiple /dev/disk/by-id entries for lvolID %s: %v — using first", lvolID, matches)
+	}
+	return matches[0], nil
+}
+
+// DisconnectByLvolID disconnects the NVMe device associated with lvolID via
+// OS-level discovery (/dev/disk/by-id).  It is idempotent: returns nil when
+// no matching device is found (already disconnected or never connected).
+func DisconnectByLvolID(ctx context.Context, lvolID string) error {
+	devicePath, err := FindDeviceByLvolID(lvolID)
+	if err != nil {
+		return err
+	}
+	if devicePath == "" {
+		klog.Infof("no NVMe device found for lvolID %s — already disconnected", lvolID)
+		return nil
+	}
+	if err := disconnectDevicePath(ctx, devicePath); err != nil {
+		return err
+	}
+	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", lvolID))
+	return waitForDeviceGone(ctx, deviceGlob)
 }
 
 func getLvolIDFromNQN(nqn string) (clusterID, lvolID string) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,9 +32,6 @@ import (
 	"k8s.io/klog"
 )
 
-// file name in which volume context is stashed.
-const volumeContextFileName = "volume-context.json"
-
 const (
 	MIB = int64(1024 * 1024)
 	GIB = MIB * 1024
@@ -263,72 +260,6 @@ func ConvertInterfaceToMap(data interface{}) (map[string]string, error) {
 	}
 
 	return strMap, nil
-}
-
-func stashContext(data interface{}, folder, fileName string) error {
-	encodedBytes, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("failed to marshall context JSON: %w", err)
-	}
-	if _, err = os.Stat(folder); os.IsNotExist(err) {
-		err = os.MkdirAll(folder, 0o755)
-		if err != nil {
-			return err
-		}
-	}
-	fPath := filepath.Join(folder, fileName)
-	err = os.WriteFile(fPath, encodedBytes, 0o600)
-	if err != nil {
-		return fmt.Errorf("failed to marshall context JSON at path (%s): %w", fPath, err)
-	}
-	return nil
-}
-
-func lookupContext(folder, fileName string) (interface{}, error) {
-	var data interface{}
-	fPath := filepath.Join(folder, fileName)
-	encodedBytes, err := os.ReadFile(fPath) // #nosec - intended reading from fPath
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return data,
-				fmt.Errorf("failed to read stashed context JSON from path (%s): %w", fPath, err)
-		}
-		return data, errors.New("volume context JSON file not found")
-	}
-	err = json.Unmarshal(encodedBytes, &data)
-	if err != nil {
-		return data,
-			fmt.Errorf("failed to unmarshall stashed context JSON from path (%s): %w", fPath, err)
-	}
-	return data, nil
-}
-
-func cleanUpContext(folder, fileName string) error {
-	fPath := filepath.Join(folder, fileName)
-	if err := os.Remove(fPath); err != nil {
-		return fmt.Errorf("failed to cleanup volume context stash (%s): %w", fPath, err)
-	}
-	return nil
-}
-
-// StashVolumeContext stashes volume context into the volumeContextFileName at the passed in path, in
-// JSON format.
-func StashVolumeContext(volumeContext map[string]string, path string) error {
-	return stashContext(volumeContext, path, volumeContextFileName)
-}
-
-// LookupVolumeContext read and returns stashed volume context at passed in path
-func LookupVolumeContext(path string) (map[string]string, error) {
-	data, err := lookupContext(path, volumeContextFileName)
-	if err != nil {
-		return nil, err
-	}
-	return ConvertInterfaceToMap(data)
-}
-
-// CleanUpVolumeContext cleans up any stashed volume context at passed in path.
-func CleanUpVolumeContext(path string) error {
-	return cleanUpContext(path, volumeContextFileName)
 }
 
 func parseDurationFromEnv(key string, def time.Duration) time.Duration {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package util_test
 
 import (
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -67,41 +66,3 @@ func TestTryLockConcurrent(t *testing.T) {
 	}
 }
 
-func TestVolumeContext(t *testing.T) {
-	volumeContextFileName := "volumeContext.json"
-
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	volumeContext := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-	}
-
-	err = util.StashVolumeContext(volumeContext, dir)
-	if err != nil {
-		t.Fatalf("StashVolumeContext returned error: %v", err)
-	}
-
-	returnedContext, err := util.LookupVolumeContext(dir)
-	if err != nil {
-		t.Fatalf("LookupVolumeContext returned error: %v", err)
-	}
-
-	if volumeContext["key1"] != returnedContext["key1"] || volumeContext["key2"] != returnedContext["key2"] {
-		t.Fatalf("LookupVolumeContext returned unexpected value: got %v, want %v", returnedContext, volumeContext)
-	}
-
-	err = util.CleanUpVolumeContext(dir)
-	if err != nil {
-		t.Fatalf("CleanUpVolumeContext returned error: %v", err)
-	}
-
-	_, err = os.Stat(dir + "/" + volumeContextFileName)
-	if !os.IsNotExist(err) {
-		t.Fatalf("CleanUpVolumeContext failed to cleanup volume context stash")
-	}
-}


### PR DESCRIPTION
fixes: https://github.com/simplyblock/simplyblock-operator/issues/161

We use only `devicename` from the stashed volume context. But this can also be obtained by querying `/dev/disk/by-id` where the Id of the device is lvol ID. 

So implemented `FindDeviceByLvolID` so that we can get device ID without needing the stashed volume context.


### testing 

triggered e2e tests with these changes
```
Will run 7 of 8 specs
S•••••••

Ran 7 of 8 Specs in 606.164 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 1 Skipped
--- PASS: TestE2E (606.17s)
PASS
ok  	github.com/spdk/spdk-csi/e2e	608.555s
```

 