### PR TITLE
isNqnConnected: use nvme list-subsys -o json

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -535,17 +535,19 @@ func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
 }
 
 func isNqnConnected(nqn string) (bool, error) {
-	cmd := exec.Command("nvme", "list-subsys")
+	cmd := exec.Command("nvme", "list-subsys", "-o", "json")
 	output, err := cmd.Output()
 	if err != nil {
 		return false, fmt.Errorf("failed to execute nvme list-subsys: %v", err)
 	}
 
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if strings.Contains(line, nqn) {
-			parts := strings.Fields(line)
-			if len(parts) > 0 {
+	var subsystems []subsystemResponse
+	if err := json.Unmarshal(output, &subsystems); err != nil {
+		return false, fmt.Errorf("failed to unmarshal nvme list-subsys output: %v", err)
+	}
+	for _, host := range subsystems {
+		for _, s := range host.Subsystems {
+			if s.NQN == nqn {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
fixes: https://github.com/simplyblock/simplyblock-operator/issues/177


using the -o json output so that parsing can be done more idiomatically. 

```
Will run 22 of 22 specs
Running in parallel across 2 processes
••••••S•••••••••••••••

Ran 21 of 22 Specs in 659.579 seconds
SUCCESS! -- 21 Passed | 0 Failed | 0 Pending | 1 Skipped


Ginkgo ran 1 suite in 11m12.237083167s
Test Suite Passed
```