### PR TITLE
fix: add jitter, exponential backoff, and circuit breaker to MonitorC…

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -782,12 +783,44 @@ func confirmSubsystemNeedsRecovery(subsystem *subsystem, devicePath string, init
 // MonitorConnection monitors NVMe-oF connections and reconnects missing or
 // IP-changed paths. Supports 1-path, 2-path, and 3-path volumes
 // (1 optimized + up to 2 non-optimized).
+const (
+	monitorBaseInterval  = 3 * time.Second
+	monitorJitter        = 500 * time.Millisecond
+	monitorMaxBackoff    = 60 * time.Second
+	monitorCircuitAfter  = 5
+	monitorCircuitCooldown = 30 * time.Second
+)
+
 func MonitorConnection(markBroken func(lvolID string)) {
+	var (
+		consecutiveErrors int
+		backoff           = monitorBaseInterval
+	)
+
 	for {
-		if err := reconnectSubsystems(markBroken); err != nil {
-			klog.Errorf("MonitorConnection error: %v", err)
+		err := reconnectSubsystems(markBroken)
+		if err != nil {
+			consecutiveErrors++
+			klog.Errorf("MonitorConnection error (%d consecutive): %v", consecutiveErrors, err)
+
+			if consecutiveErrors >= monitorCircuitAfter {
+				klog.Warningf("MonitorConnection: circuit open after %d failures, cooling down for %s", consecutiveErrors, monitorCircuitCooldown)
+				time.Sleep(monitorCircuitCooldown)
+				continue
+			}
+
+			// exponential backoff capped at monitorMaxBackoff
+			backoff *= 2
+			if backoff > monitorMaxBackoff {
+				backoff = monitorMaxBackoff
+			}
+		} else {
+			consecutiveErrors = 0
+			backoff = monitorBaseInterval
 		}
-		time.Sleep(3 * time.Second)
+
+		jitter := time.Duration(rand.Int63n(int64(monitorJitter)))
+		time.Sleep(backoff + jitter)
 	}
 }
 


### PR DESCRIPTION
…onnection

fixes: [175](https://github.com/simplyblock/simplyblock-operator/issues/175)


With 100 volumes, MonitorConnection generates ~33 HTTP calls/second to sbcli. Under sbcli degradation (response > 3s), outstanding connections accumulate — up to ~3,000 simultaneous open connections if sbcli takes the full 90s timeout. Without backoff, a downed sbcli triggers a constant retry storm every 3s indefinitely.

This PR adds 500ms random jitter to desynchronize polling goroutines across volumes, exponential backoff on consecutive errors (3s → 60s cap) to reduce API pressure during degradation, and a circuit breaker after 5 consecutive failures that holds for 30s to eliminate log storms and connection churn when sbcli is down. Backoff and error count reset to baseline on any successful poll.