### PR TITLE
Fixes volume connection with more than one storage pool

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -77,7 +77,7 @@ type controllerServer struct {
 type spdkVolume struct {
 	clusterID string
 	lvolID    string
-	poolName  string
+	poolID    string
 }
 
 type spdkSnapshot struct {
@@ -411,7 +411,7 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		klog.Errorf("failed to get spdk volume, volumeID: %s err: %v", volumeID, err)
 		return nil, err
 	}
-	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -649,21 +649,17 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 }
 
 func getSPDKVol(csiVolumeID string) (*spdkVolume, error) {
-	// extract clusterID, poolID and spdkLvolID from csiVolumeID
-	// csiVolumeID: 8ffac363-0c46-4714-a71b-f9c0b58a1269:pool01:8e2dcb9d-3a79-4362-965e-fdb0cd3f4b8d
-	// ClusterID: 8ffac363-0c46-4714-a71b-f9c0b58a1269
-	// spdkNodeName: node001
-	// spdklvolID: 8e2dcb9d-3a79-4362-965e-fdb0cd3f4b8d
-
+	// csiVolumeID format: {clusterUUID}:{poolUUID}:{lvolUUID}
+	// e.g. 8ffac363-0c46-4714-a71b-f9c0b58a1269:df34f16c-...:8e2dcb9d-...
 	ids := strings.Split(csiVolumeID, ":")
 	if len(ids) == 3 {
 		return &spdkVolume{
 			clusterID: ids[0],
-			poolName:  ids[1],
+			poolID:    ids[1],
 			lvolID:    ids[2],
 		}, nil
 	}
-	return nil, fmt.Errorf("missing clusterID or poolName in volume: %s", csiVolumeID)
+	return nil, fmt.Errorf("missing clusterID or poolID in volume: %s", csiVolumeID)
 }
 
 func getSnapshot(csiSnapshotID string) (*spdkSnapshot, error) {
@@ -706,7 +702,7 @@ func (cs *controllerServer) deleteVolume(ctx context.Context, volumeID string) e
 	if err != nil {
 		return err
 	}
-	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
 	if err != nil {
 		return err
 	}
@@ -718,7 +714,7 @@ func (cs *controllerServer) unpublishVolume(ctx context.Context, volumeID string
 	if err != nil {
 		return err
 	}
-	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
 	if err != nil {
 		return err
 	}
@@ -740,7 +736,7 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		return nil, err
 	}
 
-	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +848,7 @@ func (cs *controllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 		return nil, err
 	}
 
-	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -963,7 +959,7 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 		return nil, err
 	}
 	// Volume clone goes to the same pool as the source volume.
-	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
+	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -251,14 +251,14 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	// When the volume was provisioned against a pool with allowed_hosts, the controller
-	// couldn't fetch connection info (no host NQN available there). Re-fetch it here using
-	// the node's host NQN so that NewSpdkCsiInitiator gets the fields it needs.
-	if vc["nqn"] == "" || vc["targetType"] == "" {
-		spdkVol, parseErr := getSPDKVol(volumeID)
-		if parseErr == nil {
-			sbcClient, clientErr := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolName)
-			if clientErr == nil {
+	if spdkVol, err := getSPDKVol(volumeID); err == nil {
+		vc["poolID"] = spdkVol.poolID
+
+		// When the volume was provisioned against a pool with allowed_hosts, the controller
+		// couldn't fetch connection info (no host NQN available there). Re-fetch it here using
+		// the node's host NQN so that NewSpdkCsiInitiator gets the fields it needs.
+		if vc["nqn"] == "" || vc["targetType"] == "" {
+			if sbcClient, clientErr := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID); clientErr == nil {
 				connInfo, infoErr := sbcClient.VolumeInfo(ctx, spdkVol.lvolID, vc["hostNQN"])
 				if infoErr != nil {
 					klog.Errorf("failed to fetch volume connection info for %s: %v", volumeID, infoErr)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -69,6 +69,7 @@ type initiatorNVMf struct {
 	nsId           string
 	hostIface      string
 	hostNQN        string
+	poolID         string
 }
 
 type path struct {
@@ -223,6 +224,7 @@ func NewSpdkCsiInitiator(volumeContext map[string]string) (SpdkCsiInitiator, err
 			nsId:           volumeContext["nsId"],
 			hostIface:      volumeContext["hostIface"],
 			hostNQN:        volumeContext["hostNQN"],
+			poolID:         volumeContext["poolID"],
 		}, nil
 
 	default:
@@ -250,7 +252,7 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 
 	if !alreadyConnected {
 		clusterID, lvolID := getLvolIDFromNQN(nvmf.nqn)
-		sbcClient, err := NewsimplyBlockClient(ctx, clusterID, "")
+		sbcClient, err := NewsimplyBlockClient(ctx, clusterID, nvmf.poolID)
 		if err != nil {
 			klog.Errorf("failed to create SPDK client: %v", err)
 			return "", err

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -620,7 +620,7 @@ func (client APIClient) do(ctx context.Context, method, path string, body any) (
 		if msg == "" {
 			msg = http.StatusText(resp.StatusCode)
 		}
-		return nil, fmt.Errorf("%s: %s", method, msg)
+		return nil, fmt.Errorf("%s %d: %s", method, resp.StatusCode, msg)
 	}
 
 	return json.RawMessage(raw), nil

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -517,6 +517,7 @@ func (client APIClient) findPoolForVolume(ctx context.Context, lvolID string) (s
 		if err == nil {
 			return pool.UUID, nil
 		}
+		// FIXME: instead of parsing error messages, use an HTTP error type with status code
 		if !errorMatches(err, ErrJSONNoSuchDevice) && !strings.Contains(err.Error(), "404") {
 			return "", fmt.Errorf("unexpected error searching for volume %s in pool %s: %w", lvolID, pool.UUID, err)
 		}

--- a/pkg/util/jsonrpc_test.go
+++ b/pkg/util/jsonrpc_test.go
@@ -96,6 +96,119 @@ func TestCloneVolumeUsesPostAndLocationHeader(t *testing.T) {
 	}
 }
 
+func TestFindPoolForVolume(t *testing.T) {
+	const poolsPath = "/api/v2/clusters/cluster-id/storage-pools/"
+	const volPath1 = "/api/v2/clusters/cluster-id/storage-pools/pool-1/volumes/vol-abc/"
+	const volPath2 = "/api/v2/clusters/cluster-id/storage-pools/pool-2/volumes/vol-abc/"
+
+	const twoPools = `[{"id":"pool-1","name":"pool-one"},{"id":"pool-2","name":"pool-two"}]`
+	const onePool = `[{"id":"pool-1","name":"pool-one"}]`
+	const volFound = `{"id":"vol-abc","name":"my-vol","size":1073741824,"status":"online"}`
+
+	okResp := func(body string) *http.Response {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	}
+	errResp := func(status int, detail string) *http.Response {
+		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(`{"detail":"` + detail + `"}`)), Header: make(http.Header)}
+	}
+	newClient := func(transport roundTripFunc) *APIClient {
+		return &APIClient{
+			ClusterID:     "cluster-id",
+			ClusterSecret: "cluster-secret",
+			conn: &Connection{
+				Endpoint: "http://api.example.com",
+				HTTP:     &http.Client{Transport: transport},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		transport roundTripFunc
+		wantPool  string
+		wantErr   string
+	}{
+		{
+			name: "found in first pool",
+			transport: func(r *http.Request) (*http.Response, error) {
+				switch r.URL.Path {
+				case poolsPath:
+					return okResp(twoPools), nil
+				case volPath1:
+					return okResp(volFound), nil
+				default:
+					t.Errorf("unexpected request to %s", r.URL.Path)
+					return jsonResponse(), nil
+				}
+			},
+			wantPool: "pool-1",
+		},
+		{
+			name: "found in second pool after 404 in first",
+			transport: func(r *http.Request) (*http.Response, error) {
+				switch r.URL.Path {
+				case poolsPath:
+					return okResp(twoPools), nil
+				case volPath1:
+					return errResp(http.StatusNotFound, "LVol vol-abc not found"), nil
+				case volPath2:
+					return okResp(volFound), nil
+				default:
+					t.Errorf("unexpected request to %s", r.URL.Path)
+					return jsonResponse(), nil
+				}
+			},
+			wantPool: "pool-2",
+		},
+		{
+			name: "not found in any pool",
+			transport: func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path == poolsPath {
+					return okResp(twoPools), nil
+				}
+				return errResp(http.StatusNotFound, "LVol vol-abc not found"), nil
+			},
+			wantErr: "not found in any pool",
+		},
+		{
+			name: "list pools error",
+			transport: func(r *http.Request) (*http.Response, error) {
+				return errResp(http.StatusInternalServerError, "Internal Server Error"), nil
+			},
+			wantErr: "failed to list pools",
+		},
+		{
+			name: "unexpected non-404 error in pool",
+			transport: func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path == poolsPath {
+					return okResp(onePool), nil
+				}
+				return errResp(http.StatusInternalServerError, "Internal Server Error"), nil
+			},
+			wantErr: "unexpected error searching for volume",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			poolID, err := newClient(tc.transport).findPoolForVolume(context.Background(), "vol-abc")
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("findPoolForVolume() error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("findPoolForVolume() unexpected error: %v", err)
+			}
+			if poolID != tc.wantPool {
+				t.Errorf("findPoolForVolume() poolID = %q, want %q", poolID, tc.wantPool)
+			}
+		})
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
The CSI `volume_id` encodes the pool UUID `({clusterUUID}:{poolUUID}:{lvolUUID})` but `Connect()` never read it. 

The connect function called `NewsimplyBlockClient(ctx, clusterID, "")` with an empty pool unconditionally. 

This PR fixes this by parsing the poolID from CSI Volume ID, rather than doing a full scan. 

Also also as a part of client.do we don't return the status code. But on the receiver side, the we are parsing based on the status code. This broke the original logic with `findPoolsByName`

