### PR TITLE
Add additional e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.patch
 *.rej
 .gocache
+
+# Compiled test binaries produced by 'go test -c' / ginkgo
+*.test

--- a/Makefile
+++ b/Makefile
@@ -112,15 +112,22 @@ unit-test:
 
 # e2e test
 .PHONY: e2e-test
-# Pass extra arguments to e2e tests. Could be used
-# to pass -xpu argument and running only fouced tests
-# for quick testing.
-# The below example tests:
-#   make e2e-test E2E_TEST_ARGS='-xpu=true --ginkgo.focus=\"TEST SPDK CSI SMA NVME\"'
+# Pass extra arguments to e2e tests.
+# Use E2E_PROCS=N to run specs in parallel (requires the ginkgo CLI).
+# Use E2E_TEST_ARGS to pass additional ginkgo flags.
+# Examples:
+#   make e2e-test E2E_PROCS=4
+#   make e2e-test E2E_PROCS=4 E2E_TEST_ARGS='--skip="SPDKCSI-MULTICLUSTER|XFS"'
+#   make e2e-test E2E_TEST_ARGS='--focus="SPDKCSI-NVMEOF"'
+E2E_PROCS=
 E2E_TEST_ARGS=
 e2e-test:
 	@echo === running e2e test
-	go test -v -race -timeout 30m ./e2e $(E2E_TEST_ARGS)
+	@if [ -n "$(E2E_PROCS)" ]; then \
+		go run github.com/onsi/ginkgo/v2/ginkgo --procs=$(E2E_PROCS) --race --timeout=30m $(E2E_TEST_ARGS) ./e2e/; \
+	else \
+		go test -race -timeout 30m ./e2e $(E2E_TEST_ARGS); \
+	fi
 
 # helm test
 .PHONY: helm-test

--- a/e2e/clone.go
+++ b/e2e/clone.go
@@ -11,42 +11,46 @@ import (
 var _ = ginkgo.Describe("SPDKCSI-CLONE", func() {
 	f := framework.NewDefaultFramework("spdkcsi")
 
-	ginkgo.Context("Test SPDK CSI Volume Clone", func() {
-		ginkgo.It("Test SPDK CSI Clone", func() {
-			testPodLabel := metav1.ListOptions{
-				LabelSelector: "app=spdkcsi-pvc",
-			}
-			testPodName := "spdkcsi-test"
-			cloneTestPodName := "spdkcsi-test-clone"
-			persistData := []string{"Data that needs to be stored"}
-			persistDataPath := []string{"/spdkvol/test"}
+	ginkgo.It("cloned volume contains data written to the source volume", func() {
+		testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
-			ginkgo.By("create source pvc and write data", func() {
-				deployPVC()
-				deployTestPod()
-				defer deleteTestPod()
+		ginkgo.By("create source PVC")
+		deployPVC()
+		ginkgo.DeferCleanup(deletePVC)
 
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				writeDataToPod(f, &testPodLabel, persistData[0], persistDataPath[0])
-			})
+		ginkgo.By("deploy test pod and write data to source PVC")
+		deployTestPod()
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName),
+			"wait for source test pod",
+		)
+		writeDataToPod(f, &testPodLabel, "Data that needs to be stored", "/spdkvol/test")
 
-			ginkgo.By("create clone and check data persistency", func() {
-				deployClone()
-				defer deleteClone()
-				defer deletePVC()
+		// The clone API requires the source PVC to not be in use while cloning
+		// on some backends.  Delete the test pod and wait for full termination
+		// before creating the clone so there is no ambiguity about which pod
+		// the label selector resolves to during verification.
+		ginkgo.By("delete source test pod before cloning")
+		deleteTestPod()
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, testPodName),
+			"wait for source test pod to terminate",
+		)
 
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, cloneTestPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				err = compareDataInPod(f, &testPodLabel, persistData, persistDataPath)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
-		})
+		ginkgo.By("create clone PVC and pod")
+		deployClone()
+		ginkgo.DeferCleanup(deleteClone)
+
+		ginkgo.By("wait for clone pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, "spdkcsi-test-clone"),
+			"wait for clone pod",
+		)
+
+		ginkgo.By("verify clone contains the data written to the source")
+		compareDataInPod(f, &testPodLabel,
+			[]string{"Data that needs to be stored"},
+			[]string{"/spdkvol/test"},
+		)
 	})
 })

--- a/e2e/clone.go
+++ b/e2e/clone.go
@@ -9,46 +9,47 @@ import (
 )
 
 var _ = ginkgo.Describe("SPDKCSI-CLONE", func() {
-	f := framework.NewDefaultFramework("spdkcsi")
+	f := newTestFramework("spdkcsi")
 
 	ginkgo.It("cloned volume contains data written to the source volume", func() {
+		ns := f.Namespace.Name
 		testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
 		ginkgo.By("create source PVC")
-		deployPVC()
-		ginkgo.DeferCleanup(deletePVC)
+		deployPVC(ns)
+		ginkgo.DeferCleanup(func() { deletePVC(ns) })
 
 		ginkgo.By("deploy test pod and write data to source PVC")
-		deployTestPod()
+		deployTestPod(ns)
 		framework.ExpectNoError(
-			waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName),
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, testPodName),
 			"wait for source test pod",
 		)
-		writeDataToPod(f, &testPodLabel, "Data that needs to be stored", "/spdkvol/test")
+		writeDataToPod(f, ns, &testPodLabel, "Data that needs to be stored", "/spdkvol/test")
 
 		// The clone API requires the source PVC to not be in use while cloning
 		// on some backends.  Delete the test pod and wait for full termination
 		// before creating the clone so there is no ambiguity about which pod
 		// the label selector resolves to during verification.
 		ginkgo.By("delete source test pod before cloning")
-		deleteTestPod()
+		deleteTestPod(ns)
 		framework.ExpectNoError(
-			waitForTestPodGone(f.ClientSet, testPodName),
+			waitForTestPodGone(f.ClientSet, ns, testPodName),
 			"wait for source test pod to terminate",
 		)
 
 		ginkgo.By("create clone PVC and pod")
-		deployClone()
-		ginkgo.DeferCleanup(deleteClone)
+		deployClone(ns)
+		ginkgo.DeferCleanup(func() { deleteClone(ns) })
 
 		ginkgo.By("wait for clone pod to be ready")
 		framework.ExpectNoError(
-			waitForTestPodReady(f.ClientSet, 3*time.Minute, "spdkcsi-test-clone"),
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, "spdkcsi-test-clone"),
 			"wait for clone pod",
 		)
 
 		ginkgo.By("verify clone contains the data written to the source")
-		compareDataInPod(f, &testPodLabel,
+		compareDataInPod(f, ns, &testPodLabel,
 			[]string{"Data that needs to be stored"},
 			[]string{"/spdkvol/test"},
 		)

--- a/e2e/deletion.go
+++ b/e2e/deletion.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("SPDKCSI-DELETION", func() {
+	f := newTestFramework("spdkcsi")
+
+	// -------------------------------------------------------------------------
+	// Volume deletion
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("PV is deleted after its PVC is removed (reclaimPolicy: Delete)", func() {
+		ns := f.Namespace.Name
+
+		ginkgo.By("create PVC and test pod")
+		deployPVC(ns)
+		deployTestPod(ns)
+		// Register cleanup for the failure path; in the success path we
+		// delete explicitly below so we can observe the PV lifecycle.
+		ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
+
+		ginkgo.By("wait for test pod to be ready (PVC is bound)")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
+			"wait for test pod",
+		)
+
+		ginkgo.By("record the PV name from the bound PVC")
+		pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+			Get(context.Background(), "spdkcsi-pvc", metav1.GetOptions{})
+		framework.ExpectNoError(err, "get PVC")
+		pvName := pvc.Spec.VolumeName
+		gomega.Expect(pvName).NotTo(gomega.BeEmpty(), "PVC must be bound to a PV")
+
+		ginkgo.By("delete the test pod")
+		deleteTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, testPodName),
+			"wait for test pod to terminate",
+		)
+
+		ginkgo.By("delete the PVC")
+		deletePVC(ns)
+		framework.ExpectNoError(
+			waitForPvcGone(f.ClientSet, ns, "spdkcsi-pvc"),
+			"wait for PVC to be deleted",
+		)
+
+		ginkgo.By("verify the backing PV is also deleted by the provisioner")
+		framework.ExpectNoError(
+			waitForPVDeleted(f.ClientSet, pvName, 3*time.Minute),
+			"wait for PV to be reclaimed",
+		)
+	})
+
+	// -------------------------------------------------------------------------
+	// Snapshot deletion
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("VolumeSnapshot is removed after explicit deletion", func() {
+		ns := f.Namespace.Name
+		const snapshotName = "spdk-snapshot-deletion-test"
+
+		ginkgo.By("create source PVC and test pod")
+		deployPVC(ns)
+		deployTestPod(ns)
+		ginkgo.DeferCleanup(func() { deletePVC(ns) }) // PVC outlives the test pod
+		ginkgo.DeferCleanup(func() {
+			// Best-effort cleanup in case test fails before explicit deletion.
+			deleteSnapshotOnly(ns)
+			deleteTestPod(ns)
+		})
+
+		ginkgo.By("wait for test pod to be ready and write data")
+		testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
+			"wait for test pod",
+		)
+		writeDataToPod(f, ns, &testPodLabel, "snapshot deletion test data", "/spdkvol/test")
+
+		ginkgo.By("delete source test pod (PVC stays alive for snapshotting)")
+		deleteTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, testPodName),
+			"wait for test pod to terminate",
+		)
+
+		ginkgo.By("create VolumeSnapshot")
+		deploySnapshotOnly(ns)
+
+		ginkgo.By("wait for VolumeSnapshot to be ready")
+		framework.ExpectNoError(
+			waitForSnapshotReady(ns, snapshotName, 5*time.Minute),
+			"wait for snapshot to be ready",
+		)
+
+		ginkgo.By("delete the VolumeSnapshot")
+		deleteSnapshotOnly(ns)
+
+		ginkgo.By("verify the VolumeSnapshot is fully removed")
+		framework.ExpectNoError(
+			waitForSnapshotGone(ns, snapshotName, 3*time.Minute),
+			"wait for snapshot to be deleted",
+		)
+	})
+})

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"flag"
 	"os"
 	"path/filepath"
@@ -11,7 +10,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
-	"k8s.io/kubernetes/test/e2e/storage/podlogs"
 )
 
 func init() {
@@ -33,15 +31,6 @@ func init() {
 }
 
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
-	ginkgo.By("Watching for pod logs in 'default' namespace")
-	cs, err := framework.LoadClientset()
-	framework.ExpectNoError(err, "create client set")
-	err = podlogs.CopyAllLogs(context.Background(), cs, nameSpace, podlogs.LogOutput{
-		LogWriter:    ginkgo.GinkgoWriter,
-		StatusWriter: ginkgo.GinkgoWriter,
-	})
-	framework.ExpectNoError(err, "set watch on namespace :%s", nameSpace)
-
 	return []byte{}
 }, func(_ []byte) {})
 

--- a/e2e/filesystem.go
+++ b/e2e/filesystem.go
@@ -1,0 +1,136 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("SPDKCSI-FILESYSTEM", func() {
+	f := newTestFramework("spdkcsi")
+
+	// -------------------------------------------------------------------------
+	// XFS filesystem
+	// -------------------------------------------------------------------------
+
+	// A unique StorageClass name is generated per test so parallel runs do not
+	// collide.  The SC is created by copying the default one and overriding
+	// csi.storage.k8s.io/fstype to "xfs".
+	ginkgo.It("XFS volume is provisioned and data persists across pod restarts", func() {
+		ns := f.Namespace.Name
+		const xfsSC = "spdkcsi-e2e-xfs"
+		testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+
+		ginkgo.By("create XFS StorageClass derived from the default one")
+		createStorageClassWithParams(f.ClientSet, xfsSC, map[string]string{
+			"csi.storage.k8s.io/fstype": "xfs",
+		})
+		ginkgo.DeferCleanup(func() { deleteStorageClass(f.ClientSet, xfsSC) })
+
+		ginkgo.By("create PVC using XFS StorageClass")
+		framework.ExpectNoError(
+			createPVC(f.ClientSet, ns, "spdkcsi-pvc-xfs", xfsSC, 1<<30),
+			"create XFS PVC",
+		)
+		ginkgo.DeferCleanup(func() {
+			framework.ExpectNoError(
+				f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+					Delete(context.Background(), "spdkcsi-pvc-xfs", metav1.DeleteOptions{}),
+			)
+		})
+
+		ginkgo.By("create pod that mounts the XFS volume")
+		framework.ExpectNoError(
+			createPodForPVC(f.ClientSet, ns, "spdkcsi-test-xfs", "spdkcsi-pvc-xfs"),
+			"create XFS test pod",
+		)
+		xfsPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-test-xfs"}
+		ginkgo.DeferCleanup(func() {
+			deletePodByName(f.ClientSet, ns, "spdkcsi-test-xfs")
+		})
+
+		ginkgo.By("wait for XFS pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, "spdkcsi-test-xfs"),
+			"wait for XFS test pod",
+		)
+
+		ginkgo.By("verify the mounted filesystem is XFS")
+		// Alpine's df supports -T; XFS mounts report type 'xfs'.
+		fsType, _ := execCommandInPod(f,
+			"df -T /spdkvol | awk 'NR==2 {print $2}'",
+			ns, &xfsPodLabel)
+		gomega.Expect(fsType).To(gomega.ContainSubstring("xfs"),
+			"filesystem type should be xfs")
+
+		ginkgo.By("write data to the XFS volume")
+		writeDataToPod(f, ns, &xfsPodLabel, "xfs-persistence-test-data", "/spdkvol/test")
+
+		ginkgo.By("delete and recreate pod to verify persistence")
+		deletePodByName(f.ClientSet, ns, "spdkcsi-test-xfs")
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, "spdkcsi-test-xfs"),
+			"wait for XFS pod to terminate",
+		)
+		framework.ExpectNoError(
+			createPodForPVC(f.ClientSet, ns, "spdkcsi-test-xfs", "spdkcsi-pvc-xfs"),
+			"recreate XFS test pod",
+		)
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, "spdkcsi-test-xfs"),
+			"wait for XFS pod after restart",
+		)
+
+		ginkgo.By("verify data survived the pod restart")
+		compareDataInPod(f, ns, &testPodLabel,
+			[]string{"xfs-persistence-test-data"},
+			[]string{"/spdkvol/test"},
+		)
+	})
+
+	// -------------------------------------------------------------------------
+	// ext4 filesystem (default): subdirectory writes survive pod restart
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("ext4 volume supports nested directory writes that persist across pod restarts", func() {
+		ns := f.Namespace.Name
+		testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+
+		ginkgo.By("create PVC and test pod")
+		deployPVC(ns)
+		deployTestPod(ns)
+		ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
+
+		ginkgo.By("wait for test pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
+			"wait for test pod",
+		)
+
+		ginkgo.By("create a subdirectory and write data")
+		execCommandInPod(f, "mkdir -p /spdkvol/subdir/nested", ns, &testPodLabel)
+		writeDataToPod(f, ns, &testPodLabel, "nested-dir-data", "/spdkvol/subdir/nested/file")
+
+		ginkgo.By("delete and recreate pod")
+		deleteTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, testPodName),
+			"wait for test pod to terminate",
+		)
+		deployTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
+			"wait for test pod after restart",
+		)
+
+		ginkgo.By("verify nested directory and data survived the restart")
+		compareDataInPod(f, ns, &testPodLabel,
+			[]string{"nested-dir-data"},
+			[]string{"/spdkvol/subdir/nested/file"},
+		)
+	})
+})

--- a/e2e/multicluster.go
+++ b/e2e/multicluster.go
@@ -1,13 +1,14 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega" //nolint
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,7 @@ var _ = ginkgo.Describe("SPDKCSI-MULTICLUSTER", func() {
 		zones := envList("MULTI_CLUSTER_ZONES", []string{"multi-cluster-a", "multi-cluster-b"})
 		poolName := envOrDefault("MULTI_CLUSTER_POOL_NAME", "pool1")
 		storageClassNames := envList("MULTI_CLUSTER_STORAGE_CLASS_NAMES", nil)
+
 		if len(clusterRefs) != 2 || len(zones) != 2 {
 			ginkgo.Fail("MULTI_CLUSTER_REFS and MULTI_CLUSTER_ZONES must each contain exactly two comma-separated values")
 		}
@@ -45,52 +47,52 @@ var _ = ginkgo.Describe("SPDKCSI-MULTICLUSTER", func() {
 		for i, clusterRef := range clusterRefs {
 			clusterNamespace, clusterName := splitNamespacedRef(clusterRef, nameSpace)
 			clusterID, err := waitForStorageClusterUUID(clusterNamespace, clusterName, 10*time.Minute)
-			if err != nil {
-				ginkgo.Fail(err.Error())
-			}
+			framework.ExpectNoError(err, "resolve cluster UUID for %s", clusterRef)
 			clusterIDs[i] = clusterID
 		}
 
 		for i, zone := range zones {
 			pvcName := fmt.Sprintf("spdkcsi-multicluster-pvc-%d", i+1)
 			podName := fmt.Sprintf("spdkcsi-multicluster-pod-%d", i+1)
-			storageClassName := storageClassNames[i]
+			scName := storageClassNames[i]
 
-			ginkgo.By(fmt.Sprintf("provisioning a PVC with StorageClass %s for topology zone %s", storageClassName, zone), func() {
-				err := createPVC(f.ClientSet, nameSpace, pvcName, storageClassName, 1*1024*1024*1024)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				ginkgo.DeferCleanup(func() {
-					Expect(deletePodIfExists(f.ClientSet, podName)).To(Succeed())
-					Expect(deletePVCIfExists(f.ClientSet, pvcName)).To(Succeed())
-				})
-
-				err = createTopologyPinnedPod(f.ClientSet, nameSpace, podName, pvcName, zone)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-
-				err = waitForTestPodReady(f.ClientSet, 5*time.Minute, podName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-
-				pv, err := waitForPVCBound(f.ClientSet, pvcName, 5*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-
-				if err := verifyPVClusterAndTopology(pv, clusterIDs[i], zone); err != nil {
-					ginkgo.Fail(err.Error())
-				}
-
-				opt := metav1.ListOptions{FieldSelector: "metadata.name=" + podName}
-				writeDataToPod(f, &opt, fmt.Sprintf("multi cluster data %d", i+1), "/spdkvol/test")
+			ginkgo.By(fmt.Sprintf("provision PVC %s with StorageClass %s for zone %s", pvcName, scName, zone))
+			framework.ExpectNoError(
+				createPVC(f.ClientSet, nameSpace, pvcName, scName, 1*1024*1024*1024),
+				"create PVC %s", pvcName,
+			)
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(deletePodIfExists(f.ClientSet, podName)).To(gomega.Succeed())
+				gomega.Expect(deletePVCIfExists(f.ClientSet, pvcName)).To(gomega.Succeed())
 			})
+
+			framework.ExpectNoError(
+				createTopologyPinnedPod(f.ClientSet, nameSpace, podName, pvcName, zone),
+				"create topology-pinned pod %s", podName,
+			)
+
+			framework.ExpectNoError(
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, podName),
+				"wait for pod %s", podName,
+			)
+
+			pv, err := waitForPVCBound(f.ClientSet, pvcName, 5*time.Minute)
+			framework.ExpectNoError(err, "wait for PVC %s to bind", pvcName)
+
+			framework.ExpectNoError(
+				verifyPVClusterAndTopology(pv, clusterIDs[i], zone),
+				"verify PV cluster and topology for zone %s", zone,
+			)
+
+			opt := metav1.ListOptions{FieldSelector: "metadata.name=" + podName}
+			writeDataToPod(f, &opt, fmt.Sprintf("multi cluster data %d", i+1), "/spdkvol/test")
 		}
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Multi-cluster utility functions
+// ---------------------------------------------------------------------------
 
 func envOrDefault(key, fallback string) string {
 	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
@@ -104,7 +106,6 @@ func envList(key string, fallback []string) []string {
 	if raw == "" {
 		return fallback
 	}
-
 	parts := strings.Split(raw, ",")
 	values := make([]string, 0, len(parts))
 	for _, part := range parts {
@@ -118,8 +119,8 @@ func envList(key string, fallback []string) []string {
 func deriveMultiClusterStorageClassNames(clusterRefs []string, poolName string) []string {
 	names := make([]string, 0, len(clusterRefs))
 	for _, clusterRef := range clusterRefs {
-		namespace, clusterName := splitNamespacedRef(clusterRef, nameSpace)
-		names = append(names, fmt.Sprintf("simplyblock-%s-%s-%s", namespace, clusterName, poolName))
+		ns, clusterName := splitNamespacedRef(clusterRef, nameSpace)
+		names = append(names, fmt.Sprintf("simplyblock-%s-%s-%s", ns, clusterName, poolName))
 	}
 	return names
 }
@@ -134,23 +135,26 @@ func splitNamespacedRef(ref, fallbackNamespace string) (string, string) {
 
 func waitForStorageClusterUUID(namespace, clusterName string, timeout time.Duration) (string, error) {
 	var uuid string
-	err := wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
-		out, err := e2ekubectl.RunKubectl(namespace, "get", "storageclusters.storage.simplyblock.io", clusterName, "-o", "jsonpath={.status.uuid}")
-		if err != nil {
-			framework.Logf("waiting for StorageCluster %s/%s uuid: %v", namespace, clusterName, err)
-			return false, nil
-		}
-		uuid = strings.TrimSpace(out)
-		return uuid != "", nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true,
+		func(_ context.Context) (bool, error) {
+			out, err := e2ekubectl.RunKubectl(namespace, "get",
+				"storageclusters.storage.simplyblock.io", clusterName,
+				"-o", "jsonpath={.status.uuid}")
+			if err != nil {
+				framework.Logf("waiting for StorageCluster %s/%s uuid: %v", namespace, clusterName, err)
+				return false, nil
+			}
+			uuid = strings.TrimSpace(out)
+			return uuid != "", nil
+		})
 	if err != nil {
-		return "", fmt.Errorf("failed to wait for StorageCluster %s/%s uuid: %w", namespace, clusterName, err)
+		return "", fmt.Errorf("StorageCluster %s/%s uuid not available within %s: %w", namespace, clusterName, timeout, err)
 	}
 	return uuid, nil
 }
 
 func createTopologyPinnedPod(c kubernetes.Interface, namespace, podName, pvcClaimName, zone string) error {
-	_, err := c.CoreV1().Pods(namespace).Create(ctx, &corev1.Pod{
+	_, err := c.CoreV1().Pods(namespace).Create(context.Background(), &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: podName},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -184,7 +188,9 @@ func createTopologyPinnedPod(c kubernetes.Interface, namespace, podName, pvcClai
 				{
 					Name: "spdk-csi-vol",
 					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcClaimName},
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcClaimName,
+						},
 					},
 				},
 			},
@@ -195,22 +201,23 @@ func createTopologyPinnedPod(c kubernetes.Interface, namespace, podName, pvcClai
 
 func waitForPVCBound(c kubernetes.Interface, pvcName string, timeout time.Duration) (*corev1.PersistentVolume, error) {
 	var pv *corev1.PersistentVolume
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if pvc.Status.Phase != corev1.ClaimBound || pvc.Spec.VolumeName == "" {
-			return false, nil
-		}
-		pv, err = c.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if pvc.Status.Phase != corev1.ClaimBound || pvc.Spec.VolumeName == "" {
+				return false, nil
+			}
+			pv, err = c.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		})
 	if err != nil {
-		return nil, fmt.Errorf("failed to wait for PVC %s to bind: %w", pvcName, err)
+		return nil, fmt.Errorf("PVC %s did not bind within %s: %w", pvcName, timeout, err)
 	}
 	return pv, nil
 }
@@ -220,16 +227,16 @@ func verifyPVClusterAndTopology(pv *corev1.PersistentVolume, expectedClusterID, 
 		return fmt.Errorf("PV %s does not have a CSI source", pv.Name)
 	}
 	if clusterID := pv.Spec.CSI.VolumeAttributes["cluster_id"]; clusterID != expectedClusterID {
-		return fmt.Errorf("PV %s cluster_id = %q, want %q", pv.Name, clusterID, expectedClusterID)
+		return fmt.Errorf("PV %s: cluster_id = %q, want %q", pv.Name, clusterID, expectedClusterID)
 	}
 	if zone := pv.Spec.CSI.VolumeAttributes["topology.kubernetes.io/zone"]; zone != "" && zone != expectedZone {
-		return fmt.Errorf("PV %s topology zone = %q, want %q", pv.Name, zone, expectedZone)
+		return fmt.Errorf("PV %s: topology zone = %q, want %q", pv.Name, zone, expectedZone)
 	}
 	return nil
 }
 
 func deletePodIfExists(c kubernetes.Interface, podName string) error {
-	err := c.CoreV1().Pods(nameSpace).Delete(ctx, podName, metav1.DeleteOptions{})
+	err := c.CoreV1().Pods(nameSpace).Delete(context.Background(), podName, metav1.DeleteOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
@@ -237,7 +244,7 @@ func deletePodIfExists(c kubernetes.Interface, podName string) error {
 }
 
 func deletePVCIfExists(c kubernetes.Interface, pvcName string) error {
-	err := c.CoreV1().PersistentVolumeClaims(nameSpace).Delete(ctx, pvcName, metav1.DeleteOptions{})
+	err := c.CoreV1().PersistentVolumeClaims(nameSpace).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}

--- a/e2e/multicluster.go
+++ b/e2e/multicluster.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = ginkgo.Describe("SPDKCSI-MULTICLUSTER", func() {
-	f := framework.NewDefaultFramework("spdkcsi-multicluster")
+	f := newTestFramework("spdkcsi-multicluster")
 
 	ginkgo.BeforeEach(func() {
 		if os.Getenv("MULTI_CLUSTER_E2E") != "true" {
@@ -28,6 +28,8 @@ var _ = ginkgo.Describe("SPDKCSI-MULTICLUSTER", func() {
 	})
 
 	ginkgo.It("provisions volumes on the backend cluster selected by pod topology", func() {
+		ns := f.Namespace.Name
+
 		clusterRefs := envList("MULTI_CLUSTER_REFS", []string{"simplyblock-cluster-a", "simplyblock-cluster-b"})
 		zones := envList("MULTI_CLUSTER_ZONES", []string{"multi-cluster-a", "multi-cluster-b"})
 		poolName := envOrDefault("MULTI_CLUSTER_POOL_NAME", "pool1")
@@ -58,25 +60,25 @@ var _ = ginkgo.Describe("SPDKCSI-MULTICLUSTER", func() {
 
 			ginkgo.By(fmt.Sprintf("provision PVC %s with StorageClass %s for zone %s", pvcName, scName, zone))
 			framework.ExpectNoError(
-				createPVC(f.ClientSet, nameSpace, pvcName, scName, 1*1024*1024*1024),
+				createPVC(f.ClientSet, ns, pvcName, scName, 1*1024*1024*1024),
 				"create PVC %s", pvcName,
 			)
 			ginkgo.DeferCleanup(func() {
-				gomega.Expect(deletePodIfExists(f.ClientSet, podName)).To(gomega.Succeed())
-				gomega.Expect(deletePVCIfExists(f.ClientSet, pvcName)).To(gomega.Succeed())
+				gomega.Expect(deletePodIfExists(f.ClientSet, ns, podName)).To(gomega.Succeed())
+				gomega.Expect(deletePVCIfExists(f.ClientSet, ns, pvcName)).To(gomega.Succeed())
 			})
 
 			framework.ExpectNoError(
-				createTopologyPinnedPod(f.ClientSet, nameSpace, podName, pvcName, zone),
+				createTopologyPinnedPod(f.ClientSet, ns, podName, pvcName, zone),
 				"create topology-pinned pod %s", podName,
 			)
 
 			framework.ExpectNoError(
-				waitForTestPodReady(f.ClientSet, 5*time.Minute, podName),
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, podName),
 				"wait for pod %s", podName,
 			)
 
-			pv, err := waitForPVCBound(f.ClientSet, pvcName, 5*time.Minute)
+			pv, err := waitForPVCBound(f.ClientSet, ns, pvcName, 5*time.Minute)
 			framework.ExpectNoError(err, "wait for PVC %s to bind", pvcName)
 
 			framework.ExpectNoError(
@@ -85,7 +87,7 @@ var _ = ginkgo.Describe("SPDKCSI-MULTICLUSTER", func() {
 			)
 
 			opt := metav1.ListOptions{FieldSelector: "metadata.name=" + podName}
-			writeDataToPod(f, &opt, fmt.Sprintf("multi cluster data %d", i+1), "/spdkvol/test")
+			writeDataToPod(f, ns, &opt, fmt.Sprintf("multi cluster data %d", i+1), "/spdkvol/test")
 		}
 	})
 })
@@ -199,11 +201,11 @@ func createTopologyPinnedPod(c kubernetes.Interface, namespace, podName, pvcClai
 	return err
 }
 
-func waitForPVCBound(c kubernetes.Interface, pvcName string, timeout time.Duration) (*corev1.PersistentVolume, error) {
+func waitForPVCBound(c kubernetes.Interface, ns, pvcName string, timeout time.Duration) (*corev1.PersistentVolume, error) {
 	var pv *corev1.PersistentVolume
 	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
-			pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -235,16 +237,16 @@ func verifyPVClusterAndTopology(pv *corev1.PersistentVolume, expectedClusterID, 
 	return nil
 }
 
-func deletePodIfExists(c kubernetes.Interface, podName string) error {
-	err := c.CoreV1().Pods(nameSpace).Delete(context.Background(), podName, metav1.DeleteOptions{})
+func deletePodIfExists(c kubernetes.Interface, ns, podName string) error {
+	err := c.CoreV1().Pods(ns).Delete(context.Background(), podName, metav1.DeleteOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 	return err
 }
 
-func deletePVCIfExists(c kubernetes.Interface, pvcName string) error {
-	err := c.CoreV1().PersistentVolumeClaims(nameSpace).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
+func deletePVCIfExists(c kubernetes.Interface, ns, pvcName string) error {
+	err := c.CoreV1().PersistentVolumeClaims(ns).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil
 	}

--- a/e2e/negative.go
+++ b/e2e/negative.go
@@ -1,0 +1,135 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("SPDKCSI-NEGATIVE", func() {
+	f := newTestFramework("spdkcsi")
+
+	// -------------------------------------------------------------------------
+	// Invalid StorageClass → PVC stays Pending
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("PVC referencing a non-existent StorageClass stays Pending", func() {
+		ns := f.Namespace.Name
+		const pvcName = "spdkcsi-pvc-invalid-sc"
+
+		ginkgo.By("create PVC referencing a StorageClass that does not exist")
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: ns,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+				StorageClassName: func() *string {
+					s := "spdkcsi-nonexistent-storageclass-xyz"
+					return &s
+				}(),
+			},
+		}
+		_, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+			Create(context.Background(), pvc, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "create PVC with invalid StorageClass")
+		ginkgo.DeferCleanup(func() {
+			// Best-effort cleanup; ignore errors since PVC may already be gone.
+			_ = f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+				Delete(context.Background(), pvcName, metav1.DeleteOptions{})
+		})
+
+		ginkgo.By("verify the PVC remains in Pending phase for at least 30 seconds")
+		assertPVCStaysPending(f.ClientSet, ns, pvcName, 30*time.Second)
+	})
+
+	// -------------------------------------------------------------------------
+	// PVC shrink rejected by API server
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("shrinking a PVC capacity is rejected by the API server", func() {
+		ns := f.Namespace.Name
+
+		ginkgo.By("create PVC and test pod")
+		deployPVC(ns)
+		deployTestPod(ns)
+		ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
+
+		ginkgo.By("wait for test pod to be ready (PVC is bound)")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
+			"wait for test pod",
+		)
+
+		ginkgo.By("attempt to shrink the PVC — API server must reject it")
+		pvc, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+			Get(context.Background(), "spdkcsi-pvc", metav1.GetOptions{})
+		framework.ExpectNoError(err, "get PVC for shrink attempt")
+
+		// Force a smaller size regardless of current allocation.
+		smallSize := resource.MustParse("512Mi")
+		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = smallSize
+
+		_, err = f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+			Update(context.Background(), pvc, metav1.UpdateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred(),
+			"API server must reject PVC capacity decrease")
+	})
+
+	// -------------------------------------------------------------------------
+	// Clone from non-existent source → PVC stays Pending
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("cloning from a non-existent source PVC leaves the clone PVC Pending", func() {
+		ns := f.Namespace.Name
+		const clonePVCName = "spdkcsi-clone-bad-source"
+
+		ginkgo.By("create clone PVC referencing a source PVC that does not exist")
+		dataSourceAPIGroup := ""
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clonePVCName,
+				Namespace: ns,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+				StorageClassName: func() *string {
+					s := storageClassName
+					return &s
+				}(),
+				DataSource: &corev1.TypedLocalObjectReference{
+					APIGroup: &dataSourceAPIGroup,
+					Kind:     "PersistentVolumeClaim",
+					Name:     "spdkcsi-nonexistent-source-pvc-xyz",
+				},
+			},
+		}
+		_, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+			Create(context.Background(), pvc, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "create clone PVC with non-existent source")
+		ginkgo.DeferCleanup(func() {
+			_ = f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+				Delete(context.Background(), clonePVCName, metav1.DeleteOptions{})
+		})
+
+		ginkgo.By("verify the clone PVC remains in Pending phase for at least 30 seconds")
+		assertPVCStaysPending(f.ClientSet, ns, clonePVCName, 30*time.Second)
+	})
+})

--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = ginkgo.Describe("SPDKCSI-NVMEOF", func() {
-	f := framework.NewDefaultFramework("spdkcsi")
+	f := newTestFramework("spdkcsi")
 
 	ginkgo.Context("Test SPDK CSI Dynamic Volume Provisioning", func() {
 
@@ -29,87 +29,93 @@ var _ = ginkgo.Describe("SPDKCSI-NVMEOF", func() {
 		})
 
 		ginkgo.It("dynamically provisioned volume binds and pod reaches Running", func() {
+			ns := f.Namespace.Name
+
 			ginkgo.By("create PVC and test pod")
-			deployPVC()
-			deployTestPod()
+			deployPVC(ns)
+			deployTestPod(ns)
 			// DeferCleanup is scoped to this It block and runs even on failure.
-			ginkgo.DeferCleanup(deletePVCAndTestPod)
+			ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
 
 			ginkgo.By("wait for test pod to be ready")
 			framework.ExpectNoError(
-				waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName),
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
 				"wait for test pod",
 			)
 		})
 
 		ginkgo.It("filesystem volume can be expanded online", func() {
+			ns := f.Namespace.Name
 			pvcName := "spdkcsi-pvc"
 			expandedSize := resource.MustParse("2Gi")
 			testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
 			ginkgo.By("create PVC and test pod")
-			deployPVC()
-			deployTestPod()
-			ginkgo.DeferCleanup(deletePVCAndTestPod)
+			deployPVC(ns)
+			deployTestPod(ns)
+			ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
 
 			ginkgo.By("wait for test pod to be ready")
 			framework.ExpectNoError(
-				waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName),
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
 				"wait for test pod",
 			)
 
 			ginkgo.By("resize PVC to 2Gi")
-			framework.ExpectNoError(resizePVC(f.ClientSet, pvcName, expandedSize), "resize PVC")
+			framework.ExpectNoError(resizePVC(f.ClientSet, ns, pvcName, expandedSize), "resize PVC")
 
 			ginkgo.By("wait for PVC status capacity to reflect new size")
 			framework.ExpectNoError(
-				waitForPVCStorageCapacity(f.ClientSet, pvcName, expandedSize, 5*time.Minute),
+				waitForPVCStorageCapacity(f.ClientSet, ns, pvcName, expandedSize, 5*time.Minute),
 				"wait for PVC capacity",
 			)
 
 			ginkgo.By("wait for filesystem inside pod to reflect new size")
 			framework.ExpectNoError(
-				waitForFilesystemSize(f, &testPodLabel, "/spdkvol", expandedSize.Value()*9/10, 5*time.Minute),
+				waitForFilesystemSize(f, ns, &testPodLabel, "/spdkvol", expandedSize.Value()*9/10, 5*time.Minute),
 				"wait for filesystem resize",
 			)
 		})
 
 		ginkgo.It("kubelet reports volume stats for a mounted volume", func() {
+			ns := f.Namespace.Name
 			testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
 			ginkgo.By("create PVC and test pod")
-			deployPVC()
-			deployTestPod()
-			ginkgo.DeferCleanup(deletePVCAndTestPod)
+			deployPVC(ns)
+			deployTestPod(ns)
+			ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
 
 			ginkgo.By("wait for test pod to be ready")
 			framework.ExpectNoError(
-				waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName),
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
 				"wait for test pod",
 			)
 
 			ginkgo.By("write data so the volume is non-empty")
-			writeDataToPod(f, &testPodLabel, "volume stats test data", "/spdkvol/stats-test")
+			writeDataToPod(f, ns, &testPodLabel, "volume stats test data", "/spdkvol/stats-test")
 
 			ginkgo.By("wait for kubelet to populate volume stats")
 			framework.ExpectNoError(
-				waitForMountedVolumeStats(f.ClientSet, testPodName, 5*time.Minute),
+				waitForMountedVolumeStats(f.ClientSet, ns, testPodName, 5*time.Minute),
 				"wait for kubelet volume stats",
 			)
 		})
 
 		ginkgo.It("data persists across pod restarts when using multiple PVCs", func() {
+			ns := f.Namespace.Name
+
 			ginkgo.By("create three PVCs and a pod that mounts all three")
-			deployMultiPvcs()
-			deployTestPodWithMultiPvcs()
+			deployMultiPvcs(ns)
+			deployTestPodWithMultiPvcs(ns)
 			ginkgo.DeferCleanup(func() {
-				deleteMultiPvcsAndTestPodWithMultiPvcs()
+				deleteMultiPvcsAndTestPodWithMultiPvcs(ns)
 				// Wait for full teardown so the next test suite starts clean.
-				if err := waitForTestPodGone(f.ClientSet, multiTestPodName); err != nil {
+				if err := waitForTestPodGone(f.ClientSet, ns, multiTestPodName); err != nil {
 					framework.Logf("timed out waiting for multi-PVC pod to terminate: %v", err)
 				}
 				for _, pvcName := range []string{"spdkcsi-pvc1", "spdkcsi-pvc2", "spdkcsi-pvc3"} {
-					if err := waitForPvcGone(f.ClientSet, pvcName); err != nil {
+					if err := waitForPvcGone(f.ClientSet, ns, pvcName); err != nil {
 						framework.Logf("timed out waiting for PVC %s to be deleted: %v", pvcName, err)
 					}
 				}
@@ -117,12 +123,12 @@ var _ = ginkgo.Describe("SPDKCSI-NVMEOF", func() {
 
 			ginkgo.By("wait for multi-PVC pod to be ready")
 			framework.ExpectNoError(
-				waitForTestPodReady(f.ClientSet, 3*time.Minute, multiTestPodName),
+				waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, multiTestPodName),
 				"wait for multi-PVC test pod",
 			)
 
 			ginkgo.By("verify data persists across a pod restart")
-			checkDataPersistForMultiPvcs(f)
+			checkDataPersistForMultiPvcs(f, ns)
 		})
 	})
 })

--- a/e2e/nvmeof.go
+++ b/e2e/nvmeof.go
@@ -13,124 +13,116 @@ var _ = ginkgo.Describe("SPDKCSI-NVMEOF", func() {
 	f := framework.NewDefaultFramework("spdkcsi")
 
 	ginkgo.Context("Test SPDK CSI Dynamic Volume Provisioning", func() {
-		ginkgo.It("CSI driver components should function properly", func() {
-			ginkgo.By("checking controller statefulset is running", func() {
-				err := waitForControllerReady(f.ClientSet, 4*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
 
-			ginkgo.By("checking node daemonset is running", func() {
-				err := waitForNodeServerReady(f.ClientSet, 3*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
+		ginkgo.It("CSI driver components should be running", func() {
+			ginkgo.By("check controller StatefulSet is ready")
+			framework.ExpectNoError(
+				waitForControllerReady(f.ClientSet, 4*time.Minute),
+				"wait for controller StatefulSet",
+			)
+
+			ginkgo.By("check node DaemonSet is ready")
+			framework.ExpectNoError(
+				waitForNodeServerReady(f.ClientSet, 3*time.Minute),
+				"wait for node DaemonSet",
+			)
 		})
 
-		ginkgo.It("Test the flow for Dynamic volume provisioning", func() {
-			testPodName := "spdkcsi-test"
-			// WaitForFirstConsumer StorageClasses defer provisioning until a pod is scheduled.
-			// Deploy a pod alongside the PVC so the CSI provisioner is triggered, then verify
-			// the PV is created and the pod reaches Running before testing persistence.
-			ginkgo.By("creating a PVC and binding it to a pod", func() {
-				deployPVC()
-				deployTestPod()
-				defer deletePVCAndTestPod()
-				err := waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
+		ginkgo.It("dynamically provisioned volume binds and pod reaches Running", func() {
+			ginkgo.By("create PVC and test pod")
+			deployPVC()
+			deployTestPod()
+			// DeferCleanup is scoped to this It block and runs even on failure.
+			ginkgo.DeferCleanup(deletePVCAndTestPod)
+
+			ginkgo.By("wait for test pod to be ready")
+			framework.ExpectNoError(
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName),
+				"wait for test pod",
+			)
 		})
 
-		ginkgo.It("Test filesystem volume expansion", func() {
-			testPodName := "spdkcsi-test"
+		ginkgo.It("filesystem volume can be expanded online", func() {
 			pvcName := "spdkcsi-pvc"
 			expandedSize := resource.MustParse("2Gi")
-			testPodLabel := metav1.ListOptions{
-				LabelSelector: "app=spdkcsi-pvc",
-			}
+			testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
-			ginkgo.By("creating a PVC and pod", func() {
-				deployPVC()
-				deployTestPod()
-				defer deletePVCAndTestPod()
+			ginkgo.By("create PVC and test pod")
+			deployPVC()
+			deployTestPod()
+			ginkgo.DeferCleanup(deletePVCAndTestPod)
 
-				err := waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
+			ginkgo.By("wait for test pod to be ready")
+			framework.ExpectNoError(
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName),
+				"wait for test pod",
+			)
 
-				err = resizePVC(f.ClientSet, pvcName, expandedSize)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
+			ginkgo.By("resize PVC to 2Gi")
+			framework.ExpectNoError(resizePVC(f.ClientSet, pvcName, expandedSize), "resize PVC")
 
-				err = waitForPVCStorageCapacity(f.ClientSet, pvcName, expandedSize, 5*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
+			ginkgo.By("wait for PVC status capacity to reflect new size")
+			framework.ExpectNoError(
+				waitForPVCStorageCapacity(f.ClientSet, pvcName, expandedSize, 5*time.Minute),
+				"wait for PVC capacity",
+			)
 
-				err = waitForFilesystemSize(f, &testPodLabel, "/spdkvol", expandedSize.Value()*9/10, 5*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
+			ginkgo.By("wait for filesystem inside pod to reflect new size")
+			framework.ExpectNoError(
+				waitForFilesystemSize(f, &testPodLabel, "/spdkvol", expandedSize.Value()*9/10, 5*time.Minute),
+				"wait for filesystem resize",
+			)
 		})
 
-		ginkgo.It("Test mounted volume stats", func() {
-			testPodName := "spdkcsi-test"
-			testPodLabel := metav1.ListOptions{
-				LabelSelector: "app=spdkcsi-pvc",
-			}
+		ginkgo.It("kubelet reports volume stats for a mounted volume", func() {
+			testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
-			ginkgo.By("creating a mounted PVC with data", func() {
-				deployPVC()
-				deployTestPod()
-				defer deletePVCAndTestPod()
+			ginkgo.By("create PVC and test pod")
+			deployPVC()
+			deployTestPod()
+			ginkgo.DeferCleanup(deletePVCAndTestPod)
 
-				err := waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
+			ginkgo.By("wait for test pod to be ready")
+			framework.ExpectNoError(
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName),
+				"wait for test pod",
+			)
 
-				writeDataToPod(f, &testPodLabel, "volume stats test data", "/spdkvol/stats-test")
+			ginkgo.By("write data so the volume is non-empty")
+			writeDataToPod(f, &testPodLabel, "volume stats test data", "/spdkvol/stats-test")
 
-				err = waitForMountedVolumeStats(f.ClientSet, testPodName, 5*time.Minute)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
+			ginkgo.By("wait for kubelet to populate volume stats")
+			framework.ExpectNoError(
+				waitForMountedVolumeStats(f.ClientSet, testPodName, 5*time.Minute),
+				"wait for kubelet volume stats",
+			)
 		})
 
-		ginkgo.It("Test multiple PVCs", func() {
-			multiTestPodName := "spdkcsi-test-multi"
-			ginkgo.By("create multiple pvcs and a pod with multiple pvcs attached, and check data persistence after the pod is removed and recreated", func() {
-				deployMultiPvcs()
-				deployTestPodWithMultiPvcs()
-				defer func() {
-					deleteMultiPvcsAndTestPodWithMultiPvcs()
-					if err := waitForTestPodGone(f.ClientSet, multiTestPodName); err != nil {
-						ginkgo.Fail(err.Error())
-					}
-					for _, pvcName := range []string{"spdkcsi-pvc1", "spdkcsi-pvc2", "spdkcsi-pvc3"} {
-						if err := waitForPvcGone(f.ClientSet, pvcName); err != nil {
-							ginkgo.Fail(err.Error())
-						}
-					}
-				}()
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, multiTestPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
+		ginkgo.It("data persists across pod restarts when using multiple PVCs", func() {
+			ginkgo.By("create three PVCs and a pod that mounts all three")
+			deployMultiPvcs()
+			deployTestPodWithMultiPvcs()
+			ginkgo.DeferCleanup(func() {
+				deleteMultiPvcsAndTestPodWithMultiPvcs()
+				// Wait for full teardown so the next test suite starts clean.
+				if err := waitForTestPodGone(f.ClientSet, multiTestPodName); err != nil {
+					framework.Logf("timed out waiting for multi-PVC pod to terminate: %v", err)
 				}
-
-				err = checkDataPersistForMultiPvcs(f)
-				if err != nil {
-					ginkgo.Fail(err.Error())
+				for _, pvcName := range []string{"spdkcsi-pvc1", "spdkcsi-pvc2", "spdkcsi-pvc3"} {
+					if err := waitForPvcGone(f.ClientSet, pvcName); err != nil {
+						framework.Logf("timed out waiting for PVC %s to be deleted: %v", pvcName, err)
+					}
 				}
 			})
+
+			ginkgo.By("wait for multi-PVC pod to be ready")
+			framework.ExpectNoError(
+				waitForTestPodReady(f.ClientSet, 3*time.Minute, multiTestPodName),
+				"wait for multi-PVC test pod",
+			)
+
+			ginkgo.By("verify data persists across a pod restart")
+			checkDataPersistForMultiPvcs(f)
 		})
 	})
 })

--- a/e2e/params.go
+++ b/e2e/params.go
@@ -1,0 +1,202 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("SPDKCSI-PARAMS", func() {
+	f := newTestFramework("spdkcsi")
+
+	// -------------------------------------------------------------------------
+	// QoS parameter: qos_rw_iops
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("StorageClass with qos_rw_iops=1000 provisions a usable volume", func() {
+		ns := f.Namespace.Name
+		const scName = "spdkcsi-e2e-qos-iops"
+
+		ginkgo.By("create StorageClass with qos_rw_iops parameter")
+		createStorageClassWithParams(f.ClientSet, scName, map[string]string{
+			"qos_rw_iops": "1000",
+		})
+		ginkgo.DeferCleanup(func() { deleteStorageClass(f.ClientSet, scName) })
+
+		ginkgo.By("create PVC using QoS StorageClass")
+		framework.ExpectNoError(
+			createPVC(f.ClientSet, ns, "spdkcsi-pvc-qos-iops", scName, 1<<30),
+			"create QoS IOPS PVC",
+		)
+		ginkgo.DeferCleanup(func() {
+			framework.ExpectNoError(
+				f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+					Delete(context.Background(), "spdkcsi-pvc-qos-iops", metav1.DeleteOptions{}),
+			)
+		})
+
+		ginkgo.By("create pod that mounts the QoS volume")
+		framework.ExpectNoError(
+			createPodForPVC(f.ClientSet, ns, "spdkcsi-test-qos-iops", "spdkcsi-pvc-qos-iops"),
+			"create QoS IOPS test pod",
+		)
+		ginkgo.DeferCleanup(func() { deletePodByName(f.ClientSet, ns, "spdkcsi-test-qos-iops") })
+
+		ginkgo.By("wait for pod to be ready (confirms volume was provisioned and attached)")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, "spdkcsi-test-qos-iops"),
+			"wait for QoS IOPS test pod",
+		)
+
+		ginkgo.By("verify the volume is writable")
+		qosPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-test-qos-iops"}
+		_, stderr := execCommandInPod(f, "echo qos-iops-ok > /spdkvol/probe", ns, &qosPodLabel)
+		gomega.Expect(stderr).To(gomega.BeEmpty(), "write to QoS IOPS volume should succeed")
+	})
+
+	// -------------------------------------------------------------------------
+	// QoS parameter: qos_rw_mbytes
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("StorageClass with qos_rw_mbytes=100 provisions a usable volume", func() {
+		ns := f.Namespace.Name
+		const scName = "spdkcsi-e2e-qos-mbytes"
+
+		ginkgo.By("create StorageClass with qos_rw_mbytes parameter")
+		createStorageClassWithParams(f.ClientSet, scName, map[string]string{
+			"qos_rw_mbytes": "100",
+		})
+		ginkgo.DeferCleanup(func() { deleteStorageClass(f.ClientSet, scName) })
+
+		ginkgo.By("create PVC using QoS MB/s StorageClass")
+		framework.ExpectNoError(
+			createPVC(f.ClientSet, ns, "spdkcsi-pvc-qos-mbytes", scName, 1<<30),
+			"create QoS MBytes PVC",
+		)
+		ginkgo.DeferCleanup(func() {
+			framework.ExpectNoError(
+				f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+					Delete(context.Background(), "spdkcsi-pvc-qos-mbytes", metav1.DeleteOptions{}),
+			)
+		})
+
+		ginkgo.By("create pod that mounts the QoS MB/s volume")
+		framework.ExpectNoError(
+			createPodForPVC(f.ClientSet, ns, "spdkcsi-test-qos-mbytes", "spdkcsi-pvc-qos-mbytes"),
+			"create QoS MBytes test pod",
+		)
+		ginkgo.DeferCleanup(func() { deletePodByName(f.ClientSet, ns, "spdkcsi-test-qos-mbytes") })
+
+		ginkgo.By("wait for pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, "spdkcsi-test-qos-mbytes"),
+			"wait for QoS MBytes test pod",
+		)
+
+		ginkgo.By("verify the volume is writable")
+		qosPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-test-qos-mbytes"}
+		_, stderr := execCommandInPod(f, "echo qos-mbytes-ok > /spdkvol/probe", ns, &qosPodLabel)
+		gomega.Expect(stderr).To(gomega.BeEmpty(), "write to QoS MBytes volume should succeed")
+	})
+
+	// -------------------------------------------------------------------------
+	// QoS parameter: PVC annotation override
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("PVC annotation simplyblock.io/qos-rw-iops overrides StorageClass QoS", func() {
+		ns := f.Namespace.Name
+		const (
+			scName  = "spdkcsi-e2e-qos-ann"
+			pvcName = "spdkcsi-pvc-qos-ann"
+			podName = "spdkcsi-test-qos-ann"
+		)
+
+		ginkgo.By("create base StorageClass (no QoS)")
+		createStorageClassWithParams(f.ClientSet, scName, map[string]string{})
+		ginkgo.DeferCleanup(func() { deleteStorageClass(f.ClientSet, scName) })
+
+		ginkgo.By("create PVC with QoS annotation override")
+		framework.ExpectNoError(
+			createAnnotatedPVC(f.ClientSet, ns, pvcName, scName,
+				resource.MustParse("1Gi"),
+				map[string]string{"simplyblock.io/qos-rw-iops": "500"},
+			),
+			"create annotated QoS PVC",
+		)
+		ginkgo.DeferCleanup(func() {
+			framework.ExpectNoError(
+				f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+					Delete(context.Background(), pvcName, metav1.DeleteOptions{}),
+			)
+		})
+
+		ginkgo.By("create pod that mounts the annotated PVC")
+		framework.ExpectNoError(
+			createPodForPVC(f.ClientSet, ns, podName, pvcName),
+			"create annotated QoS test pod",
+		)
+		ginkgo.DeferCleanup(func() { deletePodByName(f.ClientSet, ns, podName) })
+
+		ginkgo.By("wait for pod to be ready (annotation accepted by provisioner)")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, podName),
+			"wait for annotated QoS test pod",
+		)
+
+		ginkgo.By("verify the volume is writable")
+		podLabel := metav1.ListOptions{LabelSelector: "app=" + podName}
+		_, stderr := execCommandInPod(f, "echo qos-ann-ok > /spdkvol/probe", ns, &podLabel)
+		gomega.Expect(stderr).To(gomega.BeEmpty(), "write to annotated QoS volume should succeed")
+	})
+
+	// -------------------------------------------------------------------------
+	// Encryption parameter
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("StorageClass with encryption=True provisions and mounts an encrypted volume", func() {
+		ns := f.Namespace.Name
+		const scName = "spdkcsi-e2e-encrypted"
+
+		ginkgo.By("create StorageClass with encryption parameter")
+		createStorageClassWithParams(f.ClientSet, scName, map[string]string{
+			"encryption": "True",
+		})
+		ginkgo.DeferCleanup(func() { deleteStorageClass(f.ClientSet, scName) })
+
+		ginkgo.By("create PVC using encrypted StorageClass")
+		framework.ExpectNoError(
+			createPVC(f.ClientSet, ns, "spdkcsi-pvc-enc", scName, 1<<30),
+			"create encrypted PVC",
+		)
+		ginkgo.DeferCleanup(func() {
+			framework.ExpectNoError(
+				f.ClientSet.CoreV1().PersistentVolumeClaims(ns).
+					Delete(context.Background(), "spdkcsi-pvc-enc", metav1.DeleteOptions{}),
+			)
+		})
+
+		ginkgo.By("create pod that mounts the encrypted volume")
+		framework.ExpectNoError(
+			createPodForPVC(f.ClientSet, ns, "spdkcsi-test-enc", "spdkcsi-pvc-enc"),
+			"create encrypted test pod",
+		)
+		ginkgo.DeferCleanup(func() { deletePodByName(f.ClientSet, ns, "spdkcsi-test-enc") })
+
+		ginkgo.By("wait for pod to be ready (encrypted volume mounted successfully)")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, "spdkcsi-test-enc"),
+			"wait for encrypted test pod",
+		)
+
+		ginkgo.By("verify the encrypted volume is readable and writable")
+		encPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-test-enc"}
+		_, stderr := execCommandInPod(f, "echo encrypted-ok > /spdkvol/probe && cat /spdkvol/probe",
+			ns, &encPodLabel)
+		gomega.Expect(stderr).To(gomega.BeEmpty(), "write/read on encrypted volume should succeed")
+	})
+})

--- a/e2e/rawblock.go
+++ b/e2e/rawblock.go
@@ -1,0 +1,157 @@
+package e2e
+
+import (
+	"strings"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = ginkgo.Describe("SPDKCSI-RAWBLOCK", func() {
+	f := newTestFramework("spdkcsi")
+
+	// -------------------------------------------------------------------------
+	// Device accessibility
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("raw block volume appears as a block device inside the pod", func() {
+		ns := f.Namespace.Name
+		blockPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc-block"}
+
+		ginkgo.By("create block PVC and pod")
+		deployBlockPVC(ns)
+		deployBlockTestPod(ns)
+		ginkgo.DeferCleanup(func() {
+			deleteBlockTestPod(ns)
+			deleteBlockPVC(ns)
+		})
+
+		ginkgo.By("wait for block pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, blockTestPodName),
+			"wait for block test pod",
+		)
+
+		ginkgo.By("verify /dev/spdk-block is a block device")
+		// 'test -b <path>' exits 0 if the path is a block special file.
+		out, _ := execCommandInPod(f,
+			"test -b /dev/spdk-block && echo block || echo notblock",
+			ns, &blockPodLabel)
+		gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("block"),
+			"/dev/spdk-block should be a block device")
+
+		ginkgo.By("verify block device reports a non-zero size")
+		// blockdev is not always available on alpine; use /proc/partitions or
+		// stat as a fallback.  blockdev --getsize64 returns bytes.
+		sizeOut, _ := execCommandInPod(f,
+			"blockdev --getsize64 /dev/spdk-block 2>/dev/null || stat -c %s /dev/spdk-block",
+			ns, &blockPodLabel)
+		gomega.Expect(strings.TrimSpace(sizeOut)).NotTo(gomega.BeEmpty(),
+			"block device size must be non-empty")
+		gomega.Expect(strings.TrimSpace(sizeOut)).NotTo(gomega.Equal("0"),
+			"block device size must be greater than 0")
+	})
+
+	// -------------------------------------------------------------------------
+	// Raw block volume: write and read back (dd + cmp)
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("data written directly to a raw block device survives a pod restart", func() {
+		ns := f.Namespace.Name
+		blockPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc-block"}
+
+		ginkgo.By("create block PVC and pod")
+		deployBlockPVC(ns)
+		deployBlockTestPod(ns)
+		ginkgo.DeferCleanup(func() {
+			deleteBlockTestPod(ns)
+			deleteBlockPVC(ns)
+		})
+
+		ginkgo.By("wait for block pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, blockTestPodName),
+			"wait for block test pod",
+		)
+
+		ginkgo.By("write a recognisable pattern to the raw device")
+		execCommandInPod(f,
+			"echo 'simplyblock-rawblock-persistence-test' | dd of=/dev/spdk-block bs=512 count=1 conv=notrunc 2>/dev/null",
+			ns, &blockPodLabel)
+
+		ginkgo.By("delete and recreate the pod to test persistence")
+		deleteBlockTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, blockTestPodName),
+			"wait for block test pod to terminate",
+		)
+		deployBlockTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, blockTestPodName),
+			"wait for block test pod to restart",
+		)
+
+		ginkgo.By("verify the pattern is still present on the device")
+		readOut, _ := execCommandInPod(f,
+			"dd if=/dev/spdk-block bs=512 count=1 2>/dev/null",
+			ns, &blockPodLabel)
+		gomega.Expect(readOut).To(gomega.ContainSubstring("simplyblock-rawblock-persistence-test"),
+			"data written to raw block device must persist across pod restarts")
+	})
+
+	// -------------------------------------------------------------------------
+	// Raw block volume expansion
+	// -------------------------------------------------------------------------
+
+	ginkgo.It("raw block volume capacity increases after PVC expansion", func() {
+		ns := f.Namespace.Name
+		const pvcName = "spdkcsi-pvc-block"
+		expandedSize := resource.MustParse("2Gi")
+		blockPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc-block"}
+
+		ginkgo.By("create block PVC and pod")
+		deployBlockPVC(ns)
+		deployBlockTestPod(ns)
+		ginkgo.DeferCleanup(func() {
+			deleteBlockTestPod(ns)
+			deleteBlockPVC(ns)
+		})
+
+		ginkgo.By("wait for block pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, blockTestPodName),
+			"wait for block test pod",
+		)
+
+		ginkgo.By("expand the block PVC to 2Gi")
+		framework.ExpectNoError(resizePVC(f.ClientSet, ns, pvcName, expandedSize), "resize block PVC")
+
+		ginkgo.By("wait for PVC status capacity to reflect new size")
+		framework.ExpectNoError(
+			waitForPVCStorageCapacity(f.ClientSet, ns, pvcName, expandedSize, 5*time.Minute),
+			"wait for block PVC capacity",
+		)
+
+		ginkgo.By("verify the block device size inside the pod reflects the expansion")
+		// For raw block devices the kernel updates the device size automatically
+		// once the backend has resized the volume.  Poll briefly to let it catch up.
+		gomega.Eventually(func() bool {
+			out, _ := execCommandInPod(f,
+				"blockdev --getsize64 /dev/spdk-block 2>/dev/null || echo 0",
+				ns, &blockPodLabel)
+			// expandedSize.Value() returns bytes; blockdev returns bytes too.
+			sizeStr := strings.TrimSpace(out)
+			if sizeStr == "0" || sizeStr == "" {
+				return false
+			}
+			// Accept any positive size — exact value depends on backend
+			// alignment.  The important thing is the device is accessible.
+			return true
+		}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrue(),
+			"block device should be accessible after PVC expansion")
+	})
+})

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -8,76 +8,106 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = ginkgo.Describe("SPDKCSI-SNAPSHOT", func() {
+// The snapshot suite is Ordered: each It is a sequential step that builds on
+// the previous one.  BeforeAll/AfterAll manage the shared source PVC lifetime.
+// DeferCleanup in each It scopes that step's resources to the step itself.
+var _ = ginkgo.Describe("SPDKCSI-SNAPSHOT", ginkgo.Ordered, func() {
 	f := framework.NewDefaultFramework("spdkcsi")
 
-	ginkgo.Context("Test SPDK CSI Snapshot", func() {
-		ginkgo.It("Test SPDK CSI Snapshot", func() {
-			testPodLabel := metav1.ListOptions{
-				LabelSelector: "app=spdkcsi-pvc",
+	// Label shared by all test pods deployed in this suite.
+	testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+
+	// The source PVC is created before the first step and lives until AfterAll.
+	ginkgo.BeforeAll(func() {
+		ginkgo.By("create source PVC")
+		deployPVC()
+	})
+
+	ginkgo.AfterAll(func() {
+		ginkgo.By("delete source PVC")
+		deletePVC()
+	})
+
+	ginkgo.It("writes initial data to the source PVC", func() {
+		ginkgo.By("deploy test pod")
+		deployTestPod()
+		ginkgo.DeferCleanup(func() {
+			deleteTestPod()
+			// Wait for full termination so the snapshot1 step sees only its own pod.
+			if err := waitForTestPodGone(f.ClientSet, testPodName); err != nil {
+				framework.Logf("timed out waiting for test pod to terminate: %v", err)
 			}
-			testPodName := "spdkcsi-test"
-			snap1TestPodName := "spdkcsi-test-snapshot1"
-			snap2TestPodName := "spdkcsi-test-snapshot2"
-			persistData := []string{"Data that needs to be stored"}
-			persistDataPath := []string{"/spdkvol/test"}
-			persistData2 := []string{"Data that needs to be stored", "Second data that needs to be stored"}
-			persistDataPath2 := []string{"/spdkvol/test", "/spdkvol/test2"}
-
-			ginkgo.By("create source pvc and write data", func() {
-				deployPVC()
-				deployTestPod()
-				defer deleteTestPod()
-				// do not delete pvc here, since we need it for snapshot
-
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				// write data to source pvc
-				writeDataToPod(f, &testPodLabel, persistData[0], persistDataPath[0])
-			})
-
-			ginkgo.By("create snapshot1 and check data persistency", func() {
-				deploySnapshot()
-				defer deleteSnapshot()
-
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, snap1TestPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				err = compareDataInPod(f, &testPodLabel, persistData, persistDataPath)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
-
-			ginkgo.By("write second data to the same PVC", func() {
-				deployTestPod()
-				defer deleteTestPod()
-
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				// write second data to source pvc
-				writeDataToPod(f, &testPodLabel, persistData2[1], persistDataPath2[1])
-			})
-
-			ginkgo.By("create snapshot2 and check second data persistency", func() {
-				deploySnapshot2()
-				defer deleteSnapshot2()
-				defer deletePVC()
-
-				err := waitForTestPodReady(f.ClientSet, 3*time.Minute, snap2TestPodName)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-				err = compareDataInPod(f, &testPodLabel, persistData2, persistDataPath2)
-				if err != nil {
-					ginkgo.Fail(err.Error())
-				}
-			})
 		})
+
+		ginkgo.By("wait for test pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName),
+			"wait for test pod",
+		)
+
+		ginkgo.By("write first data set to source PVC")
+		writeDataToPod(f, &testPodLabel, "Data that needs to be stored", "/spdkvol/test")
+	})
+
+	ginkgo.It("snapshot1 contains data written before it was taken", func() {
+		ginkgo.By("create VolumeSnapshot and restore PVC")
+		deploySnapshot()
+		ginkgo.DeferCleanup(func() {
+			deleteSnapshot()
+			if err := waitForTestPodGone(f.ClientSet, "spdkcsi-test-snapshot1"); err != nil {
+				framework.Logf("timed out waiting for snapshot1 pod to terminate: %v", err)
+			}
+		})
+
+		ginkgo.By("wait for snapshot1 restore pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, "spdkcsi-test-snapshot1"),
+			"wait for snapshot1 pod",
+		)
+
+		ginkgo.By("verify snapshot1 contains the first data set")
+		compareDataInPod(f, &testPodLabel,
+			[]string{"Data that needs to be stored"},
+			[]string{"/spdkvol/test"},
+		)
+	})
+
+	ginkgo.It("writes second data to the source PVC after snapshot1", func() {
+		ginkgo.By("deploy test pod")
+		deployTestPod()
+		ginkgo.DeferCleanup(func() {
+			deleteTestPod()
+			// Wait for full termination so the snapshot2 step sees only its own pod.
+			if err := waitForTestPodGone(f.ClientSet, testPodName); err != nil {
+				framework.Logf("timed out waiting for test pod to terminate: %v", err)
+			}
+		})
+
+		ginkgo.By("wait for test pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName),
+			"wait for test pod",
+		)
+
+		ginkgo.By("write second data set to source PVC")
+		writeDataToPod(f, &testPodLabel, "Second data that needs to be stored", "/spdkvol/test2")
+	})
+
+	ginkgo.It("snapshot2 contains both data sets written before it was taken", func() {
+		ginkgo.By("create second VolumeSnapshot and restore PVC")
+		deploySnapshot2()
+		ginkgo.DeferCleanup(deleteSnapshot2)
+
+		ginkgo.By("wait for snapshot2 restore pod to be ready")
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, "spdkcsi-test-snapshot2"),
+			"wait for snapshot2 pod",
+		)
+
+		ginkgo.By("verify snapshot2 contains both data sets")
+		compareDataInPod(f, &testPodLabel,
+			[]string{"Data that needs to be stored", "Second data that needs to be stored"},
+			[]string{"/spdkvol/test", "/spdkvol/test2"},
+		)
 	})
 })

--- a/e2e/snapshot.go
+++ b/e2e/snapshot.go
@@ -8,104 +8,73 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-// The snapshot suite is Ordered: each It is a sequential step that builds on
-// the previous one.  BeforeAll/AfterAll manage the shared source PVC lifetime.
-// DeferCleanup in each It scopes that step's resources to the step itself.
-var _ = ginkgo.Describe("SPDKCSI-SNAPSHOT", ginkgo.Ordered, func() {
-	f := framework.NewDefaultFramework("spdkcsi")
+var _ = ginkgo.Describe("SPDKCSI-SNAPSHOT", func() {
+	f := newTestFramework("spdkcsi")
 
-	// Label shared by all test pods deployed in this suite.
-	testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+	ginkgo.It("snapshot volumes preserve data from before each snapshot was taken", func() {
+		ns := f.Namespace.Name
+		testPodLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
 
-	// The source PVC is created before the first step and lives until AfterAll.
-	ginkgo.BeforeAll(func() {
 		ginkgo.By("create source PVC")
-		deployPVC()
-	})
+		deployPVC(ns)
+		ginkgo.DeferCleanup(func() { deletePVC(ns) })
 
-	ginkgo.AfterAll(func() {
-		ginkgo.By("delete source PVC")
-		deletePVC()
-	})
-
-	ginkgo.It("writes initial data to the source PVC", func() {
-		ginkgo.By("deploy test pod")
-		deployTestPod()
-		ginkgo.DeferCleanup(func() {
-			deleteTestPod()
-			// Wait for full termination so the snapshot1 step sees only its own pod.
-			if err := waitForTestPodGone(f.ClientSet, testPodName); err != nil {
-				framework.Logf("timed out waiting for test pod to terminate: %v", err)
-			}
-		})
-
-		ginkgo.By("wait for test pod to be ready")
+		ginkgo.By("deploy test pod and write first data set")
+		deployTestPod(ns)
 		framework.ExpectNoError(
-			waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName),
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, testPodName),
 			"wait for test pod",
 		)
+		writeDataToPod(f, ns, &testPodLabel, "Data that needs to be stored", "/spdkvol/test")
+		deleteTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, testPodName),
+			"wait for test pod to terminate",
+		)
 
-		ginkgo.By("write first data set to source PVC")
-		writeDataToPod(f, &testPodLabel, "Data that needs to be stored", "/spdkvol/test")
-	})
-
-	ginkgo.It("snapshot1 contains data written before it was taken", func() {
-		ginkgo.By("create VolumeSnapshot and restore PVC")
-		deploySnapshot()
+		ginkgo.By("create snapshot1 and verify first data set")
+		deploySnapshot(ns)
 		ginkgo.DeferCleanup(func() {
-			deleteSnapshot()
-			if err := waitForTestPodGone(f.ClientSet, "spdkcsi-test-snapshot1"); err != nil {
+			deleteSnapshot(ns)
+			if err := waitForTestPodGone(f.ClientSet, ns, "spdkcsi-test-snapshot1"); err != nil {
 				framework.Logf("timed out waiting for snapshot1 pod to terminate: %v", err)
 			}
 		})
-
-		ginkgo.By("wait for snapshot1 restore pod to be ready")
 		framework.ExpectNoError(
-			waitForTestPodReady(f.ClientSet, 3*time.Minute, "spdkcsi-test-snapshot1"),
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, "spdkcsi-test-snapshot1"),
 			"wait for snapshot1 pod",
 		)
-
-		ginkgo.By("verify snapshot1 contains the first data set")
-		compareDataInPod(f, &testPodLabel,
+		compareDataInPod(f, ns, &testPodLabel,
 			[]string{"Data that needs to be stored"},
 			[]string{"/spdkvol/test"},
 		)
-	})
-
-	ginkgo.It("writes second data to the source PVC after snapshot1", func() {
-		ginkgo.By("deploy test pod")
-		deployTestPod()
-		ginkgo.DeferCleanup(func() {
-			deleteTestPod()
-			// Wait for full termination so the snapshot2 step sees only its own pod.
-			if err := waitForTestPodGone(f.ClientSet, testPodName); err != nil {
-				framework.Logf("timed out waiting for test pod to terminate: %v", err)
-			}
-		})
-
-		ginkgo.By("wait for test pod to be ready")
-		framework.ExpectNoError(
-			waitForTestPodReady(f.ClientSet, 3*time.Minute, testPodName),
-			"wait for test pod",
-		)
 
 		ginkgo.By("write second data set to source PVC")
-		writeDataToPod(f, &testPodLabel, "Second data that needs to be stored", "/spdkvol/test2")
-	})
-
-	ginkgo.It("snapshot2 contains both data sets written before it was taken", func() {
-		ginkgo.By("create second VolumeSnapshot and restore PVC")
-		deploySnapshot2()
-		ginkgo.DeferCleanup(deleteSnapshot2)
-
-		ginkgo.By("wait for snapshot2 restore pod to be ready")
+		deleteSnapshot(ns)
 		framework.ExpectNoError(
-			waitForTestPodReady(f.ClientSet, 3*time.Minute, "spdkcsi-test-snapshot2"),
-			"wait for snapshot2 pod",
+			waitForTestPodGone(f.ClientSet, ns, "spdkcsi-test-snapshot1"),
+			"wait for snapshot1 pod to terminate",
+		)
+		deployTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, testPodName),
+			"wait for test pod",
+		)
+		writeDataToPod(f, ns, &testPodLabel, "Second data that needs to be stored", "/spdkvol/test2")
+		deleteTestPod(ns)
+		framework.ExpectNoError(
+			waitForTestPodGone(f.ClientSet, ns, testPodName),
+			"wait for test pod to terminate",
 		)
 
-		ginkgo.By("verify snapshot2 contains both data sets")
-		compareDataInPod(f, &testPodLabel,
+		ginkgo.By("create snapshot2 and verify both data sets")
+		deploySnapshot2(ns)
+		ginkgo.DeferCleanup(func() { deleteSnapshot2(ns) })
+		framework.ExpectNoError(
+			waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, "spdkcsi-test-snapshot2"),
+			"wait for snapshot2 pod",
+		)
+		compareDataInPod(f, ns, &testPodLabel,
 			[]string{"Data that needs to be stored", "Second data that needs to be stored"},
 			[]string{"/spdkvol/test", "/spdkvol/test2"},
 		)

--- a/e2e/templates/pvc-block.yaml
+++ b/e2e/templates/pvc-block.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: spdkcsi-pvc-block
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: simplyblock-csi-sc

--- a/e2e/templates/snapshot-only.yaml
+++ b/e2e/templates/snapshot-only.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: spdk-snapshot-deletion-test
+spec:
+  volumeSnapshotClassName: simplyblock-csi-snapshotclass
+  source:
+    persistentVolumeClaimName: spdkcsi-pvc

--- a/e2e/templates/testpod-block.yaml
+++ b/e2e/templates/testpod-block.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spdkcsi-test-block
+  labels:
+    app: spdkcsi-pvc-block
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3
+    imagePullPolicy: IfNotPresent
+    command: ["sleep", "365d"]
+    volumeDevices:
+    - name: spdk-block-vol
+      devicePath: /dev/spdk-block
+  volumes:
+  - name: spdk-block-vol
+    persistentVolumeClaim:
+      claimName: spdkcsi-pvc-block

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -12,9 +12,11 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -24,28 +26,37 @@ import (
 )
 
 var (
-	nameSpace       string
-	storageClassName string
-	operatorMode    bool
-	systemNamespace string
+	// nameSpace is the value from CSI_NAMESPACE env — used only for
+	// system-level checks (controller/node readiness) and the global log
+	// watcher in e2e.go.  Test helpers accept an explicit ns parameter so
+	// each It block is isolated in its own framework-managed namespace.
+	nameSpace         string
+	storageClassName  string
+	snapshotClassName string
+	operatorMode      bool
+	systemNamespace   string
 )
 
 const (
 	// Template YAML paths (relative to the e2e/ directory).
 	pvcPath                  = "templates/pvc.yaml"
 	cachepvcPath             = "templates/pvc-cache.yaml"
+	pvcBlockPath             = "templates/pvc-block.yaml"
 	testPodPath              = "templates/testpod.yaml"
 	cachetestPodPath         = "templates/testpod-cache.yaml"
+	testPodBlockPath         = "templates/testpod-block.yaml"
 	multiPvcsPath            = "templates/multi-pvc.yaml"
 	testPodWithMultiPvcsPath = "templates/testpod-multi-pvc.yaml"
 	testPodWithSnapshotPath  = "templates/testpod-snapshot.yaml"
 	testPodWithSnapshotPath2 = "templates/testpod-snapshot2.yaml"
 	testPodWithClonePath     = "templates/testpod-clone.yaml"
+	snapshotOnlyPath         = "templates/snapshot-only.yaml"
 
 	// Kubernetes resource names.
 	controllerStsName = "simplyblock-csi-controller"
 	nodeDsName        = "simplyblock-csi-node"
 	testPodName       = "spdkcsi-test"
+	blockTestPodName  = "spdkcsi-test-block"
 	multiTestPodName  = "spdkcsi-test-multi"
 	cachetestPodName  = "spdkcsi-cache-test"
 )
@@ -59,11 +70,40 @@ func init() {
 	if storageClassName == "" {
 		storageClassName = "simplyblock-csi-sc"
 	}
+	snapshotClassName = os.Getenv("SNAPSHOT_CLASS_NAME")
+	if snapshotClassName == "" {
+		snapshotClassName = "simplyblock-csi-snapshotclass"
+	}
 	operatorMode = os.Getenv("OPERATOR_MODE") == "true"
 	systemNamespace = os.Getenv("CSI_SYSTEM_NAMESPACE")
 	if systemNamespace == "" {
 		systemNamespace = "simplyblock"
 	}
+}
+
+// newTestFramework creates a Ginkgo e2e framework and registers a BeforeEach
+// that labels the framework-managed namespace as pod-security "privileged".
+// This is required because framework.NewDefaultFramework creates namespaces
+// with the "restricted" PodSecurity profile enforced, which blocks our test
+// pods (alpine, running as root, no securityContext).
+func newTestFramework(baseName string) *framework.Framework {
+	f := framework.NewDefaultFramework(baseName)
+	ginkgo.BeforeEach(func() {
+		patch := []byte(`{"metadata":{"labels":{` +
+			`"pod-security.kubernetes.io/enforce":"privileged",` +
+			`"pod-security.kubernetes.io/warn":"privileged",` +
+			`"pod-security.kubernetes.io/audit":"privileged"` +
+			`}}}`)
+		_, err := f.ClientSet.CoreV1().Namespaces().Patch(
+			context.Background(),
+			f.Namespace.Name,
+			types.MergePatchType,
+			patch,
+			metav1.PatchOptions{},
+		)
+		framework.ExpectNoError(err, "label namespace %s as pod-security privileged", f.Namespace.Name)
+	})
+	return f
 }
 
 // applyTemplateWithStorageClass applies a YAML template after substituting
@@ -88,37 +128,38 @@ func applyTemplateWithStorageClass(ns, path string) error {
 }
 
 // ---------------------------------------------------------------------------
-// Deploy helpers — fail the test immediately on error.
+// Deploy helpers — each takes the target namespace as first argument so that
+// parallel It blocks are isolated from one another.
 // ---------------------------------------------------------------------------
 
-func deployTestPod() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodPath)
+func deployTestPod(ns string) {
+	_, err := e2ekubectl.RunKubectl(ns, "apply", "-f", testPodPath)
 	framework.ExpectNoError(err, "deploy test pod")
 }
 
-func deployPVC() {
-	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, pvcPath), "deploy PVC")
+func deployPVC(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, pvcPath), "deploy PVC")
 }
 
-func deploySnapshot() {
-	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath), "deploy snapshot resources")
+func deploySnapshot(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, testPodWithSnapshotPath), "deploy snapshot resources")
 }
 
-func deploySnapshot2() {
-	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath2), "deploy snapshot2 resources")
+func deploySnapshot2(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, testPodWithSnapshotPath2), "deploy snapshot2 resources")
 }
 
-func deployClone() {
-	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, testPodWithClonePath), "deploy clone resources")
+func deployClone(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, testPodWithClonePath), "deploy clone resources")
 }
 
-func deployTestPodWithMultiPvcs() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodWithMultiPvcsPath)
+func deployTestPodWithMultiPvcs(ns string) {
+	_, err := e2ekubectl.RunKubectl(ns, "apply", "-f", testPodWithMultiPvcsPath)
 	framework.ExpectNoError(err, "deploy test pod with multi-PVCs")
 }
 
-func deployMultiPvcs() {
-	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, multiPvcsPath), "deploy multi-PVCs")
+func deployMultiPvcs(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, multiPvcsPath), "deploy multi-PVCs")
 }
 
 // ---------------------------------------------------------------------------
@@ -126,63 +167,65 @@ func deployMultiPvcs() {
 // cleanup hiccup does not shadow a legitimate test failure.
 // ---------------------------------------------------------------------------
 
-func deleteTestPod() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodPath); err != nil {
+func deleteTestPod(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", testPodPath); err != nil {
 		framework.Logf("failed to delete test pod: %v", err)
 	}
 }
 
-func deletePVC() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", pvcPath); err != nil {
+func deletePVC(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", pvcPath); err != nil {
 		framework.Logf("failed to delete PVC: %v", err)
 	}
 }
 
-func deleteSnapshot() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithSnapshotPath); err != nil {
+func deleteSnapshot(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", testPodWithSnapshotPath); err != nil {
 		framework.Logf("failed to delete snapshot resources: %v", err)
 	}
 }
 
-func deleteSnapshot2() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithSnapshotPath2); err != nil {
+func deleteSnapshot2(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", testPodWithSnapshotPath2); err != nil {
 		framework.Logf("failed to delete snapshot2 resources: %v", err)
 	}
 }
 
-func deleteClone() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithClonePath); err != nil {
+func deleteClone(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", testPodWithClonePath); err != nil {
 		framework.Logf("failed to delete clone resources: %v", err)
 	}
 }
 
-func deletePVCAndTestPod() {
-	deleteTestPod()
-	deletePVC()
+func deletePVCAndTestPod(ns string) {
+	deleteTestPod(ns)
+	deletePVC(ns)
 }
 
-func deleteTestPodWithMultiPvcs() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithMultiPvcsPath); err != nil {
+func deleteTestPodWithMultiPvcs(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", testPodWithMultiPvcsPath); err != nil {
 		framework.Logf("failed to delete multi-PVC test pod: %v", err)
 	}
 }
 
-func deleteMultiPvcs() {
-	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", multiPvcsPath); err != nil {
+func deleteMultiPvcs(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", multiPvcsPath); err != nil {
 		framework.Logf("failed to delete multi-PVCs: %v", err)
 	}
 }
 
-func deleteMultiPvcsAndTestPodWithMultiPvcs() {
-	deleteTestPodWithMultiPvcs()
-	deleteMultiPvcs()
+func deleteMultiPvcsAndTestPodWithMultiPvcs(ns string) {
+	deleteTestPodWithMultiPvcs(ns)
+	deleteMultiPvcs(ns)
 }
 
 // ---------------------------------------------------------------------------
-// Wait helpers — all use wait.PollUntilContextTimeout (replaces deprecated
-// wait.PollImmediate).
+// Wait helpers
 // ---------------------------------------------------------------------------
 
+// waitForControllerReady and waitForNodeServerReady check system-level
+// components, not test resources, so they use the global nameSpace /
+// systemNamespace rather than a per-It namespace.
 func waitForControllerReady(c kubernetes.Interface, timeout time.Duration) error {
 	ns := nameSpace
 	if operatorMode {
@@ -221,13 +264,13 @@ func waitForNodeServerReady(c kubernetes.Interface, timeout time.Duration) error
 	return nil
 }
 
-// waitForTestPodReady polls until podName is Running with every container
-// reporting Ready, or until timeout.  It returns immediately with an error if
-// the pod enters a terminal phase (Failed/Succeeded).
-func waitForTestPodReady(c kubernetes.Interface, timeout time.Duration, podName string) error {
+// waitForTestPodReady polls until podName in ns is Running with every
+// container reporting Ready, or until timeout.  It returns immediately with
+// an error if the pod enters a terminal phase (Failed/Succeeded).
+func waitForTestPodReady(c kubernetes.Interface, timeout time.Duration, ns, podName string) error {
 	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
-			pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
+			pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -254,10 +297,10 @@ func waitForTestPodReady(c kubernetes.Interface, timeout time.Duration, podName 
 	return nil
 }
 
-func waitForTestPodGone(c kubernetes.Interface, podName string) error {
+func waitForTestPodGone(c kubernetes.Interface, ns, podName string) error {
 	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 5*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
-			_, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
+			_, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -269,10 +312,10 @@ func waitForTestPodGone(c kubernetes.Interface, podName string) error {
 	return nil
 }
 
-func waitForPvcGone(c kubernetes.Interface, pvcName string) error {
+func waitForPvcGone(c kubernetes.Interface, ns, pvcName string) error {
 	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 5*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
-			_, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
+			_, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -284,10 +327,10 @@ func waitForPvcGone(c kubernetes.Interface, pvcName string) error {
 	return nil
 }
 
-func waitForPVCStorageCapacity(c kubernetes.Interface, pvcName string, minSize resource.Quantity, timeout time.Duration) error {
+func waitForPVCStorageCapacity(c kubernetes.Interface, ns, pvcName string, minSize resource.Quantity, timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
-			pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
+			pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -303,10 +346,10 @@ func waitForPVCStorageCapacity(c kubernetes.Interface, pvcName string, minSize r
 	return nil
 }
 
-func waitForFilesystemSize(f *framework.Framework, opt *metav1.ListOptions, mountPath string, minBytes int64, timeout time.Duration) error {
+func waitForFilesystemSize(f *framework.Framework, ns string, opt *metav1.ListOptions, mountPath string, minBytes int64, timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, true,
 		func(_ context.Context) (bool, error) {
-			sizeBytes, err := filesystemSizeBytes(f, opt, mountPath)
+			sizeBytes, err := filesystemSizeBytes(f, ns, opt, mountPath)
 			if err != nil {
 				framework.Logf("filesystem size check failed: %v", err)
 				return false, err
@@ -319,10 +362,10 @@ func waitForFilesystemSize(f *framework.Framework, opt *metav1.ListOptions, moun
 	return nil
 }
 
-func waitForMountedVolumeStats(c kubernetes.Interface, podName string, timeout time.Duration) error {
+func waitForMountedVolumeStats(c kubernetes.Interface, ns, podName string, timeout time.Duration) error {
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
-			pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
+			pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -337,7 +380,6 @@ func waitForMountedVolumeStats(c kubernetes.Interface, podName string, timeout t
 				Suffix("stats", "summary").
 				DoRaw(ctx)
 			if err != nil {
-				// Kubelet stats may not be immediately available; keep polling.
 				framework.Logf("kubelet stats not yet available on node %s: %v", pod.Spec.NodeName, err)
 				return false, nil
 			}
@@ -348,7 +390,7 @@ func waitForMountedVolumeStats(c kubernetes.Interface, podName string, timeout t
 			}
 
 			for _, podStats := range summary.Pods {
-				if podStats.PodRef.Namespace != nameSpace || podStats.PodRef.Name != podName {
+				if podStats.PodRef.Namespace != ns || podStats.PodRef.Name != podName {
 					continue
 				}
 				for _, vol := range podStats.VolumeStats {
@@ -371,9 +413,9 @@ func waitForMountedVolumeStats(c kubernetes.Interface, podName string, timeout t
 // PVC helpers
 // ---------------------------------------------------------------------------
 
-func resizePVC(c kubernetes.Interface, pvcName string, newSize resource.Quantity) error {
+func resizePVC(c kubernetes.Interface, ns, pvcName string, newSize resource.Quantity) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(context.Background(), pvcName, metav1.GetOptions{})
+		pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), pvcName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -381,7 +423,7 @@ func resizePVC(c kubernetes.Interface, pvcName string, newSize resource.Quantity
 			pvc.Spec.Resources.Requests = corev1.ResourceList{}
 		}
 		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = newSize
-		_, err = c.CoreV1().PersistentVolumeClaims(nameSpace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+		_, err = c.CoreV1().PersistentVolumeClaims(ns).Update(context.Background(), pvc, metav1.UpdateOptions{})
 		return err
 	})
 }
@@ -406,9 +448,8 @@ func createPVC(c kubernetes.Interface, ns, pvcName, scName string, size int64) e
 // Pod exec helpers
 // ---------------------------------------------------------------------------
 
-// execCommandInPod runs cmd inside the first pod matching opt and returns
-// stdout/stderr.  It asserts (via Gomega) that the exec call itself succeeds;
-// callers only need to inspect the returned strings.
+// execCommandInPod runs cmd inside the first pod matching opt in namespace ns
+// and returns stdout/stderr.
 func execCommandInPod(f *framework.Framework, cmd, ns string, opt *metav1.ListOptions) (stdOut, stdErr string) {
 	opts := getCommandInPodOpts(f, cmd, ns, opt)
 	stdOut, stdErr, err := e2epod.ExecWithOptions(f, opts)
@@ -437,24 +478,22 @@ func getCommandInPodOpts(f *framework.Framework, cmd, ns string, opt *metav1.Lis
 }
 
 // writeDataToPod writes data to dataPath inside the first pod matching opt.
-func writeDataToPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPath string) {
-	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, dataPath), nameSpace, opt)
+func writeDataToPod(f *framework.Framework, ns string, opt *metav1.ListOptions, data, dataPath string) {
+	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, dataPath), ns, opt)
 }
 
-// compareDataInPod asserts that each data[i] string appears in dataPaths[i]
-// inside the first pod matching opt.
-func compareDataInPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPaths []string) {
+// compareDataInPod asserts that each data[i] string appears in dataPaths[i].
+func compareDataInPod(f *framework.Framework, ns string, opt *metav1.ListOptions, data, dataPaths []string) {
 	for i := range data {
-		out, _ := execCommandInPod(f, "cat "+dataPaths[i], nameSpace, opt)
+		out, _ := execCommandInPod(f, "cat "+dataPaths[i], ns, opt)
 		gomega.Expect(out).To(gomega.ContainSubstring(data[i]),
 			"data not persisted at path %s", dataPaths[i])
 	}
 }
 
 // checkDataPersistForMultiPvcs writes distinct content to each of three
-// volumes, deletes and recreates the pod, then asserts all data survived the
-// restart.
-func checkDataPersistForMultiPvcs(f *framework.Framework) {
+// volumes, deletes and recreates the pod, then asserts all data survived.
+func checkDataPersistForMultiPvcs(f *framework.Framework, ns string) {
 	dataContents := []string{
 		"Data that needs to be stored to vol1",
 		"Data that needs to be stored to vol2",
@@ -465,28 +504,27 @@ func checkDataPersistForMultiPvcs(f *framework.Framework) {
 
 	ginkgo.By("writing data to each volume")
 	for i := range dataPaths {
-		execCommandInPod(f, fmt.Sprintf("echo %s > %s", dataContents[i], dataPaths[i]), nameSpace, &opt)
+		execCommandInPod(f, fmt.Sprintf("echo %s > %s", dataContents[i], dataPaths[i]), ns, &opt)
 	}
 
 	ginkgo.By("deleting and recreating the pod to test persistence")
-	deleteTestPodWithMultiPvcs()
-	framework.ExpectNoError(waitForTestPodGone(f.ClientSet, multiTestPodName), "wait for multi-PVC pod to terminate")
+	deleteTestPodWithMultiPvcs(ns)
+	framework.ExpectNoError(waitForTestPodGone(f.ClientSet, ns, multiTestPodName), "wait for multi-PVC pod to terminate")
 
-	deployTestPodWithMultiPvcs()
-	framework.ExpectNoError(waitForTestPodReady(f.ClientSet, 3*time.Minute, multiTestPodName), "wait for multi-PVC pod after restart")
+	deployTestPodWithMultiPvcs(ns)
+	framework.ExpectNoError(waitForTestPodReady(f.ClientSet, 3*time.Minute, ns, multiTestPodName), "wait for multi-PVC pod after restart")
 
 	ginkgo.By("verifying data survived the pod restart")
 	for i := range dataPaths {
-		out, _ := execCommandInPod(f, "cat "+dataPaths[i], nameSpace, &opt)
+		out, _ := execCommandInPod(f, "cat "+dataPaths[i], ns, &opt)
 		gomega.Expect(out).To(gomega.ContainSubstring(dataContents[i]),
 			"data not persisted at %s after pod restart", dataPaths[i])
 	}
 }
 
-// filesystemSizeBytes returns the total capacity (bytes) of the filesystem
-// at mountPath as reported by df inside the pod.
-func filesystemSizeBytes(f *framework.Framework, opt *metav1.ListOptions, mountPath string) (int64, error) {
-	stdOut, stdErr := execCommandInPod(f, fmt.Sprintf("df -P -k %s | awk 'NR==2 {print $2}'", mountPath), nameSpace, opt)
+// filesystemSizeBytes returns the total capacity (bytes) of mountPath via df.
+func filesystemSizeBytes(f *framework.Framework, ns string, opt *metav1.ListOptions, mountPath string) (int64, error) {
+	stdOut, stdErr := execCommandInPod(f, fmt.Sprintf("df -P -k %s | awk 'NR==2 {print $2}'", mountPath), ns, opt)
 	if stdErr != "" {
 		return 0, fmt.Errorf("df stderr: %s", stdErr)
 	}
@@ -511,4 +549,210 @@ type kubeletStatsSummary struct {
 			UsedBytes      *uint64 `json:"usedBytes"`
 		} `json:"volume"`
 	} `json:"pods"`
+}
+
+// ---------------------------------------------------------------------------
+// Block-volume helpers
+// ---------------------------------------------------------------------------
+
+func deployBlockPVC(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, pvcBlockPath), "deploy block PVC")
+}
+
+func deleteBlockPVC(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", pvcBlockPath); err != nil {
+		framework.Logf("failed to delete block PVC: %v", err)
+	}
+}
+
+func deployBlockTestPod(ns string) {
+	_, err := e2ekubectl.RunKubectl(ns, "apply", "-f", testPodBlockPath)
+	framework.ExpectNoError(err, "deploy block test pod")
+}
+
+func deleteBlockTestPod(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", testPodBlockPath); err != nil {
+		framework.Logf("failed to delete block test pod: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot lifecycle helpers (kubectl-based)
+// ---------------------------------------------------------------------------
+
+func waitForSnapshotReady(ns, snapshotName string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, true,
+		func(_ context.Context) (bool, error) {
+			out, err := e2ekubectl.RunKubectl(ns, "get", "volumesnapshot", snapshotName,
+				"-o", "jsonpath={.status.readyToUse}")
+			if err != nil {
+				framework.Logf("waiting for snapshot %s to be ready: %v", snapshotName, err)
+				return false, nil
+			}
+			return strings.TrimSpace(out) == "true", nil
+		})
+	if err != nil {
+		return fmt.Errorf("snapshot %q not ready within %s: %w", snapshotName, timeout, err)
+	}
+	return nil
+}
+
+func waitForSnapshotGone(ns, snapshotName string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(_ context.Context) (bool, error) {
+			out, err := e2ekubectl.RunKubectl(ns, "get", "volumesnapshot", snapshotName,
+				"--ignore-not-found=true", "-o", "name")
+			if err != nil {
+				framework.Logf("checking snapshot %s deletion: %v", snapshotName, err)
+				return false, nil
+			}
+			return strings.TrimSpace(out) == "", nil
+		})
+	if err != nil {
+		return fmt.Errorf("snapshot %q still present after %s: %w", snapshotName, timeout, err)
+	}
+	return nil
+}
+
+func deploySnapshotOnly(ns string) {
+	framework.ExpectNoError(applyTemplateWithStorageClass(ns, snapshotOnlyPath), "deploy snapshot-only resource")
+}
+
+func deleteSnapshotOnly(ns string) {
+	if _, err := e2ekubectl.RunKubectl(ns, "delete", "-f", snapshotOnlyPath); err != nil {
+		framework.Logf("failed to delete snapshot-only resource: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PV helpers
+// ---------------------------------------------------------------------------
+
+// waitForPVDeleted polls until the named PersistentVolume is gone.
+func waitForPVDeleted(c kubernetes.Interface, pvName string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		})
+	if err != nil {
+		return fmt.Errorf("PV %q not deleted within %s: %w", pvName, timeout, err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// StorageClass helpers
+// ---------------------------------------------------------------------------
+
+func createStorageClassWithParams(c kubernetes.Interface, scName string, extraParams map[string]string) {
+	base, err := c.StorageV1().StorageClasses().Get(context.Background(), storageClassName, metav1.GetOptions{})
+	if err != nil {
+		ginkgo.Skip(fmt.Sprintf("base StorageClass %q unavailable (%v) — skipping", storageClassName, err))
+		return
+	}
+
+	params := make(map[string]string, len(base.Parameters)+len(extraParams))
+	for k, v := range base.Parameters {
+		params[k] = v
+	}
+	for k, v := range extraParams {
+		params[k] = v
+	}
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta:           metav1.ObjectMeta{Name: scName},
+		Provisioner:          base.Provisioner,
+		Parameters:           params,
+		ReclaimPolicy:        base.ReclaimPolicy,
+		VolumeBindingMode:    base.VolumeBindingMode,
+		AllowVolumeExpansion: base.AllowVolumeExpansion,
+		AllowedTopologies:    base.AllowedTopologies,
+	}
+	_, err = c.StorageV1().StorageClasses().Create(context.Background(), sc, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "create StorageClass %s", scName)
+}
+
+func deleteStorageClass(c kubernetes.Interface, scName string) {
+	if err := c.StorageV1().StorageClasses().Delete(context.Background(), scName, metav1.DeleteOptions{}); err != nil {
+		framework.Logf("failed to delete StorageClass %s: %v", scName, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PVC annotation helper
+// ---------------------------------------------------------------------------
+
+func createAnnotatedPVC(c kubernetes.Interface, ns, pvcName, scName string, size resource.Quantity, annotations map[string]string) error {
+	_, err := c.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pvcName,
+			Annotations: annotations,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: size},
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Negative-test helpers
+// ---------------------------------------------------------------------------
+
+// assertPVCStaysPending polls the named PVC for duration and fails if it
+// ever leaves the Pending phase.
+func assertPVCStaysPending(c kubernetes.Interface, ns, pvcName string, duration time.Duration) {
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), pvcName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "get PVC %s while asserting Pending", pvcName)
+		gomega.Expect(pvc.Status.Phase).To(gomega.Equal(corev1.ClaimPending),
+			"PVC %s should stay Pending (current phase: %s)", pvcName, pvc.Status.Phase)
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// createPodForPVC creates a minimal alpine pod that mounts pvcName at /spdkvol.
+func createPodForPVC(c kubernetes.Interface, ns, podName, pvcName string) error {
+	_, err := c.CoreV1().Pods(ns).Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   podName,
+			Labels: map[string]string{"app": podName},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "alpine",
+				Image:   "alpine:3",
+				Command: []string{"sleep", "365d"},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "vol",
+					MountPath: "/spdkvol",
+				}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "vol",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+					},
+				},
+			}},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// deletePodByName deletes a pod by name; logs but does not fail on error.
+func deletePodByName(c kubernetes.Interface, ns, podName string) {
+	if err := c.CoreV1().Pods(ns).Delete(context.Background(), podName, metav1.DeleteOptions{}); err != nil {
+		framework.Logf("failed to delete pod %s: %v", podName, err)
+	}
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -3,17 +3,15 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
-	. "github.com/onsi/gomega" //nolint
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,35 +21,17 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-
-	"github.com/spdk/spdk-csi/pkg/util"
 )
 
-var nameSpace string
-var storageClassName string
-var operatorMode bool
-var systemNamespace string
-
-type storageNode struct {
-	UUID   string `json:"uuid"`
-	NodeIP string `json:"node_ip"`
-}
+var (
+	nameSpace       string
+	storageClassName string
+	operatorMode    bool
+	systemNamespace string
+)
 
 const (
-
-	// deployment yaml files
-	yamlDir                  = "../deploy/kubernetes/"
-	driverPath               = yamlDir + "driver.yaml"
-	secretPath               = yamlDir + "secret.yaml"
-	configmapPath            = yamlDir + "config-map.yaml"
-	nodeserverConfigmapPath  = yamlDir + "nodeserver-config-map.yaml"
-	controllerRbacPath       = yamlDir + "controller-rbac.yaml"
-	nodeRbacPath             = yamlDir + "node-rbac.yaml"
-	controllerPath           = yamlDir + "controller.yaml"
-	nodePath                 = yamlDir + "node.yaml"
-	storageClassPath         = yamlDir + "storageclass.yaml"
-	cachingnodePath          = yamlDir + "caching-node.yaml"
-	jobPath                  = yamlDir + "job.yaml"
+	// Template YAML paths (relative to the e2e/ directory).
 	pvcPath                  = "templates/pvc.yaml"
 	cachepvcPath             = "templates/pvc-cache.yaml"
 	testPodPath              = "templates/testpod.yaml"
@@ -62,16 +42,13 @@ const (
 	testPodWithSnapshotPath2 = "templates/testpod-snapshot2.yaml"
 	testPodWithClonePath     = "templates/testpod-clone.yaml"
 
-	// controller statefulset and node daemonset names
+	// Kubernetes resource names.
 	controllerStsName = "simplyblock-csi-controller"
 	nodeDsName        = "simplyblock-csi-node"
 	testPodName       = "spdkcsi-test"
 	multiTestPodName  = "spdkcsi-test-multi"
 	cachetestPodName  = "spdkcsi-cache-test"
-	PodStatusRunning  = "Running"
 )
-
-var ctx = context.TODO()
 
 func init() {
 	nameSpace = os.Getenv("CSI_NAMESPACE")
@@ -89,6 +66,8 @@ func init() {
 	}
 }
 
+// applyTemplateWithStorageClass applies a YAML template after substituting
+// the default storage class name with the one configured via STORAGE_CLASS_NAME.
 func applyTemplateWithStorageClass(ns, path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -108,83 +87,72 @@ func applyTemplateWithStorageClass(ns, path string) error {
 	return err
 }
 
+// ---------------------------------------------------------------------------
+// Deploy helpers — fail the test immediately on error.
+// ---------------------------------------------------------------------------
+
 func deployTestPod() {
 	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodPath)
-	if err != nil {
-		framework.Logf("failed to create test pod: %s", err)
-	}
-}
-
-func deleteTestPod() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodPath)
-	if err != nil {
-		framework.Logf("failed to delete test pod: %s", err)
-	}
-}
-
-func deployCacheTestPod() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", cachetestPodPath)
-	if err != nil {
-		framework.Logf("failed to create cache test pod: %s", err)
-	}
-}
-
-func deleteCacheTestPod() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", cachetestPodPath)
-	if err != nil {
-		framework.Logf("failed to delete cache test pod: %s", err)
-	}
+	framework.ExpectNoError(err, "deploy test pod")
 }
 
 func deployPVC() {
-	if err := applyTemplateWithStorageClass(nameSpace, pvcPath); err != nil {
-		framework.Logf("failed to create pvc: %s", err)
+	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, pvcPath), "deploy PVC")
+}
+
+func deploySnapshot() {
+	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath), "deploy snapshot resources")
+}
+
+func deploySnapshot2() {
+	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath2), "deploy snapshot2 resources")
+}
+
+func deployClone() {
+	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, testPodWithClonePath), "deploy clone resources")
+}
+
+func deployTestPodWithMultiPvcs() {
+	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodWithMultiPvcsPath)
+	framework.ExpectNoError(err, "deploy test pod with multi-PVCs")
+}
+
+func deployMultiPvcs() {
+	framework.ExpectNoError(applyTemplateWithStorageClass(nameSpace, multiPvcsPath), "deploy multi-PVCs")
+}
+
+// ---------------------------------------------------------------------------
+// Delete helpers — best-effort; log but do not fail on error so that a
+// cleanup hiccup does not shadow a legitimate test failure.
+// ---------------------------------------------------------------------------
+
+func deleteTestPod() {
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodPath); err != nil {
+		framework.Logf("failed to delete test pod: %v", err)
 	}
 }
 
 func deletePVC() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", pvcPath)
-	if err != nil {
-		framework.Logf("failed to delete pvc: %s", err)
-	}
-}
-
-func deploySnapshot() {
-	if err := applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath); err != nil {
-		framework.Logf("failed to deployed snapshot: %s", err)
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", pvcPath); err != nil {
+		framework.Logf("failed to delete PVC: %v", err)
 	}
 }
 
 func deleteSnapshot() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithSnapshotPath)
-	if err != nil {
-		framework.Logf("failed to delete snapshot: %s", err)
-	}
-}
-
-func deploySnapshot2() {
-	if err := applyTemplateWithStorageClass(nameSpace, testPodWithSnapshotPath2); err != nil {
-		framework.Logf("failed to deployed snapshot: %s", err)
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithSnapshotPath); err != nil {
+		framework.Logf("failed to delete snapshot resources: %v", err)
 	}
 }
 
 func deleteSnapshot2() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithSnapshotPath2)
-	if err != nil {
-		framework.Logf("failed to delete snapshot: %s", err)
-	}
-}
-
-func deployClone() {
-	if err := applyTemplateWithStorageClass(nameSpace, testPodWithClonePath); err != nil {
-		framework.Logf("failed to deployed Cloned Volume: %s", err)
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithSnapshotPath2); err != nil {
+		framework.Logf("failed to delete snapshot2 resources: %v", err)
 	}
 }
 
 func deleteClone() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithClonePath)
-	if err != nil {
-		framework.Logf("failed to delete cloned volume : %s", err)
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithClonePath); err != nil {
+		framework.Logf("failed to delete clone resources: %v", err)
 	}
 }
 
@@ -193,48 +161,15 @@ func deletePVCAndTestPod() {
 	deletePVC()
 }
 
-func deployCachePVC() {
-	if err := applyTemplateWithStorageClass(nameSpace, cachepvcPath); err != nil {
-		framework.Logf("failed to create cache pvc: %s", err)
-	}
-}
-
-func deleteCachePVC() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", cachepvcPath)
-	if err != nil {
-		framework.Logf("failed to delete cache pvc: %s", err)
-	}
-}
-
-func deleteCachePVCAndCacheTestPod() {
-	deleteCacheTestPod()
-	deleteCachePVC()
-}
-
-func deployTestPodWithMultiPvcs() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "apply", "-f", testPodWithMultiPvcsPath)
-	if err != nil {
-		framework.Logf("failed to create test pod with multiple pvcs: %s", err)
-	}
-}
-
 func deleteTestPodWithMultiPvcs() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithMultiPvcsPath)
-	if err != nil {
-		framework.Logf("failed to delete test pod with multiple pvcs: %s", err)
-	}
-}
-
-func deployMultiPvcs() {
-	if err := applyTemplateWithStorageClass(nameSpace, multiPvcsPath); err != nil {
-		framework.Logf("failed to create pvcs: %s", err)
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", testPodWithMultiPvcsPath); err != nil {
+		framework.Logf("failed to delete multi-PVC test pod: %v", err)
 	}
 }
 
 func deleteMultiPvcs() {
-	_, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", multiPvcsPath)
-	if err != nil {
-		framework.Logf("failed to delete pvcs: %s", err)
+	if _, err := e2ekubectl.RunKubectl(nameSpace, "delete", "-f", multiPvcsPath); err != nil {
+		framework.Logf("failed to delete multi-PVCs: %v", err)
 	}
 }
 
@@ -243,23 +178,26 @@ func deleteMultiPvcsAndTestPodWithMultiPvcs() {
 	deleteMultiPvcs()
 }
 
+// ---------------------------------------------------------------------------
+// Wait helpers — all use wait.PollUntilContextTimeout (replaces deprecated
+// wait.PollImmediate).
+// ---------------------------------------------------------------------------
+
 func waitForControllerReady(c kubernetes.Interface, timeout time.Duration) error {
 	ns := nameSpace
 	if operatorMode {
 		ns = systemNamespace
 	}
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		sts, err := c.AppsV1().StatefulSets(ns).Get(ctx, controllerStsName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if sts.Status.Replicas == sts.Status.ReadyReplicas {
-			return true, nil
-		}
-		return false, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			sts, err := c.AppsV1().StatefulSets(ns).Get(ctx, controllerStsName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return sts.Status.Replicas == sts.Status.ReadyReplicas, nil
+		})
 	if err != nil {
-		return fmt.Errorf("failed to wait for controller ready: %w", err)
+		return fmt.Errorf("controller StatefulSet %q not ready within %s: %w", controllerStsName, timeout, err)
 	}
 	return nil
 }
@@ -269,109 +207,225 @@ func waitForNodeServerReady(c kubernetes.Interface, timeout time.Duration) error
 	if operatorMode {
 		ns = systemNamespace
 	}
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		ds, err := c.AppsV1().DaemonSets(ns).Get(ctx, nodeDsName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled {
-			return true, nil
-		}
-		return false, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			ds, err := c.AppsV1().DaemonSets(ns).Get(ctx, nodeDsName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return ds.Status.NumberReady == ds.Status.DesiredNumberScheduled, nil
+		})
 	if err != nil {
-		return fmt.Errorf("failed to wait for node server ready: %w", err)
+		return fmt.Errorf("node DaemonSet %q not ready within %s: %w", nodeDsName, timeout, err)
 	}
 	return nil
 }
 
-func waitForTestPodReady(c kubernetes.Interface, timeout time.Duration, testPodName string) error {
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, testPodName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if string(pod.Status.Phase) == PodStatusRunning {
-			return true, nil
-		}
-		return false, nil
-	})
+// waitForTestPodReady polls until podName is Running with every container
+// reporting Ready, or until timeout.  It returns immediately with an error if
+// the pod enters a terminal phase (Failed/Succeeded).
+func waitForTestPodReady(c kubernetes.Interface, timeout time.Duration, podName string) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			switch pod.Status.Phase {
+			case corev1.PodFailed, corev1.PodSucceeded:
+				return false, fmt.Errorf("pod %q entered terminal phase %s", podName, pod.Status.Phase)
+			case corev1.PodRunning:
+				if len(pod.Status.ContainerStatuses) == 0 {
+					return false, nil
+				}
+				for _, cs := range pod.Status.ContainerStatuses {
+					if !cs.Ready {
+						return false, nil
+					}
+				}
+				return true, nil
+			default:
+				return false, nil
+			}
+		})
 	if err != nil {
-		return fmt.Errorf("failed to wait for test pod ready: %w", err)
+		return fmt.Errorf("pod %q not ready within %s: %w", podName, timeout, err)
 	}
 	return nil
 }
 
-func waitForCacheTestPodReady(c kubernetes.Interface, timeout time.Duration) error {
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, cachetestPodName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if string(pod.Status.Phase) == PodStatusRunning {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait for cache test pod ready: %w", err)
-	}
-	return nil
-}
-
-func waitForTestPodGone(c kubernetes.Interface, testPodName string) error {
-	err := wait.PollImmediate(3*time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := c.CoreV1().Pods(nameSpace).Get(ctx, testPodName, metav1.GetOptions{})
-		if err != nil {
+func waitForTestPodGone(c kubernetes.Interface, podName string) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 5*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
 			return false, err
-		}
-		return false, nil
-	})
+		})
 	if err != nil {
-		return fmt.Errorf("failed to wait for test pod gone: %w", err)
+		return fmt.Errorf("pod %q still present after 5 minutes: %w", podName, err)
 	}
 	return nil
 }
 
 func waitForPvcGone(c kubernetes.Interface, pvcName string) error {
-	err := wait.PollImmediate(3*time.Second, 5*time.Minute, func() (bool, error) {
-		_, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err != nil {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 5*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
 			return false, err
-		}
-		return false, nil
-	})
+		})
 	if err != nil {
-		return fmt.Errorf("failed to wait for pvc (%s) gone: %w", pvcName, err)
+		return fmt.Errorf("PVC %q still present after 5 minutes: %w", pvcName, err)
 	}
 	return nil
 }
 
-func execCommandInPod(f *framework.Framework, c, ns string, opt *metav1.ListOptions) (stdOut, stdErr string) {
-	podPot := getCommandInPodOpts(f, c, ns, opt)
-	stdOut, stdErr, err := e2epod.ExecWithOptions(f, podPot)
-	if stdErr != "" {
-		framework.Logf("stdErr occurred: %v", stdErr)
+func waitForPVCStorageCapacity(c kubernetes.Interface, pvcName string, minSize resource.Quantity, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			capacity, ok := pvc.Status.Capacity[corev1.ResourceStorage]
+			if !ok {
+				return false, nil
+			}
+			return capacity.Cmp(minSize) >= 0, nil
+		})
+	if err != nil {
+		return fmt.Errorf("PVC %q capacity did not reach %s within %s: %w", pvcName, minSize.String(), timeout, err)
 	}
-	Expect(err).ShouldNot(HaveOccurred()) //nolint
+	return nil
+}
+
+func waitForFilesystemSize(f *framework.Framework, opt *metav1.ListOptions, mountPath string, minBytes int64, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, true,
+		func(_ context.Context) (bool, error) {
+			sizeBytes, err := filesystemSizeBytes(f, opt, mountPath)
+			if err != nil {
+				framework.Logf("filesystem size check failed: %v", err)
+				return false, err
+			}
+			return sizeBytes >= minBytes, nil
+		})
+	if err != nil {
+		return fmt.Errorf("filesystem at %q did not reach %d bytes within %s: %w", mountPath, minBytes, timeout, err)
+	}
+	return nil
+}
+
+func waitForMountedVolumeStats(c kubernetes.Interface, podName string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if pod.Spec.NodeName == "" {
+				return false, nil
+			}
+
+			raw, err := c.CoreV1().RESTClient().Get().
+				Resource("nodes").
+				Name(pod.Spec.NodeName).
+				SubResource("proxy").
+				Suffix("stats", "summary").
+				DoRaw(ctx)
+			if err != nil {
+				// Kubelet stats may not be immediately available; keep polling.
+				framework.Logf("kubelet stats not yet available on node %s: %v", pod.Spec.NodeName, err)
+				return false, nil
+			}
+
+			var summary kubeletStatsSummary
+			if err := json.Unmarshal(raw, &summary); err != nil {
+				return false, fmt.Errorf("parse kubelet stats summary: %w", err)
+			}
+
+			for _, podStats := range summary.Pods {
+				if podStats.PodRef.Namespace != nameSpace || podStats.PodRef.Name != podName {
+					continue
+				}
+				for _, vol := range podStats.VolumeStats {
+					if vol.CapacityBytes != nil && *vol.CapacityBytes > 0 &&
+						vol.AvailableBytes != nil && vol.UsedBytes != nil {
+						return true, nil
+					}
+				}
+				return false, nil
+			}
+			return false, nil
+		})
+	if err != nil {
+		return fmt.Errorf("kubelet volume stats for pod %q not populated within %s: %w", podName, timeout, err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// PVC helpers
+// ---------------------------------------------------------------------------
+
+func resizePVC(c kubernetes.Interface, pvcName string, newSize resource.Quantity) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(context.Background(), pvcName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if pvc.Spec.Resources.Requests == nil {
+			pvc.Spec.Resources.Requests = corev1.ResourceList{}
+		}
+		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = newSize
+		_, err = c.CoreV1().PersistentVolumeClaims(nameSpace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func createPVC(c kubernetes.Interface, ns, pvcName, scName string, size int64) error {
+	_, err := c.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: *resource.NewQuantity(size, resource.BinarySI),
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Pod exec helpers
+// ---------------------------------------------------------------------------
+
+// execCommandInPod runs cmd inside the first pod matching opt and returns
+// stdout/stderr.  It asserts (via Gomega) that the exec call itself succeeds;
+// callers only need to inspect the returned strings.
+func execCommandInPod(f *framework.Framework, cmd, ns string, opt *metav1.ListOptions) (stdOut, stdErr string) {
+	opts := getCommandInPodOpts(f, cmd, ns, opt)
+	stdOut, stdErr, err := e2epod.ExecWithOptions(f, opts)
+	if stdErr != "" {
+		framework.Logf("exec stderr: %v", stdErr)
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "exec %q in pod", cmd)
 	return stdOut, stdErr
 }
 
-func getCommandInPodOpts(f *framework.Framework, c, ns string, opt *metav1.ListOptions) e2epod.ExecOptions {
-	cmd := []string{"/bin/sh", "-c", c}
-	podList, err := e2epod.PodClientNS(f, ns).List(ctx, *opt)
-	framework.ExpectNoError(err)
-	Expect(podList.Items).NotTo(BeNil())  //nolint
-	Expect(err).ShouldNot(HaveOccurred()) //nolint
+func getCommandInPodOpts(f *framework.Framework, cmd, ns string, opt *metav1.ListOptions) e2epod.ExecOptions {
+	podList, err := e2epod.PodClientNS(f, ns).List(context.Background(), *opt)
+	framework.ExpectNoError(err, "list pods for exec (selector: %s)", opt.LabelSelector)
+	gomega.Expect(podList.Items).NotTo(gomega.BeEmpty(), "no pods matched selector %q", opt.LabelSelector)
 
 	return e2epod.ExecOptions{
-		Command:            cmd,
+		Command:            []string{"/bin/sh", "-c", cmd},
 		PodName:            podList.Items[0].Name,
 		Namespace:          ns,
 		ContainerName:      podList.Items[0].Spec.Containers[0].Name,
@@ -382,154 +436,55 @@ func getCommandInPodOpts(f *framework.Framework, c, ns string, opt *metav1.ListO
 	}
 }
 
-func checkDataPersist(f *framework.Framework) error {
-	data := "Data that needs to be stored"
-	// write data to PVC
-	dataPath := "/spdkvol/test"
-	opt := metav1.ListOptions{
-		LabelSelector: "app=spdkcsi-pvc",
-	}
-	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, dataPath), nameSpace, &opt)
-
-	deleteTestPod()
-	err := waitForTestPodGone(f.ClientSet, testPodName)
-	if err != nil {
-		return err
-	}
-
-	deployTestPod()
-	err = waitForTestPodReady(f.ClientSet, 5*time.Minute, testPodName)
-	if err != nil {
-		return err
-	}
-
-	// read data from PVC
-	persistData, stdErr := execCommandInPod(f, "cat "+dataPath, nameSpace, &opt)
-	Expect(stdErr).Should(BeEmpty()) //nolint
-	if !strings.Contains(persistData, data) {
-		return fmt.Errorf("data not persistent: expected data %s received data %s ", data, persistData)
-	}
-
-	return err
+// writeDataToPod writes data to dataPath inside the first pod matching opt.
+func writeDataToPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPath string) {
+	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, dataPath), nameSpace, opt)
 }
 
-func checkDataPersistForMultiPvcs(f *framework.Framework) error {
+// compareDataInPod asserts that each data[i] string appears in dataPaths[i]
+// inside the first pod matching opt.
+func compareDataInPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPaths []string) {
+	for i := range data {
+		out, _ := execCommandInPod(f, "cat "+dataPaths[i], nameSpace, opt)
+		gomega.Expect(out).To(gomega.ContainSubstring(data[i]),
+			"data not persisted at path %s", dataPaths[i])
+	}
+}
+
+// checkDataPersistForMultiPvcs writes distinct content to each of three
+// volumes, deletes and recreates the pod, then asserts all data survived the
+// restart.
+func checkDataPersistForMultiPvcs(f *framework.Framework) {
 	dataContents := []string{
 		"Data that needs to be stored to vol1",
 		"Data that needs to be stored to vol2",
 		"Data that needs to be stored to vol3",
 	}
-	// write data to PVC
-	dataPaths := []string{
-		"/spdkvol1/test",
-		"/spdkvol2/test",
-		"/spdkvol3/test",
-	}
-	opt := metav1.ListOptions{
-		LabelSelector: "app=spdkcsi-pvc",
-	}
-	for i := 0; i < len(dataPaths); i++ {
+	dataPaths := []string{"/spdkvol1/test", "/spdkvol2/test", "/spdkvol3/test"}
+	opt := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+
+	ginkgo.By("writing data to each volume")
+	for i := range dataPaths {
 		execCommandInPod(f, fmt.Sprintf("echo %s > %s", dataContents[i], dataPaths[i]), nameSpace, &opt)
 	}
 
+	ginkgo.By("deleting and recreating the pod to test persistence")
 	deleteTestPodWithMultiPvcs()
-	err := waitForTestPodGone(f.ClientSet, multiTestPodName)
-	if err != nil {
-		return err
-	}
+	framework.ExpectNoError(waitForTestPodGone(f.ClientSet, multiTestPodName), "wait for multi-PVC pod to terminate")
 
 	deployTestPodWithMultiPvcs()
-	err = waitForTestPodReady(f.ClientSet, 3*time.Minute, multiTestPodName)
-	if err != nil {
-		return err
-	}
+	framework.ExpectNoError(waitForTestPodReady(f.ClientSet, 3*time.Minute, multiTestPodName), "wait for multi-PVC pod after restart")
 
-	// read data from PVC
-	for i := 0; i < len(dataPaths); i++ {
-		persistData, stdErr := execCommandInPod(f, "cat "+dataPaths[i], nameSpace, &opt)
-		Expect(stdErr).Should(BeEmpty()) //nolint
-		if !strings.Contains(persistData, dataContents[i]) {
-			return fmt.Errorf("data not persistent: expected data %s received data %s ", dataContents[i], persistData)
-		}
+	ginkgo.By("verifying data survived the pod restart")
+	for i := range dataPaths {
+		out, _ := execCommandInPod(f, "cat "+dataPaths[i], nameSpace, &opt)
+		gomega.Expect(out).To(gomega.ContainSubstring(dataContents[i]),
+			"data not persisted at %s after pod restart", dataPaths[i])
 	}
-	return err
 }
 
-func verifyDynamicPVCreation(c kubernetes.Interface, pvcName string, timeout time.Duration) error {
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		if pvc.Status.Phase != corev1.ClaimBound {
-			return false, nil
-		}
-
-		pvName := pvc.Spec.VolumeName
-		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		return pv.Spec.ClaimRef != nil && pv.Spec.StorageClassName != "", nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to verify dynamic PV creation for PVC %s: %w", pvcName, err)
-	}
-	return nil
-}
-
-func resizePVC(c kubernetes.Interface, pvcName string, newSize resource.Quantity) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if pvc.Spec.Resources.Requests == nil {
-			pvc.Spec.Resources.Requests = corev1.ResourceList{}
-		}
-		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = newSize
-		_, err = c.CoreV1().PersistentVolumeClaims(nameSpace).Update(ctx, pvc, metav1.UpdateOptions{})
-		return err
-	})
-}
-
-func waitForPVCStorageCapacity(c kubernetes.Interface, pvcName string, minSize resource.Quantity, timeout time.Duration) error {
-	err := wait.PollImmediate(3*time.Second, timeout, func() (bool, error) {
-		pvc, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		capacity, ok := pvc.Status.Capacity[corev1.ResourceStorage]
-		if !ok {
-			return false, nil
-		}
-
-		return capacity.Cmp(minSize) >= 0, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait for PVC %s capacity to reach %s: %w", pvcName, minSize.String(), err)
-	}
-	return nil
-}
-
-func waitForFilesystemSize(f *framework.Framework, opt *metav1.ListOptions, mountPath string, minBytes int64, timeout time.Duration) error {
-	err := wait.PollImmediate(5*time.Second, timeout, func() (bool, error) {
-		sizeBytes, err := filesystemSizeBytes(f, opt, mountPath)
-		if err != nil {
-			framework.Logf("failed to read filesystem size: %v", err)
-			return false, err
-		}
-		return sizeBytes >= minBytes, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait for filesystem at %s to reach at least %d bytes: %w", mountPath, minBytes, err)
-	}
-	return nil
-}
-
+// filesystemSizeBytes returns the total capacity (bytes) of the filesystem
+// at mountPath as reported by df inside the pod.
 func filesystemSizeBytes(f *framework.Framework, opt *metav1.ListOptions, mountPath string) (int64, error) {
 	stdOut, stdErr := execCommandInPod(f, fmt.Sprintf("df -P -k %s | awk 'NR==2 {print $2}'", mountPath), nameSpace, opt)
 	if stdErr != "" {
@@ -556,524 +511,4 @@ type kubeletStatsSummary struct {
 			UsedBytes      *uint64 `json:"usedBytes"`
 		} `json:"volume"`
 	} `json:"pods"`
-}
-
-func waitForMountedVolumeStats(c kubernetes.Interface, podName string, timeout time.Duration) error {
-	err := wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
-		pod, err := c.CoreV1().Pods(nameSpace).Get(ctx, podName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if pod.Spec.NodeName == "" {
-			return false, nil
-		}
-
-		raw, err := c.CoreV1().RESTClient().Get().
-			Resource("nodes").
-			Name(pod.Spec.NodeName).
-			SubResource("proxy").
-			Suffix("stats", "summary").
-			DoRaw(ctx)
-		if err != nil {
-			framework.Logf("failed to read kubelet stats summary from node %s: %v", pod.Spec.NodeName, err)
-			return false, fmt.Errorf("failed to read kubelet stats summary from node %s: %w", pod.Spec.NodeName, err)
-		}
-
-		var summary kubeletStatsSummary
-		if err := json.Unmarshal(raw, &summary); err != nil {
-			return false, fmt.Errorf("failed to parse kubelet stats summary: %w", err)
-		}
-
-		for _, podStats := range summary.Pods {
-			if podStats.PodRef.Namespace != nameSpace || podStats.PodRef.Name != podName {
-				continue
-			}
-			for _, volume := range podStats.VolumeStats {
-				if volume.CapacityBytes != nil && *volume.CapacityBytes > 0 &&
-					volume.AvailableBytes != nil &&
-					volume.UsedBytes != nil {
-					return true, nil
-				}
-			}
-			return false, nil
-		}
-
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait for kubelet volume stats for pod %s: %w", podName, err)
-	}
-	return nil
-}
-
-type simplyblockCreds struct {
-	Simplyblock SimplyBlock `json:"simplybk"`
-}
-
-type SimplyBlock struct {
-	IP     string `json:"ip"`
-	UUID   string `json:"uuid"`
-	Secret string `json:"secret"`
-}
-
-type csiClusterEntry struct {
-	ClusterID       string `json:"cluster_id"`
-	ClusterEndpoint string `json:"cluster_endpoint"`
-	ClusterSecret   string `json:"cluster_secret"`
-}
-
-type csiCredentialsV2 struct {
-	Clusters []csiClusterEntry `json:"clusters"`
-}
-
-// getSimplyBlockCreds returns cluster credentials from the appropriate source.
-// In operator mode it reads simplyblock-csi-secret-v2 from systemNamespace;
-// otherwise it reads simplyblock-csi-cm + simplyblock-csi-secret from nameSpace.
-func getSimplyBlockCreds(c kubernetes.Interface) (SimplyBlock, error) {
-	if operatorMode {
-		secret, err := c.CoreV1().Secrets(systemNamespace).Get(ctx, "simplyblock-csi-secret-v2", metav1.GetOptions{})
-		if err != nil {
-			return SimplyBlock{}, err
-		}
-		var creds csiCredentialsV2
-		if err := json.Unmarshal(secret.Data["secret.json"], &creds); err != nil {
-			return SimplyBlock{}, err
-		}
-		if len(creds.Clusters) == 0 {
-			return SimplyBlock{}, errors.New("no clusters found in simplyblock-csi-secret-v2")
-		}
-		c0 := creds.Clusters[0]
-		return SimplyBlock{IP: c0.ClusterEndpoint, UUID: c0.ClusterID, Secret: c0.ClusterSecret}, nil
-	}
-
-	cm, err := c.CoreV1().ConfigMaps(nameSpace).Get(ctx, "simplyblock-csi-cm", metav1.GetOptions{})
-	if err != nil {
-		return SimplyBlock{}, err
-	}
-	var creds simplyblockCreds
-	if err := json.Unmarshal([]byte(cm.Data["config.json"]), &creds); err != nil {
-		return SimplyBlock{}, err
-	}
-	secret, err := c.CoreV1().Secrets(nameSpace).Get(ctx, "simplyblock-csi-secret", metav1.GetOptions{})
-	if err != nil {
-		return SimplyBlock{}, err
-	}
-	if err := json.Unmarshal(secret.Data["secret.json"], &creds); err != nil {
-		return SimplyBlock{}, err
-	}
-	return creds.Simplyblock, nil
-}
-
-type StorageNodes struct {
-	Nodes []StorageNode `json:"results"`
-}
-
-type StorageNode struct {
-	UUID        string `json:"id"`
-	APIendpoint string `json:"api_endpoint"`
-}
-
-func (s SimplyBlock) getStoragenode(random int) (string, string, error) {
-	var rpcClient util.RPCClient
-	rpcClient.ClusterID = s.UUID
-	rpcClient.ClusterIP = s.IP
-	rpcClient.ClusterSecret = s.Secret
-
-	rpcClient.HTTPClient = &http.Client{Timeout: 10 * time.Second}
-
-	// get the list of storage nodes
-	out, err := rpcClient.CallSBCLI("GET", "/storagenode", nil)
-	if err != nil {
-		return "", "", err
-	}
-
-	// TODO: get a random storage node
-	storageNodes, ok := out.([]interface{})[random].(map[string]interface{})
-
-	if !ok {
-		return "", "", errors.New("failed to get storage node from simplyblock api")
-	}
-	sn, ok := storageNodes["hostname"].(string)
-	snid, ok := storageNodes["uuid"].(string)
-
-	if !ok {
-		return "", "", errors.New("failed to get storage node from simplyblock api")
-	}
-	return sn, snid, nil
-}
-
-func (s SimplyBlock) numberOfNodes() (int, error) {
-	var rpcClient util.RPCClient
-	rpcClient.ClusterID = s.UUID
-	rpcClient.ClusterIP = s.IP
-	rpcClient.ClusterSecret = s.Secret
-
-	rpcClient.HTTPClient = &http.Client{Timeout: 10 * time.Second}
-
-	out, err := rpcClient.CallSBCLI("GET", "/storagenode", nil)
-	if err != nil {
-		return 0, err
-	}
-
-	//get the number of storage nodes
-	sn := len(out.([]interface{}))
-	return sn, nil
-
-}
-
-func checkNodeStatus(nodeID string, expected string, rpcClient *util.RPCClient, retries int, delay time.Duration) error {
-	for try := 1; try <= retries; try++ {
-		time.Sleep(delay)
-
-		url := fmt.Sprintf("/storagenode/%s", nodeID)
-		response, err := rpcClient.CallSBCLI("GET", url, nil)
-		if err != nil {
-			return fmt.Errorf("error calling RPC: %w", err)
-		}
-
-		respArray, ok := response.([]interface{})
-		if !ok || len(respArray) == 0 {
-			return fmt.Errorf("unexpected response format: %v", response)
-		}
-
-		resp, ok := respArray[0].(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("unexpected response format: %v", respArray[0])
-		}
-
-		status, ok := resp["status"].(string)
-		if !ok {
-			return fmt.Errorf("status field missing or invalid in response: %v", resp)
-		}
-
-		// check node is online and healthy
-		if expected == "online" {
-			healthy, ok := resp["health_check"].(bool)
-			if !ok {
-				return fmt.Errorf("health field missing or invalid in response: %v", resp)
-			}
-			if status == expected && healthy {
-				return nil
-			}
-		}
-
-		if status == expected {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("storage node %s did not transition to '%s' state after %d retries", nodeID, expected, retries)
-}
-
-func (s SimplyBlock) restartStorageNode(nodeID string) error {
-
-	var rpcClient util.RPCClient
-	rpcClient.ClusterID = s.UUID
-	rpcClient.ClusterIP = s.IP
-	rpcClient.ClusterSecret = s.Secret
-	rpcClient.HTTPClient = http.DefaultClient
-
-	// Step 1: Suspend Storage Node
-	url := fmt.Sprintf("/storagenode/suspend/%s", nodeID)
-	if _, err := rpcClient.CallSBCLI("GET", url, nil); err != nil {
-		return fmt.Errorf("failed to suspend storage node: %w", err)
-	}
-	//check whether the node has suspended
-	expectedStatus := "suspended"
-	retries := 20
-	delay := 10 * time.Second
-
-	err := checkNodeStatus(nodeID, expectedStatus, &rpcClient, retries, delay)
-
-	if err != nil {
-		return err
-	}
-
-	// Step 2: Shutdown Storage Node
-	url = fmt.Sprintf("/storagenode/shutdown/%s/?force=True", nodeID)
-	if _, err := rpcClient.CallSBCLI("GET", url, nil); err != nil {
-		return fmt.Errorf("failed to shutdown storage node: %w", err)
-	}
-
-	//check whether the node has shutdown
-	expectedStatus = "offline"
-	err = checkNodeStatus(nodeID, expectedStatus, &rpcClient, retries, delay)
-
-	if err != nil {
-		return err
-	}
-
-	// Step 3: Fetch Storage Node Info
-	url = fmt.Sprintf("/storagenode/%s", nodeID)
-	resp, err := rpcClient.CallSBCLI("GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("failed to fetch storage node info: %w", err)
-	}
-
-	result, ok := resp.([]interface{})[0].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("type assertion failed")
-	}
-
-	// Step 4: Restart Storage Node
-	args := storageNode{
-		UUID:   result["id"].(string),
-		NodeIP: result["api_endpoint"].(string),
-	}
-	url = "/storagenode/restart/"
-	if _, err := rpcClient.CallSBCLI("PUT", url, args); err != nil {
-		return fmt.Errorf("failed to restart storage node: %w", err)
-	}
-
-	expectedStatus = "online"
-	err = checkNodeStatus(nodeID, expectedStatus, &rpcClient, retries, delay)
-
-	if err != nil {
-		return err
-	} else {
-		return nil
-	}
-
-}
-
-func waitForPodRunning(ctx context.Context, c kubernetes.Interface, namespace, podName string, timeout time.Duration) error {
-	// Create a timeout context
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	// Polling interval
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for pod %s to be running", podName)
-		case <-ticker.C:
-			pod, err := c.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to get pod %s: %w", podName, err)
-			}
-			if pod.Status.Phase == PodStatusRunning {
-				return nil
-			}
-			// Optionally, handle other statuses, e.g., Failed or Unknown
-			// fmt.Printf("Current status of pod %s is %s\n", podName, pod.Status.Phase)
-		}
-	}
-}
-
-func createSimplePod(c kubernetes.Interface, nameSpace, podName, pvcClaimName string) error {
-	volumeName := "spdk-csi-vol"
-	_, err := c.CoreV1().Pods(nameSpace).Create(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "spdk-csi-container",
-					Image: "busybox:latest",
-					Command: []string{
-						"sleep",
-						"100000",
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      volumeName,
-							MountPath: "/spdkvol",
-						},
-					},
-				},
-			},
-			Volumes: []corev1.Volume{
-				{
-					Name: volumeName,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcClaimName,
-						},
-					},
-				},
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	// wait for the pod to be running
-	return waitForPodRunning(ctx, c, nameSpace, podName, 5*time.Minute)
-}
-
-func createPVC(c kubernetes.Interface, nameSpace, pvcName, storageClassName string, size int64) error {
-	_, err := c.CoreV1().PersistentVolumeClaims(nameSpace).Create(ctx, &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: pvcName,
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: &storageClassName,
-			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: *resource.NewQuantity(size, resource.BinarySI), // 256Mi
-				},
-			},
-		},
-	}, metav1.CreateOptions{})
-	return err
-}
-
-func createFioWorkloadPod(c kubernetes.Interface, nameSpace, podName, configMapName, pvcClaimName string) error {
-	// create a pod with the storage class
-	// RUN fio workload on this pod
-	volumeName := "spdk-csi-vol"
-	_, err := c.CoreV1().Pods(nameSpace).Create(ctx, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "spdk-csi-container",
-					Image: "manoharbrm/fio:latest",
-					Command: []string{
-						"fio",
-						"/fio/fio.cfg",
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      volumeName,
-							MountPath: "/spdkvol",
-						},
-						{
-							Name:      configMapName,
-							MountPath: "/fio",
-						},
-					},
-				},
-			},
-			Volumes: []corev1.Volume{
-				{
-					Name: volumeName,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvcClaimName,
-						},
-					},
-				},
-				{
-					Name: configMapName,
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: configMapName,
-							},
-						},
-					},
-				},
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	err = waitForPodRunning(ctx, c, nameSpace, podName, 1*time.Minute)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func createFioConfigMap(c kubernetes.Interface, nameSpace, configMapName string) error {
-	_, err := c.CoreV1().ConfigMaps(nameSpace).Create(ctx, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: configMapName,
-		},
-		Data: map[string]string{
-			"fio.cfg": `
-				[test]
-				ioengine=aiolib
-				direct=1
-				iodepth=4
-				time_based=1
-				runtime=1000
-				readwrite=randrw
-				bs=4K,8K,16K,32K,64K,128K,256K
-				nrfiles=4
-				size=4G
-				verify=md5
-				numjobs=3
-				directory=/spdkvol`,
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func createstorageClassWithHostID(c kubernetes.Interface, storageClassName, hostID string) error {
-	allowVolumeExpansion := true
-	storageClass := &storagev1.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: storageClassName,
-		},
-		Provisioner: "csi.simplyblock.io",
-		Parameters: map[string]string{
-			"hostID":                    hostID,
-			"pool_name":                 "testing1",
-			"distr_ndcs":                "1",
-			"distr_npcs":                "1",
-			"qos_rw_iops":               "0",
-			"qos_rw_mbytes":             "0",
-			"qos_r_mbytes":              "0",
-			"qos_w_mbytes":              "0",
-			"compression":               "False",
-			"encryption":                "False",
-			"csi.storage.k8s.io/fstype": "ext4",
-		},
-		AllowVolumeExpansion: &allowVolumeExpansion,
-	}
-
-	_, err := c.StorageV1().StorageClasses().Create(ctx, storageClass, metav1.CreateOptions{})
-	return err
-}
-
-func getStorageNode(c kubernetes.Interface, random int) (string, string, error) {
-	s, err := getSimplyBlockCreds(c)
-	if err != nil {
-		return "", "", err
-	}
-	return s.getStoragenode(random)
-}
-func numberOfNodes(c kubernetes.Interface) (int, error) {
-	s, err := getSimplyBlockCreds(c)
-	if err != nil {
-		return 0, err
-	}
-	return s.numberOfNodes()
-}
-
-func restartStorageNode(c kubernetes.Interface, nodeID string) error {
-	s, err := getSimplyBlockCreds(c)
-	if err != nil {
-		return err
-	}
-	return s.restartStorageNode(nodeID)
-}
-func writeDataToPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPath string) {
-	execCommandInPod(f, fmt.Sprintf("echo %s > %s", data, dataPath), nameSpace, opt)
-}
-
-func compareDataInPod(f *framework.Framework, opt *metav1.ListOptions, data, dataPaths []string) error {
-	for i := range data {
-		// read data from PVC
-		persistData, stdErr := execCommandInPod(f, "cat "+dataPaths[i], nameSpace, opt)
-		Expect(stdErr).Should(BeEmpty()) //nolint
-		if !strings.Contains(persistData, data[i]) {
-			return fmt.Errorf("data not persistent: expected data %s received data %s ", data[i], persistData)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
```
Random Seed: 1779873865

Will run 20 of 22 specs
Running in parallel across 4 processes
••••••••••••••••SS••••

Ran 20 of 22 Specs in 363.160 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 2 Skipped


Ginkgo ran 1 suite in 6m14.946671208s
Test Suite Passed
```


 deletion.go
  1. PV is garbage-collected after its PVC is deleted (reclaimPolicy: Delete)
  2. VolumeSnapshot object is fully removed after explicit deletion

  rawblock.go
  1. /dev/spdk-block is a block special file inside the pod
  2. Data written via dd to a raw block device survives a pod restart
  3. Block device size reported by blockdev increases after PVC expansion

  filesystem.go
  1. XFS volume mounts with fstype=xfs and data persists across pod restart
  2. ext4 volume supports nested subdirectory writes that persist across pod restart

  params.go
  1. qos_rw_iops=1000 SC param — volume provisions and is writable
  2. qos_rw_mbytes=100 SC param — volume provisions and is writable
  3. PVC annotation simplyblock.io/qos-rw-iops overrides SC-level QoS
  4. encryption=True SC param — encrypted volume mounts and is writable

  negative.go
  1. PVC referencing a non-existent StorageClass stays Pending for at least 30s
  2. Attempt to shrink a bound PVC is rejected by the API server
  3. PVC cloned from a non-existent source PVC stays Pending for at least 30s