### PR TITLE
use lvolID as device modelID rather than parsing it from NQN

### DIFF
--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -80,11 +80,19 @@ func newNodeServer(d *csicommon.CSIDriver) (*nodeServer, error) {
 		ns.guardian = guardian
 	}
 
-	go util.MonitorConnection(func(lvolID string) {
-		if ns.guardian != nil {
-			ns.guardian.MarkBrokenLvol(lvolID)
-		}
-	})
+	go util.MonitorConnection(
+		func(lvolID string) {
+			if ns.guardian != nil {
+				ns.guardian.MarkBrokenLvol(lvolID)
+			}
+		},
+		func(nqn, nsID string) string {
+			if ns.guardian != nil {
+				return ns.guardian.ResolveLvolID(nqn, nsID)
+			}
+			return ""
+		},
+	)
 
 	return ns, nil
 }
@@ -311,20 +319,40 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 	stagingTargetPath := getStagingTargetPath(req)
 
+	// Query the live kernel mount table BEFORE unmounting to determine which NVMe
+	// device backs this volume and how many namespaces share its subsystem NQN.
+	// This is the ref-count for namespaced volumes (multiple lvols per subsystem):
+	// we only run nvme disconnect when this is the last staged namespace.
+	nvmeDevice, subsysNQN := util.NvmeDeviceForStagingPath(stagingTargetPath)
+	skipDisconnect := subsysNQN != "" && util.CountConnectedNamespacesForNQN(subsysNQN) > 1
+
 	err := ns.deleteMountPoint(stagingTargetPath) // idempotent
 	if err != nil {
 		klog.Errorf("failed to delete mount point, targetPath: %s err: %v", stagingTargetPath, err)
 		return nil, status.Errorf(codes.Internal, "unstage volume %s failed: %s", volumeID, err)
 	}
 
+	if skipDisconnect {
+		klog.Infof("NodeUnstageVolume: %s — subsystem %s has other active namespaces, skipping nvme disconnect", volumeID, subsysNQN)
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
+
+	if nvmeDevice != "" {
+		// We found the device from the mount — use it directly for a precise disconnect.
+		if err := util.DisconnectNvmeDevice(ctx, nvmeDevice); err != nil {
+			klog.Errorf("failed to disconnect NVMe device %s for volumeID %s: %v", nvmeDevice, volumeID, err)
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
+
+	// Fallback: volume was not a filesystem mount (raw block) or staging path was
+	// already gone.  Disconnect via lvolID glob — works for non-namespaced volumes.
 	spdkVol, err := getSPDKVol(volumeID)
 	if err != nil {
 		klog.Errorf("failed to parse volumeID %s: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	// Disconnect by discovering the NVMe device directly from the OS
-	// (/dev/disk/by-id/*<lvolID>*). This is idempotent: returns nil when
-	// the device is already gone (never connected or already disconnected).
 	if err := util.DisconnectByLvolID(ctx, spdkVol.lvolID); err != nil {
 		klog.Errorf("failed to disconnect NVMe device for volumeID %s: %v", volumeID, err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -344,7 +372,15 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	if ns.guardian != nil {
-		ns.guardian.RegisterPublish(req.VolumeContext["nqn"], req.TargetPath)
+		if spdkVol, parseErr := getSPDKVol(volumeID); parseErr == nil {
+			ns.guardian.RegisterPublish(
+				spdkVol.lvolID,
+				spdkVol.clusterID,
+				req.VolumeContext["nqn"],
+				req.VolumeContext["nsId"],
+				req.TargetPath,
+			)
+		}
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil
@@ -416,9 +452,14 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to parse volumeID %s: %v", volumeID, err)
 	}
-	devicePath, err := util.FindDeviceByLvolID(spdkVol.lvolID)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to find NVMe device for volume %s: %v", volumeID, err)
+	// For filesystem mounts find the device from the live kernel mount table.
+	// This is correct for namespaced volumes where lvolID != model_number.
+	devicePath, _ := util.NvmeDeviceForStagingPath(volumeMountPath)
+	if devicePath == "" {
+		devicePath, err = util.FindDeviceByLvolID(spdkVol.lvolID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to find NVMe device for volume %s: %v", volumeID, err)
+		}
 	}
 	if devicePath == "" {
 		return nil, status.Errorf(codes.Internal, "NVMe device not found for volume %s (not connected?)", volumeID)
@@ -561,7 +602,15 @@ func (ns *nodeServer) publishVolume(stagingPath string, req *csi.NodePublishVolu
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to parse volumeID %s: %v", req.GetVolumeId(), err)
 		}
-		devicePath, err := util.FindDeviceByLvolID(spdkVol.lvolID)
+		// Use model+nsId from VolumeContext for namespaced volumes (model != lvolID).
+		// Fall back to lvolID glob for non-namespaced volumes.
+		vc := req.GetVolumeContext()
+		var devicePath string
+		if vc["model"] != "" && vc["nsId"] != "" {
+			devicePath, err = util.FindDeviceByModelAndNsID(vc["model"], vc["nsId"])
+		} else {
+			devicePath, err = util.FindDeviceByLvolID(spdkVol.lvolID)
+		}
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to find NVMe device for volume %s: %v", req.GetVolumeId(), err)
 		}

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -63,6 +63,11 @@ type persistedLvolState struct {
 	PodUIDs   []string  `json:"podUIDs,omitempty"`
 	ClusterID string    `json:"clusterID,omitempty"`
 	BrokenAt  time.Time `json:"brokenAt,omitempty"`
+	// NQN and NsID are stored for namespaced volumes so that reconnectSubsystems
+	// can map a kernel device path back to the correct per-namespace lvolID after
+	// a CSI pod restart.
+	NQN  string `json:"nqn,omitempty"`
+	NsID string `json:"nsId,omitempty"`
 }
 
 type guardianState struct {
@@ -75,11 +80,15 @@ type LvolState struct {
 	// podUID -> present
 	PodUIDs map[string]struct{} `json:"-"` // persisted as []string
 
-	// derived from NQN
 	ClusterID string `json:"clusterID"`
 
 	// zero value means "not broken"
 	BrokenAt time.Time `json:"brokenAt,omitempty"`
+
+	// NQN and NsID are set for namespaced volumes at RegisterPublish time and
+	// used by ResolveLvolID to map device paths back to per-namespace lvolIDs.
+	NQN  string `json:"nqn,omitempty"`
+	NsID string `json:"nsId,omitempty"`
 }
 
 // Guardian tracks which pod uses which lvol and restarts affected pods
@@ -139,6 +148,8 @@ func (g *Guardian) loadState() {
 				PodUIDs:   set,
 				ClusterID: pls.ClusterID,
 				BrokenAt:  pls.BrokenAt,
+				NQN:       pls.NQN,
+				NsID:      pls.NsID,
 			}
 		}
 	}
@@ -206,10 +217,12 @@ func StartGuardian(ctx context.Context, cfg GuardianConfig) (*Guardian, error) {
 	return g, nil
 }
 
-// RegisterPublish records that a volume (identified by NQN) is published to a pod via targetPath.
+// RegisterPublish records that a volume is published to a pod via targetPath.
+// lvolID is the per-namespace lvol UUID (VolumeContext["uuid"]).
+// nqn and nsId are stored so ResolveLvolID can reverse-map kernel device paths
+// to the correct per-namespace lvolID after a CSI pod restart.
 // Call this from NodePublishVolume.
-func (g *Guardian) RegisterPublish(nqn string, targetPath string) {
-	clusterID, lvolID := getLvolIDFromNQN(nqn)
+func (g *Guardian) RegisterPublish(lvolID, clusterID, nqn, nsId, targetPath string) {
 	podUID := podUIDFromTargetPath(targetPath)
 	if lvolID == "" || podUID == "" || clusterID == "" {
 		return
@@ -228,12 +241,36 @@ func (g *Guardian) RegisterPublish(nqn string, targetPath string) {
 	}
 	st.PodUIDs[podUID] = struct{}{}
 	st.ClusterID = clusterID
+	if nqn != "" {
+		st.NQN = nqn
+	}
+	if nsId != "" {
+		st.NsID = nsId
+	}
 
 	if _, exists := g.clusterWasInactive[clusterID]; !exists {
 		g.clusterWasInactive[clusterID] = true
 	}
 
 	g.persistLocked()
+}
+
+// ResolveLvolID returns the lvolID whose published NQN and NsID match the given
+// values.  Used by MonitorConnection to translate a kernel device path (from
+// which nqn and nsId are derived) to the correct per-namespace lvolID.
+// Returns "" if not found.
+func (g *Guardian) ResolveLvolID(nqn, nsID string) string {
+	if nqn == "" || nsID == "" {
+		return ""
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for lvolID, st := range g.lvols {
+		if st != nil && st.NQN == nqn && st.NsID == nsID {
+			return lvolID
+		}
+	}
+	return ""
 }
 
 // RegisterUnpublish removes mapping. Call from NodeUnpublishVolume.
@@ -570,6 +607,8 @@ func (g *Guardian) persistLocked() {
 		pls := persistedLvolState{
 			ClusterID: lvs.ClusterID,
 			BrokenAt:  lvs.BrokenAt,
+			NQN:       lvs.NQN,
+			NsID:      lvs.NsID,
 		}
 		for uid := range lvs.PodUIDs {
 			pls.PodUIDs = append(pls.PodUIDs, uid)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -532,6 +532,7 @@ func getSubsystemsForDevice(devicePath string) ([]subsystemResponse, error) {
 // FindDeviceByLvolID returns the /dev/disk/by-id symlink path for the NVMe
 // block device associated with lvolID, or ("", nil) if not connected.
 // The lvolID is used as the device model name by the simplyblock storage layer.
+// For namespaced volumes use FindDeviceByModelAndNsID instead.
 func FindDeviceByLvolID(lvolID string) (string, error) {
 	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", lvolID))
 	matches, err := filepath.Glob(deviceGlob)
@@ -547,9 +548,48 @@ func FindDeviceByLvolID(lvolID string) (string, error) {
 	return matches[0], nil
 }
 
+// FindDeviceByModelAndNsID returns the /dev/disk/by-id symlink for a specific NVMe
+// namespace using its subsystem model number (= subsystem root lvolID) and namespace ID.
+// Use this for namespaced volumes where the model_number != the individual lvolID.
+func FindDeviceByModelAndNsID(model, nsID string) (string, error) {
+	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_%s", model, nsID))
+	matches, err := filepath.Glob(deviceGlob)
+	if err != nil {
+		return "", fmt.Errorf("glob %s: %w", deviceGlob, err)
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	return matches[0], nil
+}
+
+// DisconnectNvmeDevice runs nvme disconnect for a known real device path (e.g.
+// /dev/nvme0n2) and waits for the kernel device node to disappear.  Use this
+// when NodeUnstageVolume has already resolved the device from the live mount
+// table instead of searching /dev/disk/by-id/ by lvolID.
+func DisconnectNvmeDevice(ctx context.Context, realDevPath string) error {
+	if err := disconnectDevicePath(ctx, realDevPath); err != nil {
+		return err
+	}
+	for i := 0; i < 20; i++ {
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return nil
+		}
+		if _, err := os.Stat(realDevPath); os.IsNotExist(err) {
+			return nil
+		}
+	}
+	return nil
+}
+
 // DisconnectByLvolID disconnects the NVMe device associated with lvolID via
 // OS-level discovery (/dev/disk/by-id).  It is idempotent: returns nil when
 // no matching device is found (already disconnected or never connected).
+// For namespaced volumes NodeUnstageVolume handles ref-counting via live kernel
+// state before calling this; this function is the fallback for block volumes
+// and non-namespaced volumes.
 func DisconnectByLvolID(ctx context.Context, lvolID string) error {
 	devicePath, err := FindDeviceByLvolID(lvolID)
 	if err != nil {
@@ -577,6 +617,69 @@ func getLvolIDFromNQN(nqn string) (clusterID, lvolID string) {
 	return "", ""
 }
 
+// nsIDFromDevicePath extracts the NVMe namespace ID from a kernel device path.
+// "/dev/nvme0n1" → "1", "/dev/nvme1n3" → "3", other paths → "".
+func nsIDFromDevicePath(devPath string) string {
+	base := filepath.Base(devPath)
+	i := strings.Index(base, "nvme")
+	if i < 0 {
+		return ""
+	}
+	rest := base[i+4:]
+	j := 0
+	for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+		j++
+	}
+	if j >= len(rest) || rest[j] != 'n' {
+		return ""
+	}
+	return rest[j+1:]
+}
+
+// NvmeDeviceForStagingPath finds the backing NVMe block device and its subsystem NQN
+// for a staged filesystem volume by querying the live kernel mount table.
+// Returns ("", "") when the path is not a mounted filesystem (e.g. block volume
+// staging dir, already unmounted, or path doesn't exist).
+func NvmeDeviceForStagingPath(stagingTargetPath string) (devicePath, nqn string) {
+	out, err := exec.Command("findmnt", "-n", "-o", "SOURCE", "--target", stagingTargetPath).Output()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		return "", ""
+	}
+	device := strings.TrimSpace(string(out))
+	if resolved, err := filepath.EvalSymlinks(device); err == nil {
+		device = resolved
+	}
+	subsystems, err := getSubsystemsForDevice(device)
+	if err != nil {
+		return device, ""
+	}
+	for _, host := range subsystems {
+		for _, sub := range host.Subsystems {
+			if sub.NQN != "" {
+				return device, sub.NQN
+			}
+		}
+	}
+	return device, ""
+}
+
+// CountConnectedNamespacesForNQN returns the number of NVMe namespace devices
+// currently connected under the given subsystem NQN.
+// The NQN encodes the subsystem model number (root lvolID); all namespace devices
+// in that subsystem share the same model prefix in /dev/disk/by-id/.
+func CountConnectedNamespacesForNQN(nqn string) int {
+	_, model := getLvolIDFromNQN(nqn)
+	if model == "" {
+		return 0
+	}
+	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", model))
+	matches, err := filepath.Glob(deviceGlob)
+	if err != nil {
+		return 0
+	}
+	return len(matches)
+}
+
 func parseAddress(address string) string {
 	parts := strings.Split(address, ",")
 	for _, part := range parts {
@@ -587,7 +690,14 @@ func parseAddress(address string) string {
 	return ""
 }
 
-func reconnectSubsystems(markBroken func(lvolID string)) error {
+// reconnectSubsystems scans connected NVMe devices, recovers degraded paths, and
+// detects devices that have disappeared.
+//
+// resolveLvolID maps (nqn, nsId) → the actual per-namespace lvolID.  For
+// namespaced volumes, getLvolIDFromNQN returns the subsystem root UUID for every
+// namespace; the guardian provides this closure so that markBroken receives the
+// correct per-pod lvolID.  Pass nil to fall back to the NQN-parsed root UUID.
+func reconnectSubsystems(markBroken func(lvolID string), resolveLvolID func(nqn, nsID string) string) error {
 	devices, err := getNVMeDeviceInfos()
 	if err != nil {
 		return fmt.Errorf("failed to get NVMe device paths: %v", err)
@@ -610,9 +720,24 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 
 		for _, host := range subsystems {
 			for _, subsystem := range host.Subsystems {
-				clusterID, lvolID := getLvolIDFromNQN(subsystem.NQN)
-				if lvolID == "" {
+				clusterID, rootLvolID := getLvolIDFromNQN(subsystem.NQN)
+				if rootLvolID == "" {
 					continue
+				}
+
+				// For namespaced volumes every namespace in the same subsystem shares
+				// the same NQN, so getLvolIDFromNQN returns the subsystem root UUID for
+				// all of them.  Use the guardian-provided resolver (which looks up the
+				// lvolID from its persisted RegisterPublish state) to get the actual
+				// per-namespace lvolID so markBroken targets the correct pods.
+				lvolID := rootLvolID
+				if resolveLvolID != nil {
+					nsID := nsIDFromDevicePath(device.devicePath)
+					if nsID != "" {
+						if actual := resolveLvolID(subsystem.NQN, nsID); actual != "" {
+							lvolID = actual
+						}
+					}
 				}
 
 				mu.Lock()
@@ -811,14 +936,18 @@ const (
 	monitorCircuitCooldown = 30 * time.Second
 )
 
-func MonitorConnection(markBroken func(lvolID string)) {
+// MonitorConnection polls NVMe subsystem health and calls markBroken for any
+// device that has disappeared.  resolveLvolID maps (nqn, nsID) to the actual
+// per-namespace lvolID; the guardian provides this so markBroken targets the
+// right pods for namespaced volumes.  Pass nil to fall back to the NQN root UUID.
+func MonitorConnection(markBroken func(lvolID string), resolveLvolID func(nqn, nsID string) string) {
 	var (
 		consecutiveErrors int
 		backoff           = monitorBaseInterval
 	)
 
 	for {
-		err := reconnectSubsystems(markBroken)
+		err := reconnectSubsystems(markBroken, resolveLvolID)
 		if err != nil {
 			consecutiveErrors++
 			klog.Errorf("MonitorConnection error (%d consecutive): %v", consecutiveErrors, err)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -303,7 +303,7 @@ func (nvmf *initiatorNVMf) Connect(ctx context.Context) (string, error) {
 }
 
 func (nvmf *initiatorNVMf) Disconnect(ctx context.Context) error {
-	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_[0-9]*", nvmf.model))
+	deviceGlob := fmt.Sprintf(DevDiskByID, fmt.Sprintf("%s*_%s", nvmf.model, nvmf.nsId))
 	devicePath, err := filepath.Glob(deviceGlob)
 	if err != nil {
 		return fmt.Errorf("failed to find device paths matching %s: %v", deviceGlob, err)
@@ -757,6 +757,10 @@ func connectViaNVMe(ctx context.Context, conn *LvolConnectResp, ctrlLossTmo int,
 		cmd = append(cmd, "-f", conn.HostIface)
 	}
 	if err := execWithTimeoutRetry(ctx, cmd, 40, retries); err != nil {
+		if strings.Contains(err.Error(), "already connected") {
+			klog.Infof("nvme path %s:%d already connected, treating as success", conn.IP, conn.Port)
+			return nil
+		}
 		klog.Errorf("nvme connect failed: %v", err)
 		return err
 	}

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -288,7 +288,6 @@ func (client APIClient) getVolumeInfo(ctx context.Context, poolID, lvolID, hostN
 	for _, r := range result {
 		connections = append(connections, connectionInfo{IP: r.IP, Port: r.Port})
 	}
-	_, model := getLvolIDFromNQN(result[0].Nqn)
 	connectionsData, err := json.Marshal(connections)
 	if err != nil {
 		return nil, err
@@ -301,7 +300,7 @@ func (client APIClient) getVolumeInfo(ctx context.Context, poolID, lvolID, hostN
 		"reconnectDelay": strconv.Itoa(result[0].ReconnectDelay),
 		"nrIoQueues":     strconv.Itoa(result[0].NrIoQueues),
 		"ctrlLossTmo":    strconv.Itoa(result[0].CtrlLossTmo),
-		"model":          model,
+		"model":          lvolID,
 		"targetType":     result[0].TargetType,
 		"connections":    string(connectionsData),
 		"nsId":           strconv.Itoa(result[0].NSID),

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -288,6 +288,7 @@ func (client APIClient) getVolumeInfo(ctx context.Context, poolID, lvolID, hostN
 	for _, r := range result {
 		connections = append(connections, connectionInfo{IP: r.IP, Port: r.Port})
 	}
+	_, model := getLvolIDFromNQN(result[0].Nqn)
 	connectionsData, err := json.Marshal(connections)
 	if err != nil {
 		return nil, err
@@ -300,7 +301,7 @@ func (client APIClient) getVolumeInfo(ctx context.Context, poolID, lvolID, hostN
 		"reconnectDelay": strconv.Itoa(result[0].ReconnectDelay),
 		"nrIoQueues":     strconv.Itoa(result[0].NrIoQueues),
 		"ctrlLossTmo":    strconv.Itoa(result[0].CtrlLossTmo),
-		"model":          lvolID,
+		"model":          model,
 		"targetType":     result[0].TargetType,
 		"connections":    string(connectionsData),
 		"nsId":           strconv.Itoa(result[0].NSID),


### PR DESCRIPTION
Each NQN represents a subsystem. So all the Lvols with a subsystem has the same NQN. Within that subsystem, each Lvol has a separate has modelID and nsID. 

But, at the moment, we parse modelID from NQN. this is incorrect, the modelID is the lvol's ID. 

