### PR TITLE
restructure simplyblock client and deprecate old struct names

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -587,17 +587,17 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 	return &createVolReq, nil
 }
 
-func (cs *controllerServer) getExistingVolume(ctx context.Context, name, poolName string, sbclient *util.NodeNVMf, vol *csi.Volume) (*csi.Volume, error) {
+func (cs *controllerServer) getExistingVolume(ctx context.Context, name, poolName string, sbclient util.ClusterAPI, vol *csi.Volume) (*csi.Volume, error) {
 	volume, err := sbclient.GetVolume(ctx, name, poolName)
 	if err == nil {
-		vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volume.UUID)
+		vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volume.UUID)
 		klog.V(5).Info("volume already exists", vol.GetVolumeId())
 		return vol, nil
 	}
 	return nil, err
 }
 
-func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVolumeRequest, sbclient *util.NodeNVMf) (*csi.Volume, error) {
+func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVolumeRequest, sbclient util.ClusterAPI) (*csi.Volume, error) {
 	size := req.GetCapacityRange().GetRequiredBytes()
 	if size == 0 {
 		klog.Warningln("invalid volume size, resize to 1G")
@@ -645,7 +645,7 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
 	}
-	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volumeID)
+	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volumeID)
 	klog.V(5).Info("successfully created volume from Simplyblock with Volume ID: ", vol.GetVolumeId())
 
 	return &vol, nil
@@ -683,7 +683,7 @@ func getSnapshot(csiSnapshotID string) (*spdkSnapshot, error) {
 	}
 }
 
-func (cs *controllerServer) publishVolume(ctx context.Context, volumeID string, sbclient *util.NodeNVMf) (map[string]string, error) {
+func (cs *controllerServer) publishVolume(ctx context.Context, volumeID string, sbclient util.ClusterAPI) (map[string]string, error) {
 	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
 		return nil, err
@@ -939,7 +939,7 @@ func (cs *controllerServer) handleSnapshotSource(ctx context.Context, snapshot *
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
 	}
-	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volumeID)
+	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volumeID)
 	klog.V(5).Info("successfully Restored Snapshot from Simplyblock with Volume ID: ", vol.GetVolumeId())
 
 	return vol, nil
@@ -976,7 +976,7 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
 	}
