### PR TITLE
feat: recover PVC binding when volume already exists by finding onlin…

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -621,9 +620,7 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 	vol.VolumeContext["qos_r_mbytes"] = createVolReq.MaxRmBytes
 	vol.VolumeContext["qos_w_mbytes"] = createVolReq.MaxWmBytes
 
-	createCtx, createCancel := context.WithTimeout(ctx, 300*time.Millisecond)
-	defer createCancel()
-	volumeID, err := sbclient.CreateVolume(createCtx, createVolReq)
+	volumeID, err := sbclient.CreateVolume(ctx, createVolReq)
 	if err != nil {
 		if errors.Is(err, util.ErrJSONVolumeExists) {
 			klog.Infof("createVolume: volume %q already exists, searching for online match", req.GetName())

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -622,6 +622,22 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 
 	volumeID, err := sbclient.CreateVolume(ctx, createVolReq)
 	if err != nil {
+		if errors.Is(err, util.ErrJSONVolumeExists) {
+			klog.Infof("createVolume: volume %q already exists, searching for online match", req.GetName())
+			volumes, listErr := sbclient.ListVolumes(ctx)
+			if listErr != nil {
+				klog.Errorf("createVolume: failed to list volumes during exists fallback: %v", listErr)
+				return nil, err
+			}
+			for _, v := range volumes {
+				if v.Name == req.GetName() && v.Status == "online" {
+					klog.Infof("createVolume: found online existing volume %q id=%s", req.GetName(), v.UUID)
+					vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), v.UUID)
+					return &vol, nil
+				}
+			}
+			klog.Errorf("createVolume: volume %q exists but is not online", req.GetName())
+		}
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
 	}

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -621,7 +621,7 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 	vol.VolumeContext["qos_r_mbytes"] = createVolReq.MaxRmBytes
 	vol.VolumeContext["qos_w_mbytes"] = createVolReq.MaxWmBytes
 
-	createCtx, createCancel := context.WithTimeout(ctx, 1*time.Second)
+	createCtx, createCancel := context.WithTimeout(ctx, 300*time.Millisecond)
 	defer createCancel()
 	volumeID, err := sbclient.CreateVolume(createCtx, createVolReq)
 	if err != nil {

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -620,7 +621,9 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 	vol.VolumeContext["qos_r_mbytes"] = createVolReq.MaxRmBytes
 	vol.VolumeContext["qos_w_mbytes"] = createVolReq.MaxWmBytes
 
-	volumeID, err := sbclient.CreateVolume(ctx, createVolReq)
+	createCtx, createCancel := context.WithTimeout(ctx, 1*time.Second)
+	defer createCancel()
+	volumeID, err := sbclient.CreateVolume(createCtx, createVolReq)
 	if err != nil {
 		if errors.Is(err, util.ErrJSONVolumeExists) {
 			klog.Infof("createVolume: volume %q already exists, searching for online match", req.GetName())
@@ -1010,4 +1013,3 @@ func pvcAnnotation(annotations map[string]string, newKey, deprecatedKey string) 
 	}
 	return annotations[deprecatedKey]
 }
-

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -225,7 +225,7 @@ func (client APIClient) createVolume(ctx context.Context, poolID string, params 
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
-		} else if errorMatches(err, ErrJSONVolumeExists) || strings.Contains(strings.ToLower(err.Error()), "conflict") {
+		} else if strings.Contains(strings.ToLower(err.Error()), "exists") || strings.Contains(strings.ToLower(err.Error()), "conflict") {
 			err = ErrJSONVolumeExists
 		}
 		return "", err

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -35,6 +35,7 @@ import (
 var (
 	ErrJSONNoSpaceLeft  = errors.New("json: No space left")
 	ErrJSONNoSuchDevice = errors.New("json: No such device")
+	ErrJSONVolumeExists = errors.New("json: Volume exists")
 
 	// internal errors
 	ErrVolumeDeleted     = errors.New("volume deleted")
@@ -224,6 +225,8 @@ func (client APIClient) createVolume(ctx context.Context, poolID string, params 
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSpaceLeft) {
 			err = ErrJSONNoSpaceLeft
+		} else if errorMatches(err, ErrJSONVolumeExists) || strings.Contains(strings.ToLower(err.Error()), "conflict") {
+			err = ErrJSONVolumeExists
 		}
 		return "", err
 	}


### PR DESCRIPTION
…e lvol on create conflict

```
Events:
  Type     Reason                 Age                From                                                                                   Message
  ----     ------                 ----               ----                                                                                   -------
  Normal   ExternalProvisioning   12s (x2 over 12s)  persistentvolume-controller                                                            Waiting for a volume to be created either by the external provisioner 'csi.simplyblock.io' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Warning  ProvisioningFailed     12s                csi.simplyblock.io_vm04.simplyblock3.localdomain_85455e7a-99af-4ccf-bb2c-37f4cbcae48d  failed to provision volume with StorageClass "simplyblock-csi-sc": rpc error: code = Internal desc = POST: Post "http://192.168.10.91/api/v2/clusters/c6e7522d-ad1b-4ccf-8e3c-8383616722aa/storage-pools/54872cc9-7f18-415d-bea1-5a2784c3762b/volumes/": context deadline exceeded
  Normal   Provisioning           10s (x2 over 12s)  csi.simplyblock.io_vm04.simplyblock3.localdomain_85455e7a-99af-4ccf-bb2c-37f4cbcae48d  External provisioner is provisioning volume for claim "default/spdkcsi-pvc"
  Normal   ProvisioningSucceeded  10s                csi.simplyblock.io_vm04.simplyblock3.localdomain_85455e7a-99af-4ccf-bb2c-37f4cbcae48d  Successfully provisioned volume pvc-0add419e-997f-48c1-8a00-794ac5f24967

```