### PR TITLE
fix(initiator): probe both NQN-derived model and volume UUID when locating NVMe device

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -59,7 +59,8 @@ type initiatorNVMf struct {
 	reconnectDelay string
 	nrIoQueues     string
 	ctrlLossTmo    string
-	model          string
+	model          string // lvolID derived from NQN; correct in the normal case
+	uuid           string // volume's own lvolID; may differ from model when the backend rebuilt a shared subsystem under a deletion race
 	nsId           string
 	hostIface      string
 	hostNQN        string
@@ -215,6 +216,7 @@ func NewSpdkCsiInitiator(volumeContext map[string]string) (SpdkCsiInitiator, err
 			nrIoQueues:     volumeContext["nrIoQueues"],
 			ctrlLossTmo:    volumeContext["ctrlLossTmo"],
 			model:          volumeContext["model"],
+			uuid:           volumeContext["uuid"],
 			nsId:           volumeContext["nsId"],
 			hostIface:      volumeContext["hostIface"],
 			hostNQN:        volumeContext["hostNQN"],
@@ -278,86 +280,130 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 		}
 	}
 
-	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_%s", nvmf.model, nvmf.nsId))
-
-	deviceGlobOld := fmt.Sprintf(DevDiskByID, nvmf.model)
-
-	devicePath, err := waitForDeviceReady(ctx, deviceGlob, 20)
+	// Build candidate globs. model is NQN-derived and correct in the normal
+	// case; uuid is the volume's own lvolID and correct when the backend
+	// rebuilt a shared subsystem during a deletion race (model ≠ uuid).
+	// All globs are polled in each iteration so neither path adds latency.
+	globs := nvmeDeviceGlobs(nvmf.model, nvmf.uuid, nvmf.nsId)
+	devicePath, err := waitForDeviceReady(ctx, 20, globs...)
 	if err != nil {
-		klog.Warningf("New device symlink not found (%s). Retrying legacy format: %s", deviceGlob, deviceGlobOld)
-
-		devicePath, err = waitForDeviceReady(ctx, deviceGlobOld, 10)
-		if err != nil {
-			return "", fmt.Errorf("device not found in both new (%s) and old (%s) formats: %w",
-				deviceGlob, deviceGlobOld, err)
-		}
+		return "", fmt.Errorf("device not found (tried %v): %w", globs, err)
 	}
 	return devicePath, nil
 }
 
 func (nvmf *initiatorNVMf) Disconnect(ctx context.Context) error {
-	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", nvmf.model))
-	devicePath, err := filepath.Glob(deviceGlob)
-	if err != nil {
-		return fmt.Errorf("failed to find device paths matching %s: %v", deviceGlob, err)
-	}
+	globs := nvmeDisconnectGlobs(nvmf.model, nvmf.uuid)
 
 	seen := make(map[string]bool)
-	for _, dp := range devicePath {
-		realPath, err := filepath.EvalSymlinks(dp)
+	for _, g := range globs {
+		paths, err := filepath.Glob(g)
 		if err != nil {
-			klog.Warningf("failed to resolve symlink %s: %v, skipping", dp, err)
-			continue
+			return fmt.Errorf("failed to find device paths matching %s: %v", g, err)
 		}
-		if seen[realPath] {
-			continue
-		}
-		seen[realPath] = true
-		if err := disconnectDevicePath(ctx, dp); err != nil {
-			return err
+		for _, dp := range paths {
+			realPath, err := filepath.EvalSymlinks(dp)
+			if err != nil {
+				klog.Warningf("failed to resolve symlink %s: %v, skipping", dp, err)
+				continue
+			}
+			if seen[realPath] {
+				continue
+			}
+			seen[realPath] = true
+			if err := disconnectDevicePath(ctx, dp); err != nil {
+				return err
+			}
 		}
 	}
 
-	return waitForDeviceGone(ctx, deviceGlob)
+	return waitForDeviceGone(ctx, globs...)
 }
 
-// wait for device file comes up or timeout (seconds).
-func waitForDeviceReady(ctx context.Context, deviceGlob string, seconds int) (string, error) {
+// nvmeDeviceGlobs returns the ordered list of /dev/disk/by-id globs to probe
+// for an NVMe device. model is the NQN-derived lvolID (correct in the normal
+// case); uuid is the volume's own lvolID (correct when the backend rebuilt a
+// shared subsystem during a deletion race). Duplicates are elided so when
+// model == uuid each pattern appears only once.
+func nvmeDeviceGlobs(model, uuid, nsId string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(g string) {
+		if !seen[g] {
+			seen[g] = true
+			out = append(out, g)
+		}
+	}
+	add(fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_%s", model, nsId)))
+	add(fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_%s", uuid, nsId)))
+	add(fmt.Sprintf(DevDiskByID, model))
+	add(fmt.Sprintf(DevDiskByID, uuid))
+	return out
+}
+
+// nvmeDisconnectGlobs returns globs covering all namespace symlinks for both
+// model and uuid, deduplicating when they are equal.
+func nvmeDisconnectGlobs(model, uuid string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(g string) {
+		if !seen[g] {
+			seen[g] = true
+			out = append(out, g)
+		}
+	}
+	add(fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", model)))
+	add(fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", uuid)))
+	return out
+}
+
+// waitForDeviceReady polls all globs each second until one matches or the
+// timeout elapses. All globs are checked per tick so the uuid-based fallback
+// adds no extra latency when the normal model-based path matches first.
+func waitForDeviceReady(ctx context.Context, seconds int, globs ...string) (string, error) {
 	for i := 0; i < seconds; i++ {
 		select {
 		case <-time.After(time.Second):
 		case <-ctx.Done():
 			return "", ctx.Err()
 		}
-		matches, err := filepath.Glob(deviceGlob)
-		if err != nil {
-			return "", err
-		}
-		// two symbol links under /dev/disk/by-id/ to same device
-		if len(matches) >= 1 {
-			return matches[0], nil
+		for _, g := range globs {
+			matches, err := filepath.Glob(g)
+			if err != nil {
+				return "", err
+			}
+			if len(matches) >= 1 {
+				return matches[0], nil
+			}
 		}
 	}
-	return "", fmt.Errorf("timed out waiting device ready: %s", deviceGlob)
+	return "", fmt.Errorf("timed out waiting device ready: %v", globs)
 }
 
-// wait for device file gone or timeout
-func waitForDeviceGone(ctx context.Context, deviceGlob string) error {
+// waitForDeviceGone polls until none of the globs match or the timeout elapses.
+func waitForDeviceGone(ctx context.Context, globs ...string) error {
 	for i := 0; i < 20; i++ {
 		select {
 		case <-time.After(time.Second):
 		case <-ctx.Done():
-			return fmt.Errorf("context cancelled waiting for device gone %s: %w", deviceGlob, ctx.Err())
+			return fmt.Errorf("context cancelled waiting for device gone %v: %w", globs, ctx.Err())
 		}
-		matches, err := filepath.Glob(deviceGlob)
-		if err != nil {
-			return err
+		anyPresent := false
+		for _, g := range globs {
+			matches, err := filepath.Glob(g)
+			if err != nil {
+				return err
+			}
+			if len(matches) > 0 {
+				anyPresent = true
+				break
+			}
 		}
-		if len(matches) == 0 {
+		if !anyPresent {
 			return nil
 		}
 	}
-	return fmt.Errorf("timed out waiting device gone: %s", deviceGlob)
+	return fmt.Errorf("timed out waiting device gone: %v", globs)
 }
 
 // exec shell command with timeout(in seconds)

--- a/pkg/util/initiator_test.go
+++ b/pkg/util/initiator_test.go
@@ -19,6 +19,9 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -58,4 +61,96 @@ func runExecWithTimeout(cmdLine []string, timeout int) (int, error) {
 	err := execWithTimeout(context.Background(), cmdLine, timeout)
 	elapsed := int(time.Since(start) / time.Second)
 	return elapsed, err
+}
+
+// TestNvmeDeviceGlobsDedup verifies that nvmeDeviceGlobs deduplicates entries
+// when model == uuid (the common case: own subsystem, default max_namespace_per_subsys=1).
+func TestNvmeDeviceGlobsDedup(t *testing.T) {
+	id := "e7a45cb7-1234-1234-1234-123456789abc"
+	globs := nvmeDeviceGlobs(id, id, "1")
+	if len(globs) != 2 {
+		t.Fatalf("expected 2 globs when model==uuid, got %d: %v", len(globs), globs)
+	}
+}
+
+// TestNvmeDeviceGlobsRace verifies that nvmeDeviceGlobs emits separate model
+// and uuid entries when they differ (the namespace-sharing deletion race case).
+func TestNvmeDeviceGlobsRace(t *testing.T) {
+	model := "e8a1c0d6-0000-0000-0000-000000000000"
+	uuid := "e7a45cb7-1111-1111-1111-111111111111"
+	globs := nvmeDeviceGlobs(model, uuid, "1")
+	if len(globs) != 4 {
+		t.Fatalf("expected 4 globs when model!=uuid, got %d: %v", len(globs), globs)
+	}
+}
+
+// TestWaitForDeviceReadyRace is the key regression test.
+//
+// It simulates the deletion-race scenario:
+//   - model is NQN-derived and points to a deleted volume's ID (e8a1c0d6)
+//   - uuid is the clone's own lvolID (e7a45cb7)
+//   - the backend rebuilt the NVMe subsystem for the clone using uuid as the
+//     model_number, so the device appears under *uuid*, not *model*
+//
+// Before the fix, Connect() only searched by model → timeout.
+// After the fix, Connect() searches both model and uuid per tick → uuid glob hits.
+func TestWaitForDeviceReadyRace(t *testing.T) {
+	dir := t.TempDir()
+
+	modelID := "e8a1c0d6-dead-dead-dead-deaddeaddead"
+	uuidID := "e7a45cb7-cafe-cafe-cafe-cafecafecafe"
+	nsId := "1"
+
+	// Device exists only under the uuid-based name (race: backend rebuilt
+	// subsystem with clone's own UUID as model_number).
+	deviceFile := filepath.Join(dir, fmt.Sprintf("nvme-%s_%s", uuidID, nsId))
+	if err := os.WriteFile(deviceFile, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Reproduce the pre-fix Connect() logic: single model-based glob only.
+	modelGlob := filepath.Join(dir, fmt.Sprintf("*%s*_%s", modelID, nsId))
+	_, errOld := waitForDeviceReady(ctx, 2, modelGlob)
+	if errOld == nil {
+		t.Fatal("pre-fix probe should have failed: device is not at the model path")
+	}
+
+	// Post-fix Connect() logic: model + uuid globs tried each tick.
+	uuidGlob := filepath.Join(dir, fmt.Sprintf("*%s*_%s", uuidID, nsId))
+	got, errNew := waitForDeviceReady(ctx, 2, modelGlob, uuidGlob)
+	if errNew != nil {
+		t.Fatalf("post-fix probe should have found the device: %v", errNew)
+	}
+	if got != deviceFile {
+		t.Fatalf("expected %s, got %s", deviceFile, got)
+	}
+}
+
+// TestWaitForDeviceReadyNormal verifies the common path (model == uuid, device
+// present at the model path) is unaffected by the fix.
+func TestWaitForDeviceReadyNormal(t *testing.T) {
+	dir := t.TempDir()
+
+	id := "e7a45cb7-cafe-cafe-cafe-cafecafecafe"
+	nsId := "1"
+
+	deviceFile := filepath.Join(dir, fmt.Sprintf("nvme-%s_%s", id, nsId))
+	if err := os.WriteFile(deviceFile, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	glob := filepath.Join(dir, fmt.Sprintf("*%s*_%s", id, nsId))
+	got, err := waitForDeviceReady(ctx, 2, glob)
+	if err != nil {
+		t.Fatalf("normal probe should succeed: %v", err)
+	}
+	if got != deviceFile {
+		t.Fatalf("expected %s, got %s", deviceFile, got)
+	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -169,7 +169,7 @@ func GetNvmeDeviceName(ctx context.Context, nvmeModel, bdf string) (string, erro
 	if bdf != "" {
 		var uuidFilePath string
 		// find the uuid file path for the nvme device based on the bdf
-		uuidFilePath, err = waitForDeviceReady(ctx, fmt.Sprintf("/sys/bus/pci/devices/%s/nvme/nvme*/nvme*n*/uuid", bdf), 20)
+		uuidFilePath, err = waitForDeviceReady(ctx, 20, fmt.Sprintf("/sys/bus/pci/devices/%s/nvme/nvme*/nvme*n*/uuid", bdf))
 		if err != nil {
 			return "", fmt.Errorf("failed find device at %s: %w", uuidFilePath, err)
 		}
@@ -184,7 +184,7 @@ func GetNvmeDeviceName(ctx context.Context, nvmeModel, bdf string) (string, erro
 
 	deviceGlob := "/dev/" + deviceName
 
-	return waitForDeviceReady(ctx, deviceGlob, 20)
+	return waitForDeviceReady(ctx, 20, deviceGlob)
 }
 
 // GetVirtioBlkDevice returns a block device available at the
@@ -197,9 +197,9 @@ func GetVirtioBlkDeviceName(ctx context.Context, bdf string, wait bool) (string,
 	var deviceParentDirPath string
 	var err error
 	if wait {
-		deviceParentDirPath, err = waitForDeviceReady(ctx, sysBusGlob, 20)
+		deviceParentDirPath, err = waitForDeviceReady(ctx, 20, sysBusGlob)
 	} else {
-		deviceParentDirPath, err = waitForDeviceReady(ctx, sysBusGlob, 0)
+		deviceParentDirPath, err = waitForDeviceReady(ctx, 0, sysBusGlob)
 	}
 	if err != nil {
 		klog.Errorf("could not find the deviceParentDirPath (%s): %s", sysBusGlob, err)
@@ -220,7 +220,7 @@ func GetVirtioBlkDeviceName(ctx context.Context, bdf string, wait bool) (string,
 	// wait for the block device ready for VirtioBlk, eg, in the form of "/dev/vda"
 	deviceGlob := "/dev/" + deviceName[0].Name()
 
-	return waitForDeviceReady(ctx, deviceGlob, 20)
+	return waitForDeviceReady(ctx, 20, deviceGlob)
 }
 
 // GetAvailablePhysicalFunction returns next available Pf and Vf by checking


### PR DESCRIPTION
## Root cause

The simplyblock backend uses **namespace sharing**: multiple volumes can share a single NVMe-oF subsystem (same NQN, different namespace IDs) when `max_namespace_per_subsys > 1`. The function that allocates a free slot is `get_next_available_subsystem_on_node` in `sbcli`:

```python
# First loop: count active namespaces per NQN — correctly excludes IN_DELETION volumes
for lv in all_lvols:
    if lv.status not in [STATUS_IN_DELETION, STATUS_DELETED]:
        ns_counts[lv.nqn] += 1

# Second loop: find a subsystem root with a free slot — NO status filter ← bug
for lvol in all_lvols:
    if not lvol.namespace:
        if ns_counts.get(lvol.nqn, 0) < lvol.max_namespace_per_subsys:
            return lvol.get_id(), lvol.nqn   # can return an IN_DELETION volume
```

Because the second loop has no status filter, a `STATUS_IN_DELETION` volume can be returned as an available subsystem root. This triggers the following race with `E2E_PROCS≥2`:

```
Test A: volume e8a1c0d6 → STATUS_IN_DELETION (its NVMe subsystem torn down)

Test B: clone e7a45cb7 being created
  └─ get_next_available_subsystem_on_node
       first loop:  e8a1c0d6 excluded → ns_counts["nqn...e8a1c0d6"] = 0
       second loop: 0 < max_namespace_per_subsys → returns nqn...e8a1c0d6

  Backend creates a fresh subsystem for the clone:
    NQN          = nqn...e8a1c0d6   ← from the (stale) assignment
    model_number = e7a45cb7         ← clone's own lvolID

  Device appears at: /dev/disk/by-id/nvme-e7a45cb7_..._1

CSI NodeStageVolume for clone (lvolID = e7a45cb7):
  getVolumeInfo()      → NQN = nqn...e8a1c0d6
  getLvolIDFromNQN()   → model = e8a1c0d6       ← wrong
  Connect() globs for  *e8a1c0d6*_1             ← miss
  waitForDeviceReady() → TIMEOUT after 20 s     ← failure
```

The race window is narrow and non-deterministic — the June 2 E2E run missed it, the June 3 run hit it.

## Backend mitigations already in place (sbcli)

- **`e3ee508ab`** (`_resolve_namespaced_subsystem`): before calling `nvmf_subsystem_add_ns`, verifies the target subsystem still exists on the node. If gone, downgrades the clone to its own NQN (`nqn...{clone_uuid}`) and proceeds standalone. This closes the most common window.
- **`5c71667dd`**: tightens clone idempotency checks to block re-entry while a clone is `IN_CREATION` or `IN_DELETION`.

The remaining gap: the second loop in `get_next_available_subsystem_on_node` still has no status filter, and there is a narrow window between `_resolve_namespaced_subsystem`'s subsystem check and the actual `add_ns` RPC. The correct sbcli fix is a one-liner adding `STATUS_IN_DELETION` / `STATUS_DELETED` filtering to the second loop.

## Why the CSI fix is still warranted

The backend fixes operate at clone **creation** time. They do not cover:

1. **Namespace-sharing deletion races (non-default config)**: when the root volume of a shared subsystem is deleted after the clone is created, the subsystem may be rebuilt with the clone's own UUID as `model_number` while the DB still stores the root's NQN. The CSI driver then gets a mismatched NQN from `getVolumeInfo` and `Connect()` times out.
2. **Any future backend regression** that produces a similar NQN/model mismatch.

The CSI fix is defensive for the default configuration (`max_namespace_per_subsys=1`, no sharing) and actively prevents a real failure for namespace-sharing configurations.

## What changed

### `pkg/util/initiator.go`

Added a `uuid` field to `initiatorNVMf` (the volume's own lvolID, always `volumeContext["uuid"]`) alongside the existing `model` field (NQN-derived lvolID).

`waitForDeviceReady` and `waitForDeviceGone` are made variadic so multiple globs are checked **in every poll cycle** — no extra latency is added when the normal `model`-based path matches first.

Two helper functions:

- **`nvmeDeviceGlobs(model, uuid, nsId)`** — builds the ordered candidate list, deduplicating when `model == uuid`:
  1. `*{model}*_{nsId}` — correct in the normal case and unbroken namespace sharing
  2. `*{uuid}*_{nsId}` — correct when the backend rebuilt a shared subsystem during the race
  3. `*{model}*` — legacy fallback
  4. `*{uuid}*` — legacy fallback for the race case

- **`nvmeDisconnectGlobs(model, uuid)`** — same dedup logic for the `Disconnect()` path (error-path cleanup in `NodeStageVolume`).

`Connect()` and `Disconnect()` now use these helpers. When `model == uuid` (default: every volume owns its own NQN) the dedup logic collapses to two globs and behaviour is identical to before.

### `pkg/util/util.go`

Updated the three `waitForDeviceReady` call sites to the new `(ctx, seconds, globs...)` signature.

### `pkg/util/initiator_test.go`

Four new tests:

| Test | What it verifies |
|------|-----------------|
| `TestWaitForDeviceReadyRace` | Pre-fix (model-only glob) times out; post-fix (model+uuid) finds the device |
| `TestWaitForDeviceReadyNormal` | Common path (model==uuid, device at model path) unaffected |
| `TestNvmeDeviceGlobsDedup` | Glob list collapses to 2 entries when model==uuid |
| `TestNvmeDeviceGlobsRace` | Glob list has 4 distinct entries when model!=uuid |

## How to reproduce

**Unit test (deterministic, no cluster):**
```bash
go test ./pkg/util/ -run TestWaitForDeviceReadyRace -v
```

The test re-enacts the race: creates a fake device file at the `uuid`-based path, shows the pre-fix model-only probe times out after 2 s, then shows the post-fix dual-probe finds it immediately.

**On a real cluster (`E2E_PROCS≥2`):**

Run parallel tests on the same storage node — one deleting a volume, one simultaneously creating a clone from a snapshot. The race window is narrow; increase `E2E_PROCS` or loop the clone test while continuously cycling volume create/delete to raise collision probability.

## Behaviour summary

| Scenario | model | uuid | Device at | Before | After |
|----------|-------|------|-----------|--------|-------|
| Normal (own subsystem, default) | e7a45cb7 | e7a45cb7 | `*e7a45cb7*_1` | ✅ | ✅ |
| Race (shared NQN, rebuilt subsystem) | e8a1c0d6 | e7a45cb7 | `*e7a45cb7*_1` | ❌ 20 s timeout | ✅ |
| Namespace sharing, no race | e8a1c0d6 | e7a45cb7 | `*e8a1c0d6*_2` | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)