### PR TITLE
DeleteVolume: return ErrJSONNoSuchDevice upon 404 error

### DIFF
--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -312,7 +312,7 @@ func (client APIClient) getVolumeInfo(ctx context.Context, poolID, lvolID, hostN
 // deleteVolume deletes a volume by UUID
 func (client APIClient) deleteVolume(ctx context.Context, poolID, lvolID string) error {
 	_, err := client.do(ctx, "DELETE", client.v2volume(poolID, lvolID), nil)
-	if errorMatches(err, ErrJSONNoSuchDevice) {
+	if err != nil && (errorMatches(err, ErrJSONNoSuchDevice) || strings.Contains(err.Error(), "404")) {
 		err = ErrJSONNoSuchDevice
 	}
 	return err

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -330,6 +330,9 @@ func (c *ClusterClient) PublishVolume(ctx context.Context, lvolID string) error 
 func (c *ClusterClient) UnpublishVolume(ctx context.Context, lvolID string) error {
 	_, err := c.API.do(ctx, "GET", c.API.v2volume(c.poolID, lvolID), nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return ErrVolumeUnpublished
+		}
 		return err
 	}
 	klog.V(5).Infof("volume unpublished: %s", lvolID)


### PR DESCRIPTION
When this error is returned `ErrJSONNoSuchDevice`, the caller gracefully handles logs a warning and marks the deletion as success. 

https://github.com/simplyblock/simplyblock-csi/blob/ea0ad0ce1b6cb514ee4373a3f86b9445abfed7de/pkg/spdk/controllerserver.go#L367-L371


This happened v1 API returned `No such device` but v2 API returns `404: Lvol <name> not found`. This broke the check. 

adding the same check for UnpublishVolume too. 