-	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.Client.ClusterID, sbclient.Client.PoolID, volumeID)
+	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volumeID)
 	klog.V(5).Info("successfully created clone volume from Simplyblock with Volume ID: ", vol.GetVolumeId())
 
 	return vol, nil

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -484,20 +484,19 @@ func (g *Guardian) tick(ctx context.Context) {
 }
 
 func (g *Guardian) isClusterActiveByID(clusterID string) (ok bool, realStatus string, err error) {
-	node, err := NewsimplyBlockClient(context.Background(), clusterID, "")
+	client, err := NewsimplyBlockClient(context.Background(), clusterID, "")
 	if err != nil {
 		return false, "", err
 	}
 
 	clusterPath := fmt.Sprintf("api/v2/clusters/%s/", clusterID)
-	resp, err := node.Client.CallSBCLI(context.Background(), "GET", clusterPath, nil)
+	raw, err := client.API.do(context.Background(), "GET", clusterPath, nil)
 	if err != nil {
 		return false, "", err
 	}
 
 	var status ClusterStatus
-	data, _ := json.Marshal(resp)
-	if err := json.Unmarshal(data, &status); err != nil {
+	if err := json.Unmarshal(raw, &status); err != nil {
 		return false, "", err
 	}
 

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -104,6 +104,7 @@ var (
 	// without querying the API on every cycle.
 	maxSeenPathsMap = make(map[string]int)
 	maxSeenMu       sync.Mutex
+
 )
 
 // clusterConfig represents the Kubernetes secret structure
@@ -120,7 +121,7 @@ type ClustersInfo struct {
 // NewsimplyBlockClient creates a new Simplyblock client scoped to a cluster and optionally a pool.
 // poolIDOrName may be a pool UUID (used as-is) or a pool name (resolved via API), or empty
 // (no pool context — only cluster-level operations will work).
-func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (*NodeNVMf, error) {
+func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (*ClusterClient, error) {
 	secretFile := FromEnv("SPDKCSI_SECRET", "/etc/spdkcsi-secret/secret.json")
 	var clusters ClustersInfo
 	err := ParseJSONFile(secretFile, &clusters)
@@ -149,29 +150,36 @@ func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (
 		clusterConfig.ClusterEndpoint,
 	)
 
-	node, err := NewNVMf(clusterID, clusterConfig.ClusterEndpoint, clusterConfig.ClusterSecret)
+	conn, err := NewConnection(clusterConfig.ClusterEndpoint)
 	if err != nil {
 		return nil, err
 	}
+	c := &ClusterClient{
+		API: &APIClient{
+			ClusterID:     clusterID,
+			ClusterSecret: clusterConfig.ClusterSecret,
+			conn:          conn,
+		},
+	}
 
 	if poolIDOrName != "" {
-		poolUUID, err := resolvePoolUUID(ctx, node, poolIDOrName)
+		poolUUID, err := resolvePoolUUID(ctx, c, poolIDOrName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve pool %q: %w", poolIDOrName, err)
 		}
-		node.Client.PoolID = poolUUID
+		c.poolID = poolUUID
 	}
 
-	return node, nil
+	return c, nil
 }
 
 // resolvePoolUUID returns poolIDOrName as-is if it is already a UUID,
 // otherwise looks up the pool UUID by name via the API.
-func resolvePoolUUID(ctx context.Context, node *NodeNVMf, poolIDOrName string) (string, error) {
+func resolvePoolUUID(ctx context.Context, c *ClusterClient, poolIDOrName string) (string, error) {
 	if isUUID(poolIDOrName) {
 		return poolIDOrName, nil
 	}
-	return node.GetPoolUUIDByName(ctx, poolIDOrName)
+	return c.GetPoolUUIDByName(ctx, poolIDOrName)
 }
 
 // isUUID reports whether s is a standard UUID (8-4-4-4-12 hex, with hyphens).
@@ -274,11 +282,11 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 
 	deviceGlobOld := fmt.Sprintf(DevDiskByID, nvmf.model)
 
-	devicePath, err := waitForDeviceReady(deviceGlob, 20)
+	devicePath, err := waitForDeviceReady(ctx, deviceGlob, 20)
 	if err != nil {
 		klog.Warningf("New device symlink not found (%s). Retrying legacy format: %s", deviceGlob, deviceGlobOld)
 
-		devicePath, err = waitForDeviceReady(deviceGlobOld, 10)
+		devicePath, err = waitForDeviceReady(ctx, deviceGlobOld, 10)
 		if err != nil {
 			return "", fmt.Errorf("device not found in both new (%s) and old (%s) formats: %w",
 				deviceGlob, deviceGlobOld, err)
@@ -310,8 +318,8 @@ func (nvmf *initiatorNVMf) Disconnect(ctx context.Context) error {
 }
 
 // when timeout is set as 0, try to find the device file immediately
-// otherwise, wait for device file comes up or timeout
-func waitForDeviceReady(deviceGlob string, seconds int) (string, error) {
+// otherwise, wait for device file comes up or timeout.
+func waitForDeviceReady(ctx context.Context, deviceGlob string, seconds int) (string, error) {
 	for i := 0; i <= seconds; i++ {
 		matches, err := filepath.Glob(deviceGlob)
 		if err != nil {
@@ -321,7 +329,11 @@ func waitForDeviceReady(deviceGlob string, seconds int) (string, error) {
 		if len(matches) >= 1 {
 			return matches[0], nil
 		}
-		time.Sleep(time.Second)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
 	}
 	return "", fmt.Errorf("timed out waiting device ready: %s", deviceGlob)
 }
@@ -609,18 +621,18 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 	return nil
 }
 
-func fetchNodeInfo(ctx context.Context, spdkNode *NodeNVMf, lvolID string) (*NodeInfo, error) {
-	if err := spdkNode.Client.findPoolForVolume(ctx, lvolID); err != nil {
-		return nil, fmt.Errorf("failed to resolve pool for volume %s: %v", lvolID, err)
-	}
-	resp, err := spdkNode.Client.CallSBCLI(ctx, "GET", spdkNode.Client.v2volume(lvolID), nil)
+func fetchNodeInfo(ctx context.Context, client *ClusterClient, lvolID string) (*NodeInfo, error) {
+	poolID, err := client.poolForVolume(ctx, lvolID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch node info: %v", err)
+		return nil, fmt.Errorf("failed to resolve pool for volume %s: %w", lvolID, err)
+	}
+	raw, err := client.API.do(ctx, "GET", client.API.v2volume(poolID, lvolID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch node info: %w", err)
 	}
 	var info NodeInfo
-	respBytes, _ := json.Marshal(resp)
-	if err := json.Unmarshal(respBytes, &info); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal node info: %v", err)
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal node info: %w", err)
 	}
 	// v2 nodes field returns URL paths; extract UUIDs from last path segment
 	for i, n := range info.Nodes {
@@ -629,8 +641,8 @@ func fetchNodeInfo(ctx context.Context, spdkNode *NodeNVMf, lvolID string) (*Nod
 	return &info, nil
 }
 
-func isNodeOnline(ctx context.Context, spdkNode *NodeNVMf, nodeID string) bool {
-	status, err := spdkNode.Client.getStorageNodeStatus(ctx, nodeID)
+func isNodeOnline(ctx context.Context, client *ClusterClient, nodeID string) bool {
+	status, err := client.API.getStorageNodeStatus(ctx, nodeID)
 	if err != nil {
 		klog.Errorf("failed to fetch node status for node %s: %v", nodeID, err)
 		return false
@@ -638,13 +650,14 @@ func isNodeOnline(ctx context.Context, spdkNode *NodeNVMf, nodeID string) bool {
 	return status == "online"
 }
 
-func fetchLvolConnection(ctx context.Context, spdkNode *NodeNVMf, lvolID string, hostNQN string) ([]*LvolConnectResp, error) {
-	if err := spdkNode.Client.findPoolForVolume(ctx, lvolID); err != nil {
-		return nil, fmt.Errorf("failed to resolve pool for volume %s: %v", lvolID, err)
-	}
-	connections, err := spdkNode.Client.getLvolConnections(ctx, lvolID, hostNQN)
+func fetchLvolConnection(ctx context.Context, client *ClusterClient, lvolID string, hostNQN string) ([]*LvolConnectResp, error) {
+	poolID, err := client.poolForVolume(ctx, lvolID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch connection: %v", err)
+		return nil, fmt.Errorf("failed to resolve pool for volume %s: %w", lvolID, err)
+	}
+	connections, err := client.API.getLvolConnections(ctx, poolID, lvolID, hostNQN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch connection: %w", err)
 	}
 	if len(connections) == 0 {
 		return nil, fmt.Errorf("empty connection response for volume %s", lvolID)
@@ -831,7 +844,7 @@ func recoverPathsWithANA(clusterID, lvolID, devicePath string, activePaths []pat
 }
 
 func reconcileOptimizedPath(
-	sbcClient *NodeNVMf,
+	sbcClient *ClusterClient,
 	nodeInfo *NodeInfo,
 	devicePath string,
 	conn *LvolConnectResp,
@@ -872,7 +885,7 @@ func reconcileOptimizedPath(
 // reconcileNonOptimizedPaths handles connections[1..N] (secondary nodes).
 // Works for both 2-path (1 secondary) and 3-path (2 secondaries).
 func reconcileNonOptimizedPaths(
-	sbcClient *NodeNVMf,
+	sbcClient *ClusterClient,
 	nodeInfo *NodeInfo,
 	devicePath string,
 	conns []*LvolConnectResp,

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -31,53 +31,6 @@ import (
 	"k8s.io/klog"
 )
 
-// SpdkNode defines interface for SPDK storage node
-//
-//   - Info returns node info(rpc url) for debugging purpose
-//   - LvStores returns available volume stores(name, size, etc) on that node.
-//   - VolumeInfo returns a string map to be passed to client node. Client node
-//     needs these info to mount the target. E.g, target IP, service port, nqn.
-//   - Create/Delete/Publish/UnpublishVolume per CSI controller service spec.
-//
-// NOTE: concurrency, idempotency, message ordering
-//
-// In below text, "implementation" refers to the code implements this interface,
-// and "caller" is the code uses the implementation.
-//
-// Concurrency requirements for implementation and caller:
-//   - Implementation should make sure CreateVolume is thread
-//     safe. Caller is free to request creating multiple volumes in
-//     same volume store concurrently, no data race should happen.
-//   - Implementation should make sure
-//     PublishVolume/UnpublishVolume/DeleteVolume for *different
-//     volumes* thread safe. Caller may issue these requests to
-//     *different volumes", in same volume store or not, concurrently.
-//   - PublishVolume/UnpublishVolume/DeleteVolume for *same volume* is
-//     not thread safe, concurrent access may lead to data
-//     race. Caller must serialize these calls to *same volume*,
-//     possibly by mutex or message queue per volume.
-//   - Implementation should make sure LvStores and VolumeInfo are
-//     thread safe, but it doesn't lock the returned resources. It
-//     means caller should adopt optimistic concurrency control and
-//     retry on specific failures.  E.g, caller calls LvStores and
-//     finds a volume store with enough free space, it calls
-//     CreateVolume but fails with "not enough space" because another
-//     caller may issue similar request at same time. The failed
-//     caller may redo above steps(call LvStores, pick volume store,
-//     CreateVolume) under this condition, or it can simply fail.
-//
-// Idempotent requirements for implementation:
-// Per CSI spec, it's possible that same request been sent multiple times due to
-// issues such as a temporary network failure. Implementation should have basic
-// logic to deal with idempotency.
-// E.g, ignore publishing an already published volume.
-//
-// Out of order messages handling for implementation:
-// Out of order message may happen in kubernetes CSI framework. E.g, unpublish
-// an already deleted volume. The baseline is there should be no code crash or
-// data corruption under these conditions. Implementation may try to detect and
-// report errors if possible.
-
 // errors deserve special care
 var (
 	ErrJSONNoSpaceLeft  = errors.New("json: No space left")
@@ -88,25 +41,49 @@ var (
 	ErrVolumeUnpublished = errors.New("volume not published")
 )
 
-type SpdkNode interface {
+// ClusterAPI is the interface through which the CSI driver manages volumes,
+// snapshots, and storage pools on a SimplyBlock cluster.
+//
+// Concurrency: CreateVolume is safe for concurrent calls. Publish/Unpublish/Delete
+// for different volumes are safe concurrently; for the same volume they must be
+// serialised by the caller.
+//
+// Idempotency: implementations must tolerate duplicate CSI requests (e.g. double
+// publish) as required by the CSI spec.
+type ClusterAPI interface {
+	// Identity
 	Info() string
-	LvStores() ([]LvStore, error)
-	VolumeInfo(lvolID string, hostNQN string) (map[string]string, error)
-	CreateVolume(lvolName, lvsName string, sizeMiB int64) (string, error)
-	GetVolume(lvolName, lvsName string) (string, error)
-	DeleteVolume(lvolID string) error
-	PublishVolume(lvolID string) error
-	UnpublishVolume(lvolID string) error
-	CreateSnapshot(lvolName, snapshotName string) (string, error)
-	DeleteSnapshot(snapshotID string) error
+	ClusterID() string
+	PoolID() string
+
+	// Storage pools
+	ListStoragePools(ctx context.Context) ([]StoragePool, error)
+	GetPoolUUIDByName(ctx context.Context, poolName string) (string, error)
+	GetMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error)
+
+	// Volumes
+	CreateVolume(ctx context.Context, params *CreateLVolData) (string, error)
+	GetVolume(ctx context.Context, lvolName, poolName string) (*LvolResp, error)
+	GetVolumeSize(ctx context.Context, lvolID string) (string, error)
+	ListVolumes(ctx context.Context) ([]*LvolResp, error)
+	ResizeVolume(ctx context.Context, lvolID string, newSize int64) (bool, error)
+	DeleteVolume(ctx context.Context, lvolID string) error
+	PublishVolume(ctx context.Context, lvolID string) error
+	UnpublishVolume(ctx context.Context, lvolID string) error
+	VolumeInfo(ctx context.Context, lvolID string, hostNQN string) (map[string]string, error)
+	CloneVolume(ctx context.Context, lvolID, cloneName, newSize, pvcName string) (string, error)
+
+	// Snapshots
+	CreateSnapshot(ctx context.Context, lvolID, snapshotName string) (string, error)
+	ListSnapshots(ctx context.Context) ([]*SnapshotResp, error)
+	DeleteSnapshot(ctx context.Context, snapshotID string) error
+	CloneSnapshot(ctx context.Context, snapshotID, cloneName, newSize, pvcName string) (string, error)
 }
 
-// logical volume store
-type LvStore struct {
-	Name         string
-	UUID         string
-	TotalSizeMiB int64
-	FreeSizeMiB  int64
+// StoragePool represents a SimplyBlock storage pool returned by the cluster API.
+type StoragePool struct {
+	Name string `json:"name"`
+	UUID string `json:"id"`
 }
 
 type LvolConnectResp struct {
@@ -135,24 +112,25 @@ type LvolResp struct {
 	Status   string `json:"status"`
 }
 
-// RPCClient holds the connection information to the SimplyBlock Cluster
-type RPCClient struct {
+// Connection holds the shared HTTP transport to a webappapi service.
+// One Connection serves multiple clusters that share the same endpoint.
+type Connection struct {
+	Endpoint string
+	HTTP     *http.Client
+}
+
+// APIClient is cluster-scoped: it carries the credentials for one cluster
+// and borrows a Connection to reach the webappapi service.
+// It is immutable after construction; pool scoping is handled by the caller.
+type APIClient struct {
 	ClusterID     string
-	PoolID        string
-	ClusterIP     string
 	ClusterSecret string
-	HTTPClient    *http.Client
+	conn          *Connection
 }
 
 // ClusterStatus is a partial view of the GET /clusters/{id}/ response in v2.
 type ClusterStatus struct {
 	Status string `json:"status"`
-}
-
-// CSIPoolsResp is the response of GET /storage-pools/ — field tags match v2 StoragePoolDTO
-type CSIPoolsResp struct {
-	Name string `json:"name"`
-	UUID string `json:"id"`
 }
 
 // SnapshotResp is the response of GET /snapshots/ — field tags match v2 SnapshotDTO
@@ -192,105 +170,90 @@ type MasterLvol struct {
 	MaxNamespaces int    `json:"MaxNamespaces"`
 }
 
-func (client *RPCClient) info() string {
+func (client APIClient) info() string {
 	return client.ClusterID
 }
 
 // --- v2 URL path helpers ---
 
-func (client *RPCClient) v2pools() string {
-	return fmt.Sprintf("api/v2/clusters/%s/storage-pools", client.ClusterID)
+func (client APIClient) v2pools() string {
+	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/", client.ClusterID)
 }
 
-func (client *RPCClient) v2pool(poolID string) string {
+func (client APIClient) v2pool(poolID string) string {
 	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s", client.ClusterID, poolID)
 }
 
-func (client *RPCClient) v2volumes() string {
-	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/volumes", client.ClusterID, client.PoolID)
+func (client APIClient) v2volumes(poolID string) string {
+	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/volumes/", client.ClusterID, poolID)
 }
 
-func (client *RPCClient) v2volume(volumeID string) string {
-	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/volumes/%s/", client.ClusterID, client.PoolID, volumeID)
+func (client APIClient) v2volume(poolID, volumeID string) string {
+	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/volumes/%s/", client.ClusterID, poolID, volumeID)
 }
 
-func (client *RPCClient) v2snapshots() string {
-	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/snapshots", client.ClusterID, client.PoolID)
+func (client APIClient) v2snapshots(poolID string) string {
+	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/snapshots/", client.ClusterID, poolID)
 }
 
-func (client *RPCClient) v2snapshot(snapshotID string) string {
-	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/snapshots/%s/", client.ClusterID, client.PoolID, snapshotID)
+func (client APIClient) v2snapshot(poolID, snapshotID string) string {
+	return fmt.Sprintf("api/v2/clusters/%s/storage-pools/%s/snapshots/%s/", client.ClusterID, poolID, snapshotID)
 }
 
-func (client *RPCClient) v2storageNode(nodeID string) string {
+func (client APIClient) v2storageNode(nodeID string) string {
 	return fmt.Sprintf("api/v2/clusters/%s/storage-nodes/%s/", client.ClusterID, nodeID)
 }
 
 // --- API methods ---
 
-// lvStores returns all available storage pools
-func (client *RPCClient) lvStores(ctx context.Context) ([]LvStore, error) {
-	out, err := client.CallSBCLI(ctx, "GET", client.v2pools()+"/", nil)
+// listStoragePools returns all available storage pools
+func (client APIClient) listStoragePools(ctx context.Context) ([]StoragePool, error) {
+	raw, err := client.do(ctx, "GET", client.v2pools(), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal pools response: %w", err)
-	}
-	var result []CSIPoolsResp
-	if err := json.Unmarshal(b, &result); err != nil {
+	var result []StoragePool
+	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal pools response: %w", err)
 	}
-
-	lvs := make([]LvStore, len(result))
-	for i := range result {
-		lvs[i].Name = result[i].Name
-		lvs[i].UUID = result[i].UUID
-	}
-	return lvs, nil
+	return result, nil
 }
 
 // createVolume creates a logical volume and returns its UUID
-func (client *RPCClient) createVolume(ctx context.Context, params *CreateLVolData) (string, error) {
-	out, err := client.CallSBCLI(ctx, "POST", client.v2volumes()+"/", params)
+func (client APIClient) createVolume(ctx context.Context, poolID string, params *CreateLVolData) (string, error) {
+	raw, err := client.do(ctx, "POST", client.v2volumes(poolID), params)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
 		}
 		return "", err
 	}
-	lvolID, ok := out.(string)
-	if !ok {
-		return "", fmt.Errorf("unexpected response for createVolume: %T %v", out, out)
+	var lvolID string
+	if err := json.Unmarshal(raw, &lvolID); err != nil {
+		return "", fmt.Errorf("unexpected response for createVolume: %w", err)
 	}
 	return lvolID, nil
 }
 
 // getVolumeByUUID fetches a single volume by its UUID
-func (client *RPCClient) getVolumeByUUID(ctx context.Context, lvolID string) (*LvolResp, error) {
-	out, err := client.CallSBCLI(ctx, "GET", client.v2volume(lvolID), nil)
+func (client APIClient) getVolumeByUUID(ctx context.Context, poolID, lvolID string) (*LvolResp, error) {
+	raw, err := client.do(ctx, "GET", client.v2volume(poolID, lvolID), nil)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSuchDevice) {
 			err = ErrJSONNoSuchDevice
 		}
 		return nil, err
 	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal volume response: %w", err)
-	}
 	var result LvolResp
-	if err := json.Unmarshal(b, &result); err != nil {
+	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal volume response: %w", err)
 	}
 	return &result, nil
 }
 
 // getVolumeByName lists all volumes in the pool and returns the one with matching name
-func (client *RPCClient) getVolumeByName(ctx context.Context, name string) (*LvolResp, error) {
-	volumes, err := client.listVolumes(ctx)
+func (client APIClient) getVolumeByName(ctx context.Context, poolID, name string) (*LvolResp, error) {
+	volumes, err := client.listVolumes(ctx, poolID)
 	if err != nil {
 		return nil, err
 	}
@@ -303,35 +266,31 @@ func (client *RPCClient) getVolumeByName(ctx context.Context, name string) (*Lvo
 }
 
 // getVolume accepts either a UUID or a "poolName/volName" path (legacy callers)
-func (client *RPCClient) getVolume(ctx context.Context, lvolIDOrPath string) (*LvolResp, error) {
+func (client APIClient) getVolume(ctx context.Context, poolID, lvolIDOrPath string) (*LvolResp, error) {
 	if strings.Contains(lvolIDOrPath, "/") {
 		// "poolName/volName" — extract the volume name and search by name
 		parts := strings.SplitN(lvolIDOrPath, "/", 2)
-		return client.getVolumeByName(ctx, parts[1])
+		return client.getVolumeByName(ctx, poolID, parts[1])
 	}
-	return client.getVolumeByUUID(ctx, lvolIDOrPath)
+	return client.getVolumeByUUID(ctx, poolID, lvolIDOrPath)
 }
 
 // listVolumes returns all volumes in the pool
-func (client *RPCClient) listVolumes(ctx context.Context) ([]*LvolResp, error) {
-	out, err := client.CallSBCLI(ctx, "GET", client.v2volumes()+"/", nil)
+func (client APIClient) listVolumes(ctx context.Context, poolID string) ([]*LvolResp, error) {
+	raw, err := client.do(ctx, "GET", client.v2volumes(poolID), nil)
 	if err != nil {
 		return nil, err
 	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal volumes response: %w", err)
-	}
 	var results []*LvolResp
-	if err := json.Unmarshal(b, &results); err != nil {
+	if err := json.Unmarshal(raw, &results); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal volumes response: %w", err)
 	}
 	return results, nil
 }
 
-// getVolumeInfo returns the NVMe connection info for a volume as a CSI VolumeContext map.
-func (client *RPCClient) getVolumeInfo(ctx context.Context, lvolID string, hostNQN string) (map[string]string, error) {
-	result, err := client.getLvolConnections(ctx, lvolID, hostNQN)
+// getVolumeInfo returns the NVMe connection info for a volume
+func (client APIClient) getVolumeInfo(ctx context.Context, poolID, lvolID, hostNQN string) (map[string]string, error) {
+	result, err := client.getLvolConnections(ctx, poolID, lvolID, hostNQN)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSuchDevice) {
 			err = ErrJSONNoSuchDevice
@@ -368,8 +327,8 @@ func (client *RPCClient) getVolumeInfo(ctx context.Context, lvolID string, hostN
 }
 
 // deleteVolume deletes a volume by UUID
-func (client *RPCClient) deleteVolume(ctx context.Context, lvolID string) error {
-	_, err := client.CallSBCLI(ctx, "DELETE", client.v2volume(lvolID), nil)
+func (client APIClient) deleteVolume(ctx context.Context, poolID, lvolID string) error {
+	_, err := client.do(ctx, "DELETE", client.v2volume(poolID, lvolID), nil)
 	if errorMatches(err, ErrJSONNoSuchDevice) {
 		err = ErrJSONNoSuchDevice
 	}
@@ -377,8 +336,8 @@ func (client *RPCClient) deleteVolume(ctx context.Context, lvolID string) error 
 }
 
 // getPoolUUIDByName resolves a pool name to its UUID
-func (client *RPCClient) getPoolUUIDByName(ctx context.Context, poolName string) (string, error) {
-	pools, err := client.lvStores(ctx)
+func (client APIClient) getPoolUUIDByName(ctx context.Context, poolName string) (string, error) {
+	pools, err := client.listStoragePools(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -391,21 +350,17 @@ func (client *RPCClient) getPoolUUIDByName(ctx context.Context, poolName string)
 }
 
 // getMasterLvols returns master lvols for a pool
-func (client *RPCClient) getMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error) {
+func (client APIClient) getMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error) {
 	path := client.v2pool(poolUUID) + "/master-lvols"
-	out, err := client.CallSBCLI(ctx, "GET", path, nil)
+	raw, err := client.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
-	if out == nil {
+	if raw == nil {
 		return []MasterLvol{}, nil
 	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal master lvols response: %w", err)
-	}
 	var result []MasterLvol
-	if err := json.Unmarshal(b, &result); err != nil {
+	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal master lvols response: %w", err)
 	}
 	if result == nil {
@@ -415,8 +370,8 @@ func (client *RPCClient) getMasterLvols(ctx context.Context, poolUUID string) ([
 }
 
 // resizeVolume resizes a volume
-func (client *RPCClient) resizeVolume(ctx context.Context, lvolID string, size int64) (bool, error) {
-	_, err := client.CallSBCLI(ctx, "PUT", client.v2volume(lvolID), &ResizeVolReq{Size: size})
+func (client APIClient) resizeVolume(ctx context.Context, poolID, lvolID string, size int64) (bool, error) {
+	_, err := client.do(ctx, "PUT", client.v2volume(poolID, lvolID), &ResizeVolReq{Size: size})
 	if err != nil {
 		return false, err
 	}
@@ -424,8 +379,8 @@ func (client *RPCClient) resizeVolume(ctx context.Context, lvolID string, size i
 }
 
 // cloneVolume clones a volume by UUID, returning the new volume's UUID
-func (client *RPCClient) cloneVolume(ctx context.Context, lvolID, cloneName, newSize, pvcName string) (string, error) {
-	path := client.v2volume(lvolID) + "clone?clone_name=" + url.QueryEscape(cloneName)
+func (client APIClient) cloneVolume(ctx context.Context, poolID, lvolID, cloneName, newSize, pvcName string) (string, error) {
+	path := client.v2volume(poolID, lvolID) + "clone?clone_name=" + url.QueryEscape(cloneName)
 	if newSize != "" {
 		path += "&new_size=" + url.QueryEscape(newSize)
 	}
@@ -435,22 +390,22 @@ func (client *RPCClient) cloneVolume(ctx context.Context, lvolID, cloneName, new
 
 	klog.V(5).Infof("cloneVolume size: %s", newSize)
 
-	out, err := client.CallSBCLI(ctx, "POST", path, nil)
+	raw, err := client.do(ctx, "POST", path, nil)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
 		}
 		return "", err
 	}
-	lvID, ok := out.(string)
-	if !ok {
-		return "", fmt.Errorf("unexpected response for cloneVolume: %T %v", out, out)
+	var lvID string
+	if err := json.Unmarshal(raw, &lvID); err != nil {
+		return "", fmt.Errorf("unexpected response for cloneVolume: %w", err)
 	}
 	return lvID, nil
 }
 
 // cloneSnapshot creates a new volume from a snapshot, returning the new volume's UUID
-func (client *RPCClient) cloneSnapshot(ctx context.Context, snapshotID, cloneName, newSize, pvcName string) (string, error) {
+func (client APIClient) cloneSnapshot(ctx context.Context, poolID, snapshotID, cloneName, newSize, pvcName string) (string, error) {
 	params := struct {
 		Name       string `json:"name"`
 		SnapshotID string `json:"snapshot_id"`
@@ -465,51 +420,43 @@ func (client *RPCClient) cloneSnapshot(ctx context.Context, snapshotID, cloneNam
 
 	klog.V(5).Infof("cloneSnapshot size: %s", newSize)
 
-	out, err := client.CallSBCLI(ctx, "POST", client.v2volumes()+"/", &params)
+	raw, err := client.do(ctx, "POST", client.v2volumes(poolID), &params)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
 		}
 		return "", err
 	}
-	lvolID, ok := out.(string)
-	if !ok {
-		return "", fmt.Errorf("unexpected response for cloneSnapshot: %T %v", out, out)
+	var lvolID string
+	if err := json.Unmarshal(raw, &lvolID); err != nil {
+		return "", fmt.Errorf("unexpected response for cloneSnapshot: %w", err)
 	}
 	return lvolID, nil
 }
 
 // listSnapshots returns all snapshots in the pool
-func (client *RPCClient) listSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
-	out, err := client.CallSBCLI(ctx, "GET", client.v2snapshots()+"/", nil)
+func (client APIClient) listSnapshots(ctx context.Context, poolID string) ([]*SnapshotResp, error) {
+	raw, err := client.do(ctx, "GET", client.v2snapshots(poolID), nil)
 	if err != nil {
 		return nil, err
 	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal snapshots response: %w", err)
-	}
 	var results []*SnapshotResp
-	if err := json.Unmarshal(b, &results); err != nil {
+	if err := json.Unmarshal(raw, &results); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal snapshots response: %w", err)
 	}
 	return results, nil
 }
 
 // listAllSnapshots iterates every pool in the cluster and collects all snapshots.
-// Used when PoolID is not set (e.g. ListSnapshots CSI RPC).
-func (client *RPCClient) listAllSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
-	pools, err := client.lvStores(ctx)
+// Used when no pool is set (e.g. ListSnapshots CSI RPC).
+func (client APIClient) listAllSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
+	pools, err := client.listStoragePools(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var all []*SnapshotResp
-	savedPool := client.PoolID
-	defer func() { client.PoolID = savedPool }()
-
 	for _, pool := range pools {
-		client.PoolID = pool.UUID
-		snaps, err := client.listSnapshots(ctx)
+		snaps, err := client.listSnapshots(ctx, pool.UUID)
 		if err != nil {
 			return nil, err
 		}
@@ -523,33 +470,33 @@ func (client *RPCClient) listAllSnapshots(ctx context.Context) ([]*SnapshotResp,
 }
 
 // snapshot creates a snapshot of a volume and returns the snapshot UUID
-func (client *RPCClient) snapshot(ctx context.Context, lvolID, snapShotName string) (string, error) {
+func (client APIClient) snapshot(ctx context.Context, poolID, lvolID, snapShotName string) (string, error) {
 	params := struct {
 		Name string `json:"name"`
 	}{Name: snapShotName}
 
-	path := client.v2volume(lvolID) + "snapshots"
-	out, err := client.CallSBCLI(ctx, "POST", path, &params)
+	path := client.v2volume(poolID, lvolID) + "snapshots"
+	raw, err := client.do(ctx, "POST", path, &params)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
 		}
 		return "", err
 	}
-	snapshotID, ok := out.(string)
-	if !ok {
-		return "", fmt.Errorf("unexpected response for snapshot: %T %v", out, out)
+	var snapshotID string
+	if err := json.Unmarshal(raw, &snapshotID); err != nil {
+		return "", fmt.Errorf("unexpected response for snapshot: %w", err)
 	}
 	return snapshotID, nil
 }
 
 // deleteSnapshot deletes a snapshot.
-// If PoolID is not set (legacy 2-part snapshot IDs), it scans all pools.
-func (client *RPCClient) deleteSnapshot(ctx context.Context, snapshotID string) error {
-	if client.PoolID == "" {
+// If poolID is empty (legacy 2-part snapshot IDs), it scans all pools.
+func (client APIClient) deleteSnapshot(ctx context.Context, poolID, snapshotID string) error {
+	if poolID == "" {
 		return client.deleteSnapshotScanPools(ctx, snapshotID)
 	}
-	_, err := client.CallSBCLI(ctx, "DELETE", client.v2snapshot(snapshotID), nil)
+	_, err := client.do(ctx, "DELETE", client.v2snapshot(poolID, snapshotID), nil)
 	if errorMatches(err, ErrJSONNoSuchDevice) {
 		err = ErrJSONNoSuchDevice
 	}
@@ -558,17 +505,13 @@ func (client *RPCClient) deleteSnapshot(ctx context.Context, snapshotID string) 
 
 // deleteSnapshotScanPools finds a snapshot across all pools and deletes it.
 // Used for backward compat with legacy 2-part CSI snapshot IDs that have no pool info.
-func (client *RPCClient) deleteSnapshotScanPools(ctx context.Context, snapshotID string) error {
-	pools, err := client.lvStores(ctx)
+func (client APIClient) deleteSnapshotScanPools(ctx context.Context, snapshotID string) error {
+	pools, err := client.listStoragePools(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list pools while deleting snapshot %s: %w", snapshotID, err)
 	}
-	savedPool := client.PoolID
-	defer func() { client.PoolID = savedPool }()
-
 	for _, pool := range pools {
-		client.PoolID = pool.UUID
-		_, err := client.CallSBCLI(ctx, "DELETE", client.v2snapshot(snapshotID), nil)
+		_, err := client.do(ctx, "DELETE", client.v2snapshot(pool.UUID, snapshotID), nil)
 		if err == nil {
 			return nil
 		}
@@ -579,85 +522,78 @@ func (client *RPCClient) deleteSnapshotScanPools(ctx context.Context, snapshotID
 	return fmt.Errorf("snapshot %s not found in any pool", snapshotID)
 }
 
-// findPoolForVolume scans all pools to find the one containing the given volume UUID,
-// then sets client.PoolID. No-op if PoolID is already set.
-func (client *RPCClient) findPoolForVolume(ctx context.Context, lvolID string) error {
-	if client.PoolID != "" {
-		return nil
-	}
-	pools, err := client.lvStores(ctx)
+// findPoolForVolume scans all storage pools to find which one contains the given
+// volume UUID, and returns that pool's UUID. Returns an error if not found.
+func (client APIClient) findPoolForVolume(ctx context.Context, lvolID string) (string, error) {
+	pools, err := client.listStoragePools(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to list pools while resolving pool for volume %s: %w", lvolID, err)
+		return "", fmt.Errorf("failed to list pools for volume %s: %w", lvolID, err)
 	}
 	for _, pool := range pools {
-		client.PoolID = pool.UUID
-		_, err := client.getVolumeByUUID(ctx, lvolID)
+		_, err := client.getVolumeByUUID(ctx, pool.UUID, lvolID)
 		if err == nil {
-			return nil
+			return pool.UUID, nil
 		}
 		if !errorMatches(err, ErrJSONNoSuchDevice) && !strings.Contains(err.Error(), "404") {
-			client.PoolID = ""
-			return fmt.Errorf("unexpected error searching for volume %s in pool %s: %w", lvolID, pool.UUID, err)
+			return "", fmt.Errorf("unexpected error searching for volume %s in pool %s: %w", lvolID, pool.UUID, err)
 		}
 	}
-	client.PoolID = ""
-	return fmt.Errorf("volume %s not found in any pool", lvolID)
+	return "", fmt.Errorf("volume %s not found in any pool", lvolID)
 }
 
 // getLvolConnections returns the raw NVMe-oF connection list for a volume.
-func (client *RPCClient) getLvolConnections(ctx context.Context, lvolID, hostNQN string) ([]*LvolConnectResp, error) {
-	path := client.v2volume(lvolID) + "connect"
+func (client APIClient) getLvolConnections(ctx context.Context, poolID, lvolID, hostNQN string) ([]*LvolConnectResp, error) {
+	path := client.v2volume(poolID, lvolID) + "connect"
 	if hostNQN != "" {
 		path += "?host_nqn=" + url.QueryEscape(hostNQN)
 	}
-	out, err := client.CallSBCLI(ctx, "GET", path, nil)
+	raw, err := client.do(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal connections response: %w", err)
-	}
 	var result []*LvolConnectResp
-	if err := json.Unmarshal(b, &result); err != nil {
+	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal connections response: %w", err)
 	}
 	return result, nil
 }
 
 // getStorageNodeStatus returns the status string for a storage node by UUID.
-func (client *RPCClient) getStorageNodeStatus(ctx context.Context, nodeID string) (string, error) {
-	out, err := client.CallSBCLI(ctx, "GET", client.v2storageNode(nodeID), nil)
+func (client APIClient) getStorageNodeStatus(ctx context.Context, nodeID string) (string, error) {
+	raw, err := client.do(ctx, "GET", client.v2storageNode(nodeID), nil)
 	if err != nil {
 		return "", err
-	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal node status response: %w", err)
 	}
 	var resp struct {
 		Status string `json:"status"`
 	}
-	if err := json.Unmarshal(b, &resp); err != nil {
+	if err := json.Unmarshal(raw, &resp); err != nil {
 		return "", fmt.Errorf("failed to unmarshal node status response: %w", err)
 	}
 	return resp.Status, nil
 }
 
-// CallSBCLI is a generic function to call the SimplyBlock API v2
-func (client *RPCClient) CallSBCLI(ctx context.Context, method, path string, args interface{}) (interface{}, error) {
+// do executes an HTTP request against the SimplyBlock API and returns the raw
+// JSON response body. Callers unmarshal directly into their typed structs.
+//
+// Response handling:
+//   - 204 No Content → (nil, nil)
+//   - 201 Created    → UUID extracted from Location header, encoded as a JSON string
+//   - 2xx            → raw JSON body
+//   - 4xx/5xx        → error with extracted message
+func (client APIClient) do(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
 	path = strings.TrimLeft(path, "/")
 
 	var bodyReader io.Reader
-	if args != nil {
-		data, err := json.Marshal(args)
+	if body != nil {
+		data, err := json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", method, err)
 		}
 		bodyReader = bytes.NewReader(data)
 	}
 
-	requestURL := fmt.Sprintf("%s/%s", client.ClusterIP, path)
+	requestURL := fmt.Sprintf("%s/%s", client.conn.Endpoint, path)
 	klog.Infof("Calling Simplyblock API v2: %s %s", method, requestURL)
 
 	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
@@ -666,11 +602,11 @@ func (client *RPCClient) CallSBCLI(ctx context.Context, method, path string, arg
 	}
 
 	req.Header.Set("Authorization", client.authorizationHeader(path))
-	if args != nil {
+	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := client.HTTPClient.Do(req)
+	resp, err := client.conn.HTTP.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", method, err)
 	}
@@ -681,36 +617,33 @@ func (client *RPCClient) CallSBCLI(ctx context.Context, method, path string, arg
 		return nil, nil
 	}
 
-	// 201 Created — return the UUID extracted from the Location header
+	// 201 Created — return the UUID extracted from the Location header, encoded as a JSON string
 	if resp.StatusCode == http.StatusCreated {
 		location := resp.Header.Get("Location")
 		if location == "" {
 			return nil, fmt.Errorf("%s: 201 response missing Location header", method)
 		}
-		return locationToUUID(location), nil
+		encoded, _ := json.Marshal(locationToUUID(location))
+		return json.RawMessage(encoded), nil
 	}
 
-	body, readErr := io.ReadAll(resp.Body)
+	raw, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return nil, fmt.Errorf("%s: failed to read response body: %w", method, readErr)
 	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		msg := extractErrorMessage(body)
+		msg := extractErrorMessage(raw)
 		if msg == "" {
 			msg = http.StatusText(resp.StatusCode)
 		}
 		return nil, fmt.Errorf("%s: %s", method, msg)
 	}
 
-	var result interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("%s: failed to decode response: %w", method, err)
-	}
-	return result, nil
+	return json.RawMessage(raw), nil
 }
 
-func (client *RPCClient) authorizationHeader(path string) string {
+func (client APIClient) authorizationHeader(path string) string {
 	if strings.HasPrefix(path, "api/v2/") {
 		return "Bearer " + client.ClusterSecret
 	}
@@ -731,8 +664,8 @@ func locationToUUID(location string) string {
 // extractErrorMessage pulls a human-readable message from a FastAPI error response body.
 func extractErrorMessage(body []byte) string {
 	var resp struct {
-		Detail interface{} `json:"detail"`
-		Error  string      `json:"error"`
+		Detail any    `json:"detail"`
+		Error  string `json:"error"`
 	}
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return string(body)

--- a/pkg/util/jsonrpc_test.go
+++ b/pkg/util/jsonrpc_test.go
@@ -8,40 +8,44 @@ import (
 	"testing"
 )
 
-func TestCallSBCLIUsesBearerAuthForAPIV2(t *testing.T) {
+func TestDoUsesBearerAuthForAPIV2(t *testing.T) {
 	var gotAuth string
-	client := &RPCClient{
+	client := &APIClient{
 		ClusterID:     "cluster-id",
-		ClusterIP:     "http://api.example.com",
 		ClusterSecret: "cluster-secret",
-		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			gotAuth = r.Header.Get("Authorization")
-			return jsonResponse(), nil
-		})},
+		conn: &Connection{
+			Endpoint: "http://api.example.com",
+			HTTP: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				gotAuth = r.Header.Get("Authorization")
+				return jsonResponse(), nil
+			})},
+		},
 	}
 
-	if _, err := client.CallSBCLI(context.Background(), http.MethodGet, "/api/v2/clusters/cluster-id/storage-pools/", nil); err != nil {
-		t.Fatalf("CallSBCLI: %v", err)
+	if _, err := client.do(context.Background(), http.MethodGet, "/api/v2/clusters/cluster-id/storage-pools/", nil); err != nil {
+		t.Fatalf("do: %v", err)
 	}
 	if gotAuth != "Bearer cluster-secret" {
 		t.Fatalf("Authorization = %q, want Bearer cluster-secret", gotAuth)
 	}
 }
 
-func TestCallSBCLIUsesLegacyAuthOutsideAPIV2(t *testing.T) {
+func TestDoUsesLegacyAuthOutsideAPIV2(t *testing.T) {
 	var gotAuth string
-	client := &RPCClient{
+	client := &APIClient{
 		ClusterID:     "cluster-id",
-		ClusterIP:     "http://api.example.com",
 		ClusterSecret: "cluster-secret",
-		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			gotAuth = r.Header.Get("Authorization")
-			return jsonResponse(), nil
-		})},
+		conn: &Connection{
+			Endpoint: "http://api.example.com",
+			HTTP: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				gotAuth = r.Header.Get("Authorization")
+				return jsonResponse(), nil
+			})},
+		},
 	}
 
-	if _, err := client.CallSBCLI(context.Background(), http.MethodGet, "/lvol/lvol-id", nil); err != nil {
-		t.Fatalf("CallSBCLI: %v", err)
+	if _, err := client.do(context.Background(), http.MethodGet, "/lvol/lvol-id", nil); err != nil {
+		t.Fatalf("do: %v", err)
 	}
 	if gotAuth != "cluster-id cluster-secret" {
 		t.Fatalf("Authorization = %q, want cluster-id cluster-secret", gotAuth)
@@ -52,26 +56,27 @@ func TestCloneVolumeUsesPostAndLocationHeader(t *testing.T) {
 	var gotMethod string
 	var gotPath string
 	var gotQuery string
-	client := &RPCClient{
+	client := &APIClient{
 		ClusterID:     "cluster-id",
-		PoolID:        "pool-id",
-		ClusterIP:     "http://api.example.com",
 		ClusterSecret: "cluster-secret",
-		HTTPClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			gotMethod = r.Method
-			gotPath = r.URL.Path
-			gotQuery = r.URL.RawQuery
-			return &http.Response{
-				StatusCode: http.StatusCreated,
-				Body:       io.NopCloser(strings.NewReader("")),
-				Header: http.Header{
-					"Location": []string{"/api/v2/clusters/cluster-id/storage-pools/pool-id/volumes/clone-id/"},
-				},
-			}, nil
-		})},
+		conn: &Connection{
+			Endpoint: "http://api.example.com",
+			HTTP: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				gotQuery = r.URL.RawQuery
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Header: http.Header{
+						"Location": []string{"/api/v2/clusters/cluster-id/storage-pools/pool-id/volumes/clone-id/"},
+					},
+				}, nil
+			})},
+		},
 	}
 
-	cloneID, err := client.cloneVolume(context.Background(), "source-id", "clone name", "1073741824", "default/my-pvc")
+	cloneID, err := client.cloneVolume(context.Background(), "pool-id", "source-id", "clone name", "1073741824", "default/my-pvc")
 	if err != nil {
 		t.Fatalf("cloneVolume: %v", err)
 	}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -93,15 +93,33 @@ func tlsServerName(clusterIP string) string {
 	return fmt.Sprintf("%s.%s.svc", host, strings.TrimSpace(string(ns)))
 }
 
-type NodeNVMf struct {
-	Client *RPCClient
+type ClusterClient struct {
+	API    *APIClient
+	poolID string // pool scope for this client; empty means cluster-level only
 }
 
-// NewNVMf creates a new NVMf client. The HTTP transport is selected by the
-// SB_TLS_CONNECT environment variable: "disabled" (or unset) uses plain HTTP;
-// "anonymous" uses HTTPS validated against SB_TLS_CERTIFICATE_AUTHORITY;
-// "authenticated" adds a client cert/key from SB_TLS_CERTIFICATE / SB_TLS_KEY.
-func NewNVMf(clusterID, clusterIP, clusterSecret string) (*NodeNVMf, error) {
+func (c *ClusterClient) ClusterID() string { return c.API.ClusterID }
+func (c *ClusterClient) PoolID() string    { return c.poolID }
+
+// poolForVolume returns the pool ID for lvolID. If this client is already
+// scoped to a pool, that pool ID is returned immediately. Otherwise all pools
+// are scanned to locate the volume.
+func (c *ClusterClient) poolForVolume(ctx context.Context, lvolID string) (string, error) {
+	if c.poolID != "" {
+		return c.poolID, nil
+	}
+	return c.API.findPoolForVolume(ctx, lvolID)
+}
+
+// NewConnection builds a shared HTTP connection to a webappapi endpoint.
+// TLS is configured from environment variables:
+//   - SB_TLS_CONNECT: "disabled" (default), "anonymous", or "authenticated"
+//   - SB_TLS_CERTIFICATE_AUTHORITY: path to CA bundle
+//   - SB_TLS_CERTIFICATE / SB_TLS_KEY: client cert/key for authenticated mode
+//
+// The returned Connection may be shared across multiple APIClients that
+// all reach the same webappapi service.
+func NewConnection(endpoint string) (*Connection, error) {
 	mode, err := parseTLSMode(os.Getenv(envTLSConnect))
 	if err != nil {
 		return nil, err
@@ -119,8 +137,8 @@ func NewNVMf(clusterID, clusterIP, clusterSecret string) (*NodeNVMf, error) {
 			return nil, fmt.Errorf("no certificates parsed from TLS CA %s", caFile)
 		}
 
-		clusterIP = strings.Replace(clusterIP, "http://", "https://", 1)
-		tlsCfg := &tls.Config{RootCAs: pool, ServerName: tlsServerName(clusterIP)}
+		endpoint = strings.Replace(endpoint, "http://", "https://", 1)
+		tlsCfg := &tls.Config{RootCAs: pool, ServerName: tlsServerName(endpoint)}
 
 		if mode == tlsAuthenticated {
 			certFile := envOr(envTLSCert, defaultTLSCert)
@@ -135,28 +153,42 @@ func NewNVMf(clusterID, clusterIP, clusterSecret string) (*NodeNVMf, error) {
 		transport = &http.Transport{TLSClientConfig: tlsCfg}
 	}
 
-	client := RPCClient{
-		HTTPClient:    &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second, Transport: transport},
-		ClusterID:     clusterID,
-		ClusterIP:     clusterIP,
-		ClusterSecret: clusterSecret,
+	return &Connection{
+		Endpoint: endpoint,
+		HTTP:     &http.Client{Timeout: cfgRPCTimeoutSeconds * time.Second, Transport: transport},
+	}, nil
+}
+
+// NewClusterClient creates a cluster-scoped API client.
+// It builds a Connection to the webappapi endpoint and binds it to the
+// given cluster credentials. For clusters that share an endpoint, prefer
+// building one Connection via NewConnection and constructing APIClient directly.
+func NewClusterClient(clusterID, endpoint, clusterSecret string) (*ClusterClient, error) {
+	conn, err := NewConnection(endpoint)
+	if err != nil {
+		return nil, err
 	}
-	return &NodeNVMf{Client: &client}, nil
+	client := APIClient{
+		ClusterID:     clusterID,
+		ClusterSecret: clusterSecret,
+		conn:          conn,
+	}
+	return &ClusterClient{API: &client}, nil
 }
 
-func (node *NodeNVMf) Info() string {
-	return node.Client.info()
+func (c *ClusterClient) Info() string {
+	return c.API.info()
 }
 
-func (node *NodeNVMf) LvStores(ctx context.Context) ([]LvStore, error) {
-	return node.Client.lvStores(ctx)
+func (c *ClusterClient) ListStoragePools(ctx context.Context) ([]StoragePool, error) {
+	return c.API.listStoragePools(ctx)
 }
 
 // VolumeInfo returns a string:string map containing information necessary
 // for CSI node(initiator) to connect to this target and identify the disk.
 // hostNQN is passed to the sbcli API when the volume has allowed_hosts configured.
-func (node *NodeNVMf) VolumeInfo(ctx context.Context, lvolID string, hostNQN string) (map[string]string, error) {
-	return node.Client.getVolumeInfo(ctx, lvolID, hostNQN)
+func (c *ClusterClient) VolumeInfo(ctx context.Context, lvolID string, hostNQN string) (map[string]string, error) {
+	return c.API.getVolumeInfo(ctx, c.poolID, lvolID, hostNQN)
 }
 
 // CreateLVolData is the data structure for creating a logical volume
@@ -184,8 +216,8 @@ type CreateLVolData struct {
 }
 
 // CreateVolume creates a logical volume and returns volume ID
-func (node *NodeNVMf) CreateVolume(ctx context.Context, params *CreateLVolData) (string, error) {
-	lvolID, err := node.Client.createVolume(ctx, params)
+func (c *ClusterClient) CreateVolume(ctx context.Context, params *CreateLVolData) (string, error) {
+	lvolID, err := c.API.createVolume(ctx, c.poolID, params)
 	if err != nil {
 		return "", err
 	}
@@ -194,13 +226,13 @@ func (node *NodeNVMf) CreateVolume(ctx context.Context, params *CreateLVolData) 
 }
 
 // GetVolume returns the LvolResp for the given volume name and pool name. Returns error if not found.
-func (node *NodeNVMf) GetVolume(ctx context.Context, lvolName, poolName string) (*LvolResp, error) {
-	return node.Client.getVolume(ctx, fmt.Sprintf("%s/%s", poolName, lvolName))
+func (c *ClusterClient) GetVolume(ctx context.Context, lvolName, poolName string) (*LvolResp, error) {
+	return c.API.getVolume(ctx, c.poolID, fmt.Sprintf("%s/%s", poolName, lvolName))
 }
 
 // GetVolumeSize returns the size of the volume
-func (node *NodeNVMf) GetVolumeSize(ctx context.Context, lvolID string) (string, error) {
-	lvol, err := node.Client.getVolume(ctx, lvolID)
+func (c *ClusterClient) GetVolumeSize(ctx context.Context, lvolID string) (string, error) {
+	lvol, err := c.API.getVolume(ctx, c.poolID, lvolID)
 	if err != nil {
 		return "", err
 	}
@@ -210,37 +242,36 @@ func (node *NodeNVMf) GetVolumeSize(ctx context.Context, lvolID string) (string,
 }
 
 // ListVolumes returns a list of volumes
-
-func (node *NodeNVMf) ListVolumes(ctx context.Context) ([]*LvolResp, error) {
-	return node.Client.listVolumes(ctx)
+func (c *ClusterClient) ListVolumes(ctx context.Context) ([]*LvolResp, error) {
+	return c.API.listVolumes(ctx, c.poolID)
 }
 
 // GetMasterLvols returns master lvols for the given pool UUID
-func (node *NodeNVMf) GetMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error) {
-	return node.Client.getMasterLvols(ctx, poolUUID)
+func (c *ClusterClient) GetMasterLvols(ctx context.Context, poolUUID string) ([]MasterLvol, error) {
+	return c.API.getMasterLvols(ctx, poolUUID)
 }
 
 // GetPoolUUIDByName returns the UUID of the pool with the given name
-func (node *NodeNVMf) GetPoolUUIDByName(ctx context.Context, poolName string) (string, error) {
-	return node.Client.getPoolUUIDByName(ctx, poolName)
+func (c *ClusterClient) GetPoolUUIDByName(ctx context.Context, poolName string) (string, error) {
+	return c.API.getPoolUUIDByName(ctx, poolName)
 }
 
 // ResizeVolume resizes a volume
-func (node *NodeNVMf) ResizeVolume(ctx context.Context, lvolID string, newSize int64) (bool, error) {
-	return node.Client.resizeVolume(ctx, lvolID, newSize)
+func (c *ClusterClient) ResizeVolume(ctx context.Context, lvolID string, newSize int64) (bool, error) {
+	return c.API.resizeVolume(ctx, c.poolID, lvolID, newSize)
 }
 
 // ListSnapshots returns a list of snapshots. When PoolID is not set, iterates all pools.
-func (node *NodeNVMf) ListSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
-	if node.Client.PoolID == "" {
-		return node.Client.listAllSnapshots(ctx)
+func (c *ClusterClient) ListSnapshots(ctx context.Context) ([]*SnapshotResp, error) {
+	if c.poolID == "" {
+		return c.API.listAllSnapshots(ctx)
 	}
-	return node.Client.listSnapshots(ctx)
+	return c.API.listSnapshots(ctx, c.poolID)
 }
 
 // CloneSnapshot clones a snapshot to a new volume
-func (node *NodeNVMf) CloneSnapshot(ctx context.Context, snapshotID, cloneName, newSize, pvcName string) (string, error) {
-	lvolID, err := node.Client.cloneSnapshot(ctx, snapshotID, cloneName, newSize, pvcName)
+func (c *ClusterClient) CloneSnapshot(ctx context.Context, snapshotID, cloneName, newSize, pvcName string) (string, error) {
+	lvolID, err := c.API.cloneSnapshot(ctx, c.poolID, snapshotID, cloneName, newSize, pvcName)
 	if err != nil {
 		return "", err
 	}
@@ -249,8 +280,8 @@ func (node *NodeNVMf) CloneSnapshot(ctx context.Context, snapshotID, cloneName, 
 }
 
 // CloneVolume clones a volume to a new volume
-func (node *NodeNVMf) CloneVolume(ctx context.Context, lvolID, cloneName, newSize, pvcName string) (string, error) {
-	lvolID, err := node.Client.cloneVolume(ctx, lvolID, cloneName, newSize, pvcName)
+func (c *ClusterClient) CloneVolume(ctx context.Context, lvolID, cloneName, newSize, pvcName string) (string, error) {
+	lvolID, err := c.API.cloneVolume(ctx, c.poolID, lvolID, cloneName, newSize, pvcName)
 	if err != nil {
 		return "", err
 	}
@@ -260,19 +291,19 @@ func (node *NodeNVMf) CloneVolume(ctx context.Context, lvolID, cloneName, newSiz
 
 // CreateSnapshot creates a snapshot of a volume.
 // Returns a 3-part CSI snapshot ID: {clusterID}:{poolID}:{snapshotUUID}
-func (node *NodeNVMf) CreateSnapshot(ctx context.Context, lvolID, snapshotName string) (string, error) {
-	snapshotID, err := node.Client.snapshot(ctx, lvolID, snapshotName)
+func (c *ClusterClient) CreateSnapshot(ctx context.Context, lvolID, snapshotName string) (string, error) {
+	snapshotID, err := c.API.snapshot(ctx, c.poolID, lvolID, snapshotName)
 	if err != nil {
 		return "", err
 	}
-	csiID := fmt.Sprintf("%s:%s:%s", node.Client.ClusterID, node.Client.PoolID, snapshotID)
+	csiID := fmt.Sprintf("%s:%s:%s", c.API.ClusterID, c.poolID, snapshotID)
 	klog.V(5).Infof("snapshot created: %s", csiID)
 	return csiID, nil
 }
 
 // DeleteVolume deletes a volume
-func (node *NodeNVMf) DeleteVolume(ctx context.Context, lvolID string) error {
-	err := node.Client.deleteVolume(ctx, lvolID)
+func (c *ClusterClient) DeleteVolume(ctx context.Context, lvolID string) error {
+	err := c.API.deleteVolume(ctx, c.poolID, lvolID)
 	if err != nil {
 		return err
 	}
@@ -281,8 +312,8 @@ func (node *NodeNVMf) DeleteVolume(ctx context.Context, lvolID string) error {
 }
 
 // DeleteSnapshot deletes a snapshot
-func (node *NodeNVMf) DeleteSnapshot(ctx context.Context, snapshotID string) error {
-	err := node.Client.deleteSnapshot(ctx, snapshotID)
+func (c *ClusterClient) DeleteSnapshot(ctx context.Context, snapshotID string) error {
+	err := c.API.deleteSnapshot(ctx, c.poolID, snapshotID)
 	if err != nil {
 		return err
 	}
@@ -291,8 +322,8 @@ func (node *NodeNVMf) DeleteSnapshot(ctx context.Context, snapshotID string) err
 }
 
 // PublishVolume exports a volume through NVMf target
-func (node *NodeNVMf) PublishVolume(ctx context.Context, lvolID string) error {
-	_, err := node.Client.CallSBCLI(ctx, "GET", node.Client.v2volume(lvolID), nil)
+func (c *ClusterClient) PublishVolume(ctx context.Context, lvolID string) error {
+	_, err := c.API.do(ctx, "GET", c.API.v2volume(c.poolID, lvolID), nil)
 	if err != nil {
 		return err
 	}
@@ -301,12 +332,11 @@ func (node *NodeNVMf) PublishVolume(ctx context.Context, lvolID string) error {
 }
 
 // UnpublishVolume unexports a volume through NVMf target
-func (node *NodeNVMf) UnpublishVolume(ctx context.Context, lvolID string) error {
-	_, err := node.Client.CallSBCLI(ctx, "GET", node.Client.v2volume(lvolID), nil)
+func (c *ClusterClient) UnpublishVolume(ctx context.Context, lvolID string) error {
+	_, err := c.API.do(ctx, "GET", c.API.v2volume(c.poolID, lvolID), nil)
 	if err != nil {
 		return err
 	}
-
 	klog.V(5).Infof("volume unpublished: %s", lvolID)
 	return nil
 }

--- a/pkg/util/nvmf_test.go
+++ b/pkg/util/nvmf_test.go
@@ -97,40 +97,40 @@ func writeTestPEMs(t *testing.T) (caFile, certFile, keyFile string) {
 	return caFile, certFile, keyFile
 }
 
-func transportOf(t *testing.T, n *NodeNVMf) *http.Transport {
+func transportOf(t *testing.T, n *ClusterClient) *http.Transport {
 	t.Helper()
-	tr, ok := n.Client.HTTPClient.Transport.(*http.Transport)
+	tr, ok := n.API.conn.HTTP.Transport.(*http.Transport)
 	if !ok {
-		t.Fatalf("transport is %T, want *http.Transport", n.Client.HTTPClient.Transport)
+		t.Fatalf("transport is %T, want *http.Transport", n.API.conn.HTTP.Transport)
 	}
 	return tr
 }
 
-func TestNewNVMfDisabled(t *testing.T) {
+func TestNewClusterClientDisabled(t *testing.T) {
 	t.Setenv(envTLSConnect, "disabled")
-	n, err := NewNVMf("c", "http://api.example.com:5000", "s")
+	n, err := NewClusterClient("c", "http://api.example.com:5000", "s")
 	if err != nil {
-		t.Fatalf("NewNVMf: %v", err)
+		t.Fatalf("NewClusterClient: %v", err)
 	}
-	if n.Client.ClusterIP != "http://api.example.com:5000" {
-		t.Errorf("ClusterIP rewritten unexpectedly: %s", n.Client.ClusterIP)
+	if n.API.conn.Endpoint != "http://api.example.com:5000" {
+		t.Errorf("Endpoint rewritten unexpectedly: %s", n.API.conn.Endpoint)
 	}
-	if n.Client.HTTPClient.Transport != http.DefaultTransport {
-		t.Errorf("expected http.DefaultTransport, got %T", n.Client.HTTPClient.Transport)
+	if n.API.conn.HTTP.Transport != http.DefaultTransport {
+		t.Errorf("expected http.DefaultTransport, got %T", n.API.conn.HTTP.Transport)
 	}
 }
 
-func TestNewNVMfAnonymous(t *testing.T) {
+func TestNewClusterClientAnonymous(t *testing.T) {
 	caFile, _, _ := writeTestPEMs(t)
 	t.Setenv(envTLSConnect, "anonymous")
 	t.Setenv(envTLSCAFile, caFile)
 
-	n, err := NewNVMf("c", "http://api.example.com:5000", "s")
+	n, err := NewClusterClient("c", "http://api.example.com:5000", "s")
 	if err != nil {
-		t.Fatalf("NewNVMf: %v", err)
+		t.Fatalf("NewClusterClient: %v", err)
 	}
-	if n.Client.ClusterIP != "https://api.example.com:5000" {
-		t.Errorf("ClusterIP not rewritten to https: %s", n.Client.ClusterIP)
+	if n.API.conn.Endpoint != "https://api.example.com:5000" {
+		t.Errorf("Endpoint not rewritten to https: %s", n.API.conn.Endpoint)
 	}
 	cfg := transportOf(t, n).TLSClientConfig
 	if cfg == nil || cfg.RootCAs == nil {
@@ -141,16 +141,16 @@ func TestNewNVMfAnonymous(t *testing.T) {
 	}
 }
 
-func TestNewNVMfAuthenticated(t *testing.T) {
+func TestNewClusterClientAuthenticated(t *testing.T) {
 	caFile, certFile, keyFile := writeTestPEMs(t)
 	t.Setenv(envTLSConnect, "authenticated")
 	t.Setenv(envTLSCAFile, caFile)
 	t.Setenv(envTLSCert, certFile)
 	t.Setenv(envTLSKey, keyFile)
 
-	n, err := NewNVMf("c", "http://api.example.com:5000", "s")
+	n, err := NewClusterClient("c", "http://api.example.com:5000", "s")
 	if err != nil {
-		t.Fatalf("NewNVMf: %v", err)
+		t.Fatalf("NewClusterClient: %v", err)
 	}
 	cfg := transportOf(t, n).TLSClientConfig
 	if cfg == nil || cfg.RootCAs == nil {
@@ -161,17 +161,17 @@ func TestNewNVMfAuthenticated(t *testing.T) {
 	}
 }
 
-func TestNewNVMfInvalidMode(t *testing.T) {
+func TestNewClusterClientInvalidMode(t *testing.T) {
 	t.Setenv(envTLSConnect, "bogus")
-	if _, err := NewNVMf("c", "http://api.example.com:5000", "s"); err == nil {
+	if _, err := NewClusterClient("c", "http://api.example.com:5000", "s"); err == nil {
 		t.Fatal("expected error for invalid SB_TLS_CONNECT, got nil")
 	}
 }
 
-func TestNewNVMfMissingCA(t *testing.T) {
+func TestNewClusterClientMissingCA(t *testing.T) {
 	t.Setenv(envTLSConnect, "anonymous")
 	t.Setenv(envTLSCAFile, filepath.Join(t.TempDir(), "missing.crt"))
-	if _, err := NewNVMf("c", "http://api.example.com:5000", "s"); err == nil {
+	if _, err := NewClusterClient("c", "http://api.example.com:5000", "s"); err == nil {
 		t.Fatal("expected error for missing CA file, got nil")
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -165,13 +166,13 @@ func detectNvmeDeviceName(nvmeModel string) (string, error) {
 }
 
 // get the Nvme block device
-func GetNvmeDeviceName(nvmeModel, bdf string) (string, error) {
+func GetNvmeDeviceName(ctx context.Context, nvmeModel, bdf string) (string, error) {
 	var deviceName string
 	var err error
 	if bdf != "" {
 		var uuidFilePath string
 		// find the uuid file path for the nvme device based on the bdf
-		uuidFilePath, err = waitForDeviceReady(fmt.Sprintf("/sys/bus/pci/devices/%s/nvme/nvme*/nvme*n*/uuid", bdf), 20)
+		uuidFilePath, err = waitForDeviceReady(ctx, fmt.Sprintf("/sys/bus/pci/devices/%s/nvme/nvme*/nvme*n*/uuid", bdf), 20)
 		if err != nil {
 			return "", fmt.Errorf("failed find device at %s: %w", uuidFilePath, err)
 		}
@@ -186,22 +187,22 @@ func GetNvmeDeviceName(nvmeModel, bdf string) (string, error) {
 
 	deviceGlob := "/dev/" + deviceName
 
-	return waitForDeviceReady(deviceGlob, 20)
+	return waitForDeviceReady(ctx, deviceGlob, 20)
 }
 
 // GetVirtioBlkDevice returns a block device available at the
 // given bdf path. If wait is true then it wait till a device
 // appear at the bdf path.
-func GetVirtioBlkDeviceName(bdf string, wait bool) (string, error) {
+func GetVirtioBlkDeviceName(ctx context.Context, bdf string, wait bool) (string, error) {
 	// The parent dir path of the block device for VirtioBlk should be
 	// in the form of "/sys/bus/pci/devices/0000:01:01.0/virtio2/block"
 	sysBusGlob := fmt.Sprintf("/sys/bus/pci/devices/%s/virtio*/block", bdf)
 	var deviceParentDirPath string
 	var err error
 	if wait {
-		deviceParentDirPath, err = waitForDeviceReady(sysBusGlob, 20)
+		deviceParentDirPath, err = waitForDeviceReady(ctx, sysBusGlob, 20)
 	} else {
-		deviceParentDirPath, err = waitForDeviceReady(sysBusGlob, 0)
+		deviceParentDirPath, err = waitForDeviceReady(ctx, sysBusGlob, 0)
 	}
 	if err != nil {
 		klog.Errorf("could not find the deviceParentDirPath (%s): %s", sysBusGlob, err)
@@ -222,7 +223,7 @@ func GetVirtioBlkDeviceName(bdf string, wait bool) (string, error) {
 	// wait for the block device ready for VirtioBlk, eg, in the form of "/dev/vda"
 	deviceGlob := "/dev/" + deviceName[0].Name()
 
-	return waitForDeviceReady(deviceGlob, 20)
+	return waitForDeviceReady(ctx, deviceGlob, 20)
 }
 
 // GetAvailablePhysicalFunction returns next available Pf and Vf by checking


### PR DESCRIPTION
fixes: https://github.com/simplyblock/simplyblock-operator/issues/164
fixes: https://github.com/simplyblock/simplyblock-operator/issues/168

### `CallSBCLI` → `do` + `json.RawMessage

Rename the internal HTTP dispatcher to the unexported `do` and change its return type from `(any, error)` to `(json.RawMessage, error)`. This eliminates the double marshal/unmarshal round-trip in every caller: callers now do a single `json.Unmarshal(raw, &result)` directly

### `ClusterAPI` interface

Replace the stale, never-used `SpdkNode` interface with `ClusterAPI`, whose method signatures match the actual `ClusterClient` implementation. Switch `controllerserver.go` to accept `ClusterAPI` so tests can inject mocks without depending on the concrete struct.

 ### Connection reuse

Extract a `Connection` struct that owns the http.Client and http.Transport. A single ClusterClient reuses one TCP pool for its entire lifetime, avoiding a fresh TLS handshake on each API call.


### testing

no functional changes. just restructuring. 

e2e tests also pass on this branch

```
Will run 22 of 22 specs
Running in parallel across 2 processes
•••••••S••••••••••••••

Ran 21 of 22 Specs in 646.264 seconds
SUCCESS! -- 21 Passed | 0 Failed | 0 Pending | 1 Skipped


Ginkgo ran 1 suite in 10m58.513219083s
Test Suite Passed
```


