### PR TITLE
Added an additional check to ensure we only handle lvols under PV/PVC management

### DIFF
--- a/e2e/reconnect.go
+++ b/e2e/reconnect.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	"github.com/spdk/spdk-csi/pkg/kubernetes/volumehandle"
+)
+
+// nvme list-subsys -o json output (subset of fields we need). The command
+// returns a top-level array, one entry per host.
+type nvmeSubsysHost struct {
+	Subsystems []nvmeSubsystem `json:"Subsystems"`
+}
+
+type nvmeSubsystem struct {
+	Name  string     `json:"Name"`
+	NQN   string     `json:"NQN"`
+	Paths []nvmePath `json:"Paths"`
+}
+
+type nvmePath struct {
+	Name     string `json:"Name"` // controller, e.g. "nvme0"
+	State    string `json:"State"`
+	ANAState string `json:"ANAState"`
+}
+
+var _ = ginkgo.Describe("SPDKCSI-RECONNECT", func() {
+	f := newTestFramework("spdkcsi")
+
+	ginkgo.Context("NVMe-oF path recovery for PV/PVC-managed volumes", func() {
+		ginkgo.It("restores a degraded managed volume's NVMe paths", func() {
+			ns := f.Namespace.Name
+			pvcLabel := metav1.ListOptions{LabelSelector: "app=spdkcsi-pvc"}
+			const dataPath = "/spdkvol/reconnect-test"
+			const data = "reconnect-survives-path-loss"
+
+			ginkgo.By("check driver components are running")
+			framework.ExpectNoError(waitForControllerReady(f.ClientSet, 4*time.Minute), "controller ready")
+			framework.ExpectNoError(waitForNodeServerReady(f.ClientSet, 3*time.Minute), "node DaemonSet ready")
+
+			ginkgo.By("create PVC and test pod")
+			deployPVC(ns)
+			deployTestPod(ns)
+			ginkgo.DeferCleanup(func() { deletePVCAndTestPod(ns) })
+			framework.ExpectNoError(
+				waitForTestPodReady(f.ClientSet, 5*time.Minute, ns, testPodName),
+				"wait for test pod",
+			)
+
+			ginkgo.By("write data so we can verify I/O survives the disruption")
+			writeDataToPod(f, ns, &pvcLabel, data, dataPath)
+
+			ginkgo.By("locate the worker node and its csi-node pod")
+			workerNode := testPodNode(f.ClientSet, ns, testPodName)
+			pluginPod, pluginContainer := nodePluginPodOnNode(f.ClientSet, workerNode)
+			framework.Logf("test pod on node %q served by csi-node pod %q", workerNode, pluginPod)
+
+			ginkgo.By("resolve the volume's lvol ID from its PV handle")
+			lvolID := lvolIDForPVC(f.ClientSet, ns, "spdkcsi-pvc")
+
+			ginkgo.By("find the NVMe subsystem and its live paths on the node")
+			sub := waitForSubsystem(f, pluginPod, pluginContainer, lvolID, time.Minute)
+			origLive := liveControllers(sub)
+			framework.Logf("lvol %s subsystem %s has live paths: %v", lvolID, sub.NQN, origLive)
+
+			if len(origLive) < 2 {
+				ginkgo.Skip(fmt.Sprintf(
+					"volume has %d live path(s); the monitor only recovers degraded multipath, "+
+						"so path-loss recovery cannot be exercised on a single-path volume", len(origLive)))
+			}
+
+			ginkgo.By("drop one NVMe path by deleting its controller on the node")
+			// Delete the last live controller, leaving at least one path so I/O continues.
+			victim := origLive[len(origLive)-1]
+			execInPod(f, driverNamespace(), pluginPod, pluginContainer,
+				fmt.Sprintf("echo 1 > /sys/class/nvme/%s/delete_controller", victim))
+
+			ginkgo.By("confirm the path count actually dropped")
+			gomega.Eventually(func() int {
+				s := subsystemForLvol(listSubsystems(f, pluginPod, pluginContainer), lvolID)
+				if s == nil {
+					return 0
+				}
+				return len(liveControllers(s))
+			}, 30*time.Second, 2*time.Second).Should(gomega.BeNumerically("<", len(origLive)),
+				"expected a path to drop after deleting controller %s", victim)
+
+			ginkgo.By("wait for the node plugin to reconnect the missing path")
+			gomega.Eventually(func() int {
+				s := subsystemForLvol(listSubsystems(f, pluginPod, pluginContainer), lvolID)
+				if s == nil {
+					return 0
+				}
+				return len(liveControllers(s))
+			}, 3*time.Minute, 3*time.Second).Should(gomega.BeNumerically(">=", len(origLive)),
+				"monitor should restore the degraded path back to %d live paths", len(origLive))
+
+			ginkgo.By("verify the data written before the disruption is intact")
+			compareDataInPod(f, ns, &pvcLabel, []string{data}, []string{dataPath})
+		})
+	})
+})
+
+// driverNamespace returns the namespace the CSI driver components run in.
+func driverNamespace() string {
+	if operatorMode {
+		return systemNamespace
+	}
+	return nameSpace
+}
+
+// testPodNode returns the node a pod is scheduled on.
+func testPodNode(c kubernetes.Interface, ns, podName string) string {
+	pod, err := c.CoreV1().Pods(ns).Get(context.Background(), podName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "get pod %s/%s", ns, podName)
+	gomega.Expect(pod.Spec.NodeName).NotTo(gomega.BeEmpty(), "pod %s has no node assigned", podName)
+	return pod.Spec.NodeName
+}
+
+// nodePluginPodOnNode returns the csi-node DaemonSet pod (and its first
+// container) running on the given node.
+func nodePluginPodOnNode(c kubernetes.Interface, nodeName string) (podName, container string) {
+	dns := driverNamespace()
+	ds, err := c.AppsV1().DaemonSets(dns).Get(context.Background(), nodeDsName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "get node DaemonSet %s/%s", dns, nodeDsName)
+
+	pods, err := c.CoreV1().Pods(dns).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set(ds.Spec.Selector.MatchLabels).String(),
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
+	framework.ExpectNoError(err, "list csi-node pods on node %s", nodeName)
+	gomega.Expect(pods.Items).NotTo(gomega.BeEmpty(), "no csi-node pod found on node %s", nodeName)
+
+	pod := pods.Items[0]
+	return pod.Name, pod.Spec.Containers[0].Name
+}
+
+// lvolIDForPVC resolves the lvol (volume) ID from the PVC's bound PV handle.
+func lvolIDForPVC(c kubernetes.Interface, ns, pvcName string) string {
+	pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), pvcName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "get PVC %s/%s", ns, pvcName)
+	gomega.Expect(pvc.Spec.VolumeName).NotTo(gomega.BeEmpty(), "PVC %s not bound", pvcName)
+
+	pv, err := c.CoreV1().PersistentVolumes().Get(context.Background(), pvc.Spec.VolumeName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "get PV %s", pvc.Spec.VolumeName)
+	gomega.Expect(pv.Spec.CSI).NotTo(gomega.BeNil(), "PV %s has no CSI source", pv.Name)
+
+	vh, ok := volumehandle.Parse(pv.Spec.CSI.VolumeHandle)
+	gomega.Expect(ok).To(gomega.BeTrue(), "parse volume handle %q", pv.Spec.CSI.VolumeHandle)
+	return vh.VolumeID
+}
+
+// execInPod runs cmd in a specific pod/container and returns stdout.
+func execInPod(f *framework.Framework, ns, podName, container, cmd string) string {
+	opts := e2epod.ExecOptions{
+		Command:            []string{"/bin/sh", "-c", cmd},
+		PodName:            podName,
+		Namespace:          ns,
+		ContainerName:      container,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: true,
+	}
+	stdout, stderr, err := e2epod.ExecWithOptions(f, opts)
+	if stderr != "" {
+		framework.Logf("exec %q stderr: %s", cmd, stderr)
+	}
+	framework.ExpectNoError(err, "exec %q in %s/%s", cmd, ns, podName)
+	return stdout
+}
+
+// listSubsystems runs `nvme list-subsys` in the csi-node pod and parses it.
+func listSubsystems(f *framework.Framework, podName, container string) []nvmeSubsystem {
+	out := execInPod(f, driverNamespace(), podName, container, "nvme list-subsys -o json")
+	var hosts []nvmeSubsysHost
+	if err := json.Unmarshal([]byte(out), &hosts); err != nil {
+		framework.Failf("parse nvme list-subsys output %q: %v", out, err)
+	}
+	var subs []nvmeSubsystem
+	for _, h := range hosts {
+		subs = append(subs, h.Subsystems...)
+	}
+	return subs
+}
+
+// subsystemForLvol returns the subsystem whose NQN carries the given lvol ID.
+func subsystemForLvol(subs []nvmeSubsystem, lvolID string) *nvmeSubsystem {
+	for i := range subs {
+		if strings.Contains(subs[i].NQN, lvolID) {
+			return &subs[i]
+		}
+	}
+	return nil
+}
+
+// waitForSubsystem polls until the subsystem for lvolID appears on the node.
+func waitForSubsystem(f *framework.Framework, podName, container, lvolID string, timeout time.Duration) *nvmeSubsystem {
+	var found *nvmeSubsystem
+	gomega.Eventually(func() *nvmeSubsystem {
+		found = subsystemForLvol(listSubsystems(f, podName, container), lvolID)
+		return found
+	}, timeout, 3*time.Second).ShouldNot(gomega.BeNil(),
+		"NVMe subsystem for lvol %s never appeared on the node", lvolID)
+	return found
+}
+
+// liveControllers returns the controller names of all live paths in a subsystem.
+func liveControllers(sub *nvmeSubsystem) []string {
+	var ctrls []string
+	for _, p := range sub.Paths {
+		if strings.EqualFold(p.State, "live") {
+			ctrls = append(ctrls, p.Name)
+		}
+	}
+	return ctrls
+}

--- a/e2e/reconnect_fullloss.go
+++ b/e2e/reconnect_fullloss.go
@@ -1,0 +1,218 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	fullLossFSPath    = "/spdkvol/fullloss-marker"
+	fullLossBlockPath = "/dev/spdkblk"
+)
+
+type fullLossMode struct {
+	name   string
+	block  bool
+	fsType string // "" for raw block
+}
+
+var _ = ginkgo.Describe("SPDKCSI-RECONNECT-FULLLOSS", func() {
+	f := newTestFramework("spdkcsi")
+
+	ginkgo.Context("volume recovers after total NVMe-oF path loss", func() {
+		modes := []fullLossMode{
+			{name: "raw block", block: true},
+			{name: "ext4 filesystem", fsType: "ext4"},
+			{name: "xfs filesystem", fsType: "xfs"},
+		}
+
+		for _, m := range modes {
+			m := m
+			ginkgo.It(fmt.Sprintf("reconnects and keeps data for a %s volume", m.name), func() {
+				ns := f.Namespace.Name
+				appLabel := "fullloss"
+				pvcName := "fullloss-pvc"
+				depName := "fullloss"
+				marker := "fullloss-" + ns
+				if len(marker) > 60 {
+					marker = marker[:60]
+				}
+
+				ginkgo.By("check node DaemonSet is ready")
+				framework.ExpectNoError(waitForNodeServerReady(f.ClientSet, 3*time.Minute), "node DaemonSet ready")
+
+				ginkgo.By("create the StorageClass / PVC for this volume type")
+				scName := storageClassName
+				if !m.block {
+					scName = fmt.Sprintf("fullloss-%s-%s", m.fsType, ns)
+					createStorageClassWithParams(f.ClientSet, scName, map[string]string{"csi.storage.k8s.io/fstype": m.fsType})
+					ginkgo.DeferCleanup(func() { deleteStorageClass(f.ClientSet, scName) })
+				}
+				framework.ExpectNoError(createModePVC(f.ClientSet, ns, pvcName, scName, m.block), "create PVC")
+
+				ginkgo.By("pick a worker node and run a pod pinned to it")
+				workerNode, _, _ := anyNodePluginPod(f.ClientSet)
+				framework.ExpectNoError(
+					createPinnedDeployment(f.ClientSet, ns, depName, appLabel, pvcName, workerNode, m.block),
+					"create workload")
+				ginkgo.DeferCleanup(func() {
+					_ = f.ClientSet.AppsV1().Deployments(ns).Delete(context.Background(), depName, metav1.DeleteOptions{})
+				})
+
+				pod := waitForReadyPod(f.ClientSet, ns, appLabel, "", 5*time.Minute)
+
+				ginkgo.By("write a marker to the volume")
+				writeMarker(f, ns, appLabel, m, marker)
+
+				ginkgo.By("locate the csi-node pod and the volume's NVMe subsystem")
+				pluginPod, pluginContainer := nodePluginPodOnNode(f.ClientSet, workerNode)
+				lvolID := lvolIDForPVC(f.ClientSet, ns, pvcName)
+				sub := waitForSubsystem(f, pluginPod, pluginContainer, lvolID, time.Minute)
+
+				ginkgo.By("induce TOTAL path loss by disconnecting the whole subsystem")
+				execInPod(f, driverNamespace(), pluginPod, pluginContainer, "nvme disconnect -n "+sub.NQN)
+
+				ginkgo.By("force-delete the pod to trigger a same-node replacement")
+				// GracePeriod 0 mimics the guardian's restart and biases toward the
+				// race where the new pod's NodePublish runs before kubelet unstages.
+				zero := int64(0)
+				framework.ExpectNoError(
+					f.ClientSet.CoreV1().Pods(ns).Delete(context.Background(), pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero}),
+					"force-delete pod %s", pod.Name)
+
+				ginkgo.By("wait for the replacement pod to become ready (volume restaged/reconnected)")
+				newPod := waitForReadyPod(f.ClientSet, ns, appLabel, string(pod.UID), 5*time.Minute)
+				gomega.Expect(newPod.UID).NotTo(gomega.Equal(pod.UID), "expected a replacement pod")
+
+				ginkgo.By("verify the marker written before the outage is intact")
+				gomega.Expect(readMarker(f, ns, appLabel, m, len(marker))).To(gomega.ContainSubstring(marker),
+					"data lost across full path loss + recovery")
+			})
+		}
+	})
+})
+
+// createModePVC creates an RWO PVC in Filesystem or Block mode.
+func createModePVC(c kubernetes.Interface, ns, pvcName, scName string, block bool) error {
+	volMode := corev1.PersistentVolumeFilesystem
+	if block {
+		volMode = corev1.PersistentVolumeBlock
+	}
+	_, err := c.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			VolumeMode:       &volMode,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// createPinnedDeployment runs a single alpine pod (via a Deployment so it is
+// recreated after deletion) pinned to nodeName, consuming pvcName as a block
+// device or filesystem mount.
+func createPinnedDeployment(c kubernetes.Interface, ns, name, appLabel, pvcName, nodeName string, block bool) error {
+	replicas := int32(1)
+	container := corev1.Container{
+		Name:    "alpine",
+		Image:   "alpine:3",
+		Command: []string{"sleep", "365d"},
+	}
+	if block {
+		container.VolumeDevices = []corev1.VolumeDevice{{Name: "vol", DevicePath: fullLossBlockPath}}
+	} else {
+		container.VolumeMounts = []corev1.VolumeMount{{Name: "vol", MountPath: "/spdkvol"}}
+	}
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appLabel}},
+				Spec: corev1.PodSpec{
+					NodeName:   nodeName,
+					Containers: []corev1.Container{container},
+					Volumes: []corev1.Volume{{
+						Name: "vol",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+						},
+					}},
+				},
+			},
+		},
+	}
+	_, err := c.AppsV1().Deployments(ns).Create(context.Background(), dep, metav1.CreateOptions{})
+	return err
+}
+
+// waitForReadyPod waits for a Running+Ready pod matching app=appLabel whose UID
+// differs from excludeUID (pass "" to accept any).
+func waitForReadyPod(c kubernetes.Interface, ns, appLabel, excludeUID string, timeout time.Duration) *corev1.Pod {
+	var ready *corev1.Pod
+	gomega.Eventually(func() bool {
+		pods, err := c.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: "app=" + appLabel})
+		if err != nil {
+			return false
+		}
+		for i := range pods.Items {
+			p := &pods.Items[i]
+			if string(p.UID) == excludeUID || p.DeletionTimestamp != nil {
+				continue
+			}
+			if p.Status.Phase == corev1.PodRunning && podReady(p) {
+				ready = p
+				return true
+			}
+		}
+		return false
+	}, timeout, 5*time.Second).Should(gomega.BeTrue(), "no ready pod for app=%s", appLabel)
+	return ready
+}
+
+func podReady(p *corev1.Pod) bool {
+	for _, cond := range p.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// writeMarker writes marker to the volume: to a file for filesystem volumes, or
+// to the start of the raw device for block volumes.
+func writeMarker(f *framework.Framework, ns, appLabel string, m fullLossMode, marker string) {
+	opt := metav1.ListOptions{LabelSelector: "app=" + appLabel}
+	if m.block {
+		execCommandInPod(f, fmt.Sprintf("printf '%%s' '%s' | dd of=%s bs=4096 count=1 conv=fsync 2>/dev/null", marker, fullLossBlockPath), ns, &opt)
+		return
+	}
+	execCommandInPod(f, fmt.Sprintf("printf '%%s' '%s' > %s && sync", marker, fullLossFSPath), ns, &opt)
+}
+
+// readMarker reads back the marker written by writeMarker.
+func readMarker(f *framework.Framework, ns, appLabel string, m fullLossMode, length int) string {
+	opt := metav1.ListOptions{LabelSelector: "app=" + appLabel}
+	if m.block {
+		out, _ := execCommandInPod(f, fmt.Sprintf("dd if=%s bs=1 count=%d 2>/dev/null", fullLossBlockPath, length), ns, &opt)
+		return out
+	}
+	out, _ := execCommandInPod(f, "cat "+fullLossFSPath, ns, &opt)
+	return out
+}

--- a/e2e/reconnect_unmanaged.go
+++ b/e2e/reconnect_unmanaged.go
@@ -1,0 +1,170 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// uuidRe extracts a volume UUID from sbctl output.
+var uuidRe = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+var _ = ginkgo.Describe("SPDKCSI-RECONNECT-UNMANAGED", func() {
+	f := newTestFramework("spdkcsi")
+
+	ginkgo.Context("NVMe-oF path recovery is gated on PV/PVC management", func() {
+		// A simplyblock volume created directly via the API (no PV/PVC) is still
+		// an NVMe-oF subsystem on the host, but the node plugin must NOT manage
+		// its paths. We connect such a volume, degrade it, and confirm the
+		// monitor leaves it alone (no recovery) — the behaviour the positive
+		// SPDKCSI-RECONNECT test shows it WOULD apply to a managed volume.
+		ginkgo.It("skips a connected simplyblock volume that has no PV/PVC", func() {
+			pool := envOr("E2E_SB_POOL", "testing1")
+			size := envOr("E2E_SB_VOLUME_SIZE", "1G")
+			volName := "e2e-unmanaged-" + f.Namespace.Name
+
+			ginkgo.By("check driver components are running")
+			framework.ExpectNoError(waitForNodeServerReady(f.ClientSet, 3*time.Minute), "node DaemonSet ready")
+
+			ginkgo.By("pick a worker node and its csi-node pod")
+			workerNode, pluginPod, pluginContainer := anyNodePluginPod(f.ClientSet)
+			framework.Logf("using node %q (csi-node pod %q)", workerNode, pluginPod)
+
+			ginkgo.By(fmt.Sprintf("create an unmanaged volume %q via sbctl", volName))
+			addOut := sbctl(f, fmt.Sprintf("volume add %s %s %s", volName, size, pool))
+			volID := uuidRe.FindString(addOut)
+			gomega.Expect(volID).NotTo(gomega.BeEmpty(), "could not parse volume UUID from sbctl output: %q", addOut)
+			framework.Logf("created unmanaged volume %s (id %s)", volName, volID)
+			// Delete the backend volume even if later steps fail.
+			ginkgo.DeferCleanup(func() {
+				out := sbctl(f, "volume delete "+volID)
+				framework.Logf("sbctl volume delete %s: %s", volID, out)
+			})
+
+			ginkgo.By("connect the volume on the chosen host")
+			connectOut := sbctl(f, "volume connect "+volID)
+			connectCmds := nvmeConnectCommands(connectOut)
+			gomega.Expect(connectCmds).NotTo(gomega.BeEmpty(),
+				"no `nvme connect` commands in sbctl output: %q", connectOut)
+			for _, cmd := range connectCmds {
+				execInPod(f, driverNamespace(), pluginPod, pluginContainer, cmd)
+			}
+			// Disconnect from the host even if later steps fail. Re-list at
+			// cleanup time to resolve the subsystem NQN.
+			ginkgo.DeferCleanup(func() {
+				if s := subsystemForLvol(listSubsystems(f, pluginPod, pluginContainer), volID); s != nil {
+					execInPod(f, driverNamespace(), pluginPod, pluginContainer,
+						"nvme disconnect -n "+s.NQN+" || true")
+				}
+			})
+
+			ginkgo.By("confirm the volume is connected as multipath")
+			sub := waitForSubsystem(f, pluginPod, pluginContainer, volID, time.Minute)
+			origLive := liveControllers(sub)
+			framework.Logf("unmanaged volume %s subsystem %s has live paths: %v", volID, sub.NQN, origLive)
+			if len(origLive) < 2 {
+				ginkgo.Skip(fmt.Sprintf(
+					"unmanaged volume has %d live path(s); a single path cannot be degraded "+
+						"to observe (non-)recovery", len(origLive)))
+			}
+
+			ginkgo.By("drop one NVMe path by deleting its controller on the node")
+			victim := origLive[len(origLive)-1]
+			execInPod(f, driverNamespace(), pluginPod, pluginContainer,
+				fmt.Sprintf("echo 1 > /sys/class/nvme/%s/delete_controller", victim))
+
+			ginkgo.By("confirm the path count actually dropped")
+			gomega.Eventually(func() int {
+				return liveCount(f, pluginPod, pluginContainer, volID)
+			}, 30*time.Second, 2*time.Second).Should(gomega.BeNumerically("<", len(origLive)),
+				"expected a path to drop after deleting controller %s", victim)
+
+			ginkgo.By("verify the node plugin does NOT recover the unmanaged volume")
+			// A managed volume recovers within ~1 minute (see SPDKCSI-RECONNECT).
+			// Hold for longer and assert the degraded path is never restored.
+			gomega.Consistently(func() int {
+				return liveCount(f, pluginPod, pluginContainer, volID)
+			}, 90*time.Second, 5*time.Second).Should(gomega.BeNumerically("<", len(origLive)),
+				"node plugin must not reconnect paths for a volume with no PV/PVC")
+		})
+	})
+})
+
+// envOr returns the env var value or a default.
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// anyNodePluginPod returns an arbitrary csi-node DaemonSet pod, its node, and
+// its first container.
+func anyNodePluginPod(c kubernetes.Interface) (nodeName, podName, container string) {
+	dns := driverNamespace()
+	ds, err := c.AppsV1().DaemonSets(dns).Get(context.Background(), nodeDsName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "get node DaemonSet %s/%s", dns, nodeDsName)
+
+	pods, err := c.CoreV1().Pods(dns).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set(ds.Spec.Selector.MatchLabels).String(),
+	})
+	framework.ExpectNoError(err, "list csi-node pods")
+	gomega.Expect(pods.Items).NotTo(gomega.BeEmpty(), "no csi-node pods found")
+
+	pod := pods.Items[0]
+	return pod.Spec.NodeName, pod.Name, pod.Spec.Containers[0].Name
+}
+
+// sbctl runs `sbctl <args>` inside the webappapi pod and returns stdout.
+func sbctl(f *framework.Framework, args string) string {
+	ns, pod, container := webappAPIPod(f.ClientSet)
+	return execInPod(f, ns, pod, container, "sbctl "+args)
+}
+
+// webappAPIPod locates the running control-plane API pod hosting the sbctl CLI.
+func webappAPIPod(c kubernetes.Interface) (ns, name, container string) {
+	pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	framework.ExpectNoError(err, "list pods to find webappapi")
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Status.Phase == corev1.PodRunning && strings.Contains(p.Name, "webappapi") {
+			return p.Namespace, p.Name, p.Spec.Containers[0].Name
+		}
+	}
+	framework.Failf("no running webappapi pod found")
+	return "", "", ""
+}
+
+// nvmeConnectCommands extracts the `nvme connect ...` command lines emitted by
+// `sbctl volume connect`.
+func nvmeConnectCommands(out string) []string {
+	var cmds []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "nvme connect") {
+			cmds = append(cmds, line)
+		}
+	}
+	return cmds
+}
+
+// liveCount returns the number of live paths for the volume's subsystem, or 0
+// if the subsystem is gone.
+func liveCount(f *framework.Framework, podName, container, lvolID string) int {
+	s := subsystemForLvol(listSubsystems(f, podName, container), lvolID)
+	if s == nil {
+		return 0
+	}
+	return len(liveControllers(s))
+}

--- a/pkg/csi-common/driver.go
+++ b/pkg/csi-common/driver.go
@@ -95,6 +95,10 @@ func (d *CSIDriver) GetVolumeCapabilityAccessModes() []*csi.VolumeCapability_Acc
 	return d.vc
 }
 
+func (d *CSIDriver) GetName() string {
+	return d.name
+}
+
 func (d *CSIDriver) GetNodeID() string {
 	return d.nodeID
 }

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -80,6 +80,18 @@ func (m *Manager) Start(ctx context.Context) {
 	m.factory.Start(ctx.Done())
 }
 
+// HasSynced reports whether both informer caches have completed their initial
+// LIST. It is a status query (useful for readiness checks and tests), not a
+// gate: the caches populate automatically after Start, and reads transparently
+// fall back to the API until this returns true, so callers never need to block
+// on it. Returns false on a nil Manager.
+func (m *Manager) HasSynced() bool {
+	if m == nil {
+		return false
+	}
+	return m.pvInformer.HasSynced() && m.pvcInformer.HasSynced()
+}
+
 // Client returns the underlying Kubernetes client, for reads of resources the
 // Manager does not cache (e.g. Pods, StorageClasses). Returns nil on a nil
 // Manager.

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -1,0 +1,86 @@
+// Package kubernetes provides a Manager that serves Kubernetes object reads
+// from watch-backed, in-memory caches, transparently falling back to direct
+// API reads whenever the cache is not (yet) available. Hot paths get cache
+// performance without having to handle cache setup or sync failures themselves.
+package kubernetes
+
+import (
+	"context"
+
+	"k8s.io/client-go/informers"
+	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// csiDriverIndex is the name of the informer index that groups
+// PersistentVolumes by their CSI driver.
+const csiDriverIndex = "csiDriver"
+
+// Manager owns the shared informer caches for the resources the CSI driver
+// reads on hot paths (PersistentVolumes, PersistentVolumeClaims). Every read
+// goes through the cache when it is synced and falls back to a direct API read
+// otherwise, so callers never have to deal with an unavailable cache.
+//
+// A nil *Manager is valid and means "no Kubernetes access at all" (e.g. no
+// in-cluster client could be built); its read methods return empty results so
+// callers can keep operating in a degraded mode.
+type Manager struct {
+	client      k8sclient.Interface
+	factory     informers.SharedInformerFactory
+	pvInformer  cache.SharedIndexInformer
+	pvcInformer cache.SharedIndexInformer
+}
+
+// NewManager builds a Manager backed by the given client. Call Start to launch
+// the caches. Returns nil when client is nil, since without a client there is
+// neither a cache nor an API to fall back to.
+func NewManager(client k8sclient.Interface) *Manager {
+	if client == nil {
+		return nil
+	}
+
+	// resync period 0: rely purely on watch deltas, never re-List periodically.
+	factory := informers.NewSharedInformerFactory(client, 0)
+	pvInformer := factory.Core().V1().PersistentVolumes().Informer()
+	pvcInformer := factory.Core().V1().PersistentVolumeClaims().Informer()
+
+	if err := pvInformer.AddIndexers(cache.Indexers{
+		csiDriverIndex: indexPersistentVolumeByCSIDriver,
+	}); err != nil {
+		// Only fails on a duplicate index name or an already-started informer,
+		// neither of which can happen here. Reads stay correct via the API
+		// fallback even without the index, so log and continue.
+		klog.Warningf("kubernetes cache manager: failed to register %q index, "+
+			"PersistentVolume-by-driver reads will use the API: %v", csiDriverIndex, err)
+	}
+
+	return &Manager{
+		client:      client,
+		factory:     factory,
+		pvInformer:  pvInformer,
+		pvcInformer: pvcInformer,
+	}
+}
+
+// Start launches the informers, which LIST-then-WATCH in the background and
+// populate the caches automatically; there is no manual sync step. Reads check
+// HasSynced per call and fall back to the API until the initial LIST completes,
+// so Start need not block on sync. It is a no-op on a nil Manager and should be
+// called once from a single owner. The informers run until ctx is cancelled.
+func (m *Manager) Start(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.factory.Start(ctx.Done())
+}
+
+// Client returns the underlying Kubernetes client, for reads of resources the
+// Manager does not cache (e.g. Pods, StorageClasses). Returns nil on a nil
+// Manager.
+func (m *Manager) Client() k8sclient.Interface {
+	if m == nil {
+		return nil
+	}
+	return m.client
+}

--- a/pkg/kubernetes/manager.go
+++ b/pkg/kubernetes/manager.go
@@ -17,6 +17,10 @@ import (
 // PersistentVolumes by their CSI driver.
 const csiDriverIndex = "csiDriver"
 
+// lvolIndex is the name of the informer index that maps PersistentVolumes by
+// the lvol (logical volume) ID encoded in their CSI volume handle.
+const lvolIndex = "lvol"
+
 // Manager owns the shared informer caches for the resources the CSI driver
 // reads on hot paths (PersistentVolumes, PersistentVolumeClaims). Every read
 // goes through the cache when it is synced and falls back to a direct API read
@@ -47,12 +51,13 @@ func NewManager(client k8sclient.Interface) *Manager {
 
 	if err := pvInformer.AddIndexers(cache.Indexers{
 		csiDriverIndex: indexPersistentVolumeByCSIDriver,
+		lvolIndex:      indexPersistentVolumeByLvolID,
 	}); err != nil {
 		// Only fails on a duplicate index name or an already-started informer,
 		// neither of which can happen here. Reads stay correct via the API
 		// fallback even without the index, so log and continue.
-		klog.Warningf("kubernetes cache manager: failed to register %q index, "+
-			"PersistentVolume-by-driver reads will use the API: %v", csiDriverIndex, err)
+		klog.Warningf("kubernetes cache manager: failed to register PersistentVolume "+
+			"indexers, those reads will fall back to the API: %v", err)
 	}
 
 	return &Manager{

--- a/pkg/kubernetes/manager_test.go
+++ b/pkg/kubernetes/manager_test.go
@@ -1,0 +1,213 @@
+package kubernetes_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	sbkube "github.com/spdk/spdk-csi/pkg/kubernetes"
+)
+
+const testDriver = "csi.simplyblock.io"
+
+// Realistic handle components: clusterID and lvolID are UUIDs (as production
+// volume handles always are); poolID is a name here to exercise that it need
+// not be a UUID.
+const (
+	clusterUUID = "8ffac363-0c46-4714-a71b-f9c0b58a1269"
+	poolName    = "pool-1"
+
+	lvolA       = "a1111111-1111-4111-8111-111111111111"
+	lvolB       = "b2222222-2222-4222-8222-222222222222"
+	lvolC       = "c3333333-3333-4333-8333-333333333333"
+	lvolMissing = "d4444444-4444-4444-8444-444444444444"
+	lvolZ       = "e5555555-5555-4555-8555-555555555555"
+)
+
+func handle(lvolID string) string {
+	return clusterUUID + ":" + poolName + ":" + lvolID
+}
+
+func testPV(name, driver, handle string) *corev1.PersistentVolume {
+	pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if driver != "" || handle != "" {
+		pv.Spec.PersistentVolumeSource.CSI = &corev1.CSIPersistentVolumeSource{
+			Driver:       driver,
+			VolumeHandle: handle,
+		}
+	}
+	return pv
+}
+
+func testPVC(namespace, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+// sampleObjects returns a fresh fixture set on every call so tests never share
+// mutable objects through the fake clientset/informer store.
+func sampleObjects() []runtime.Object {
+	return []runtime.Object{
+		testPV("pv-a", testDriver, handle(lvolA)),
+		testPV("pv-b", testDriver, handle(lvolB)),
+		testPV("pv-other", "other.csi.io", handle(lvolC)),
+		testPV("pv-nocsi", "", ""),
+		testPVC("ns1", "claim-x"),
+	}
+}
+
+func nameSet(pvs []*corev1.PersistentVolume) map[string]bool {
+	s := make(map[string]bool, len(pvs))
+	for _, pv := range pvs {
+		s[pv.Name] = true
+	}
+	return s
+}
+
+func waitForSync(t *testing.T, m *sbkube.Manager) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.HasSynced() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("cache did not sync within timeout")
+}
+
+// assertReads exercises every read method against the standard fixture set and
+// is run against both the API-fallback path and the cache path.
+func assertReads(t *testing.T, ctx context.Context, m *sbkube.Manager) {
+	t.Helper()
+
+	pvs, err := m.PersistentVolumesByDriver(ctx, testDriver)
+	if err != nil {
+		t.Fatalf("PersistentVolumesByDriver: unexpected error %v", err)
+	}
+	if got := nameSet(pvs); len(got) != 2 || !got["pv-a"] || !got["pv-b"] {
+		t.Fatalf("PersistentVolumesByDriver = %v, want {pv-a, pv-b}", got)
+	}
+
+	if pv, err := m.PersistentVolumeByName(ctx, "pv-a"); err != nil || pv == nil || pv.Name != "pv-a" {
+		t.Fatalf("PersistentVolumeByName(pv-a) = %v, %v", pv, err)
+	}
+	if _, err := m.PersistentVolumeByName(ctx, "missing"); !apierrors.IsNotFound(err) {
+		t.Fatalf("PersistentVolumeByName(missing) error = %v, want NotFound", err)
+	}
+
+	if pv, err := m.PersistentVolumeByLogicalVolumeID(ctx, lvolB); err != nil || pv == nil || pv.Name != "pv-b" {
+		t.Fatalf("PersistentVolumeByLogicalVolumeID(lvolB) = %v, %v", pv, err)
+	}
+	// lvol index is driver-agnostic: a non-simplyblock PV is still found by lvol ID.
+	if pv, err := m.PersistentVolumeByLogicalVolumeID(ctx, lvolC); err != nil || pv == nil || pv.Name != "pv-other" {
+		t.Fatalf("PersistentVolumeByLogicalVolumeID(lvolC) = %v, %v", pv, err)
+	}
+	if _, err := m.PersistentVolumeByLogicalVolumeID(ctx, lvolMissing); !apierrors.IsNotFound(err) {
+		t.Fatalf("PersistentVolumeByLogicalVolumeID(lvolMissing) error = %v, want NotFound", err)
+	}
+
+	if pvc, err := m.PersistentVolumeClaimByNamespaceAndName(ctx, "ns1", "claim-x"); err != nil || pvc == nil || pvc.Name != "claim-x" {
+		t.Fatalf("PersistentVolumeClaimByNamespaceAndName(ns1/claim-x) = %v, %v", pvc, err)
+	}
+	if _, err := m.PersistentVolumeClaimByNamespaceAndName(ctx, "ns1", "missing"); !apierrors.IsNotFound(err) {
+		t.Fatalf("PersistentVolumeClaimByNamespaceAndName(missing) error = %v, want NotFound", err)
+	}
+}
+
+func TestNewManagerNilClient(t *testing.T) {
+	if m := sbkube.NewManager(nil); m != nil {
+		t.Fatalf("NewManager(nil) = %v, want nil", m)
+	}
+
+	var m *sbkube.Manager // nil receiver must be safe
+	ctx := context.Background()
+
+	if pvs, err := m.PersistentVolumesByDriver(ctx, testDriver); pvs != nil || err != nil {
+		t.Fatalf("nil.PersistentVolumesByDriver = %v, %v; want nil, nil", pvs, err)
+	}
+	if _, err := m.PersistentVolumeByName(ctx, "x"); !apierrors.IsNotFound(err) {
+		t.Fatalf("nil.PersistentVolumeByName error = %v, want NotFound", err)
+	}
+	if _, err := m.PersistentVolumeByLogicalVolumeID(ctx, "x"); !apierrors.IsNotFound(err) {
+		t.Fatalf("nil.PersistentVolumeByLogicalVolumeID error = %v, want NotFound", err)
+	}
+	if _, err := m.PersistentVolumeClaimByNamespaceAndName(ctx, "ns", "x"); !apierrors.IsNotFound(err) {
+		t.Fatalf("nil.PersistentVolumeClaimByNamespaceAndName error = %v, want NotFound", err)
+	}
+	if m.Client() != nil {
+		t.Fatal("nil.Client() != nil")
+	}
+	if m.HasSynced() {
+		t.Fatal("nil.HasSynced() == true")
+	}
+	m.Start(ctx) // must not panic
+}
+
+func TestManagerAPIFallback(t *testing.T) {
+	client := fake.NewSimpleClientset(sampleObjects()...)
+	m := sbkube.NewManager(client)
+
+	// No Start: the informers never sync, so every read takes the API path.
+	if m.HasSynced() {
+		t.Fatal("HasSynced() == true before Start")
+	}
+	assertReads(t, context.Background(), m)
+}
+
+func TestManagerServesFromCache(t *testing.T) {
+	client := fake.NewSimpleClientset(sampleObjects()...)
+	m := sbkube.NewManager(client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	waitForSync(t, m)
+
+	// Disable the API so any successful read must be served from the cache.
+	disabled := errors.New("API disabled")
+	react := func(k8stesting.Action) (bool, runtime.Object, error) { return true, nil, disabled }
+	client.PrependReactor("list", "*", react)
+	client.PrependReactor("get", "*", react)
+
+	assertReads(t, ctx, m)
+}
+
+func TestManagerReflectsWatchUpdates(t *testing.T) {
+	client := fake.NewSimpleClientset() // start empty
+	m := sbkube.NewManager(client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	waitForSync(t, m)
+
+	if _, err := m.PersistentVolumeByLogicalVolumeID(ctx, lvolZ); !apierrors.IsNotFound(err) {
+		t.Fatalf("before create: error = %v, want NotFound", err)
+	}
+
+	if _, err := client.CoreV1().PersistentVolumes().Create(ctx,
+		testPV("pv-z", testDriver, handle(lvolZ)), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create PV: %v", err)
+	}
+
+	// The watch must propagate the new PV into the cache.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		pv, err := m.PersistentVolumeByLogicalVolumeID(ctx, lvolZ)
+		if err == nil && pv != nil && pv.Name == "pv-z" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("watch update not reflected in cache (last err = %v)", err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/pkg/kubernetes/persistent_volume_claims.go
+++ b/pkg/kubernetes/persistent_volume_claims.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+// PersistentVolumeClaimByNamespaceAndName returns the PersistentVolumeClaim with
+// the given namespace and name. Served from the cache when synced, otherwise
+// fetched directly from the API. A missing claim is reported as a NotFound error
+// from either path.
+func (m *Manager) PersistentVolumeClaimByNamespaceAndName(ctx context.Context, namespace, name string) (*corev1.PersistentVolumeClaim, error) {
+	if m == nil {
+		return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumeclaims"), name)
+	}
+
+	if m.pvcInformer.HasSynced() {
+		obj, exists, err := m.pvcInformer.GetStore().GetByKey(namespace + "/" + name)
+		if err == nil {
+			if !exists {
+				return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumeclaims"), name)
+			}
+			if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+				return pvc, nil
+			}
+		} else {
+			klog.Warningf("kubernetes cache manager: PersistentVolumeClaim %s/%s lookup failed, falling back to API: %v", namespace, name, err)
+		}
+	}
+
+	return m.client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/persistent_volumes.go
+++ b/pkg/kubernetes/persistent_volumes.go
@@ -2,12 +2,13 @@ package kubernetes
 
 import (
 	"context"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+
+	"github.com/spdk/spdk-csi/pkg/kubernetes/volumehandle"
 )
 
 // indexPersistentVolumeByCSIDriver is the IndexFunc that groups
@@ -22,27 +23,17 @@ func indexPersistentVolumeByCSIDriver(obj interface{}) ([]string, error) {
 
 // indexPersistentVolumeByLvolID is the IndexFunc that maps PersistentVolumes by
 // the lvol ID in their CSI volume handle ("<clusterID>:<poolID>:<lvolID>").
+// Handles that are not well-formed are left out of the index.
 func indexPersistentVolumeByLvolID(obj interface{}) ([]string, error) {
 	pv, ok := obj.(*corev1.PersistentVolume)
 	if !ok || pv.Spec.CSI == nil {
 		return nil, nil
 	}
-	if lvolID := lvolIDFromVolumeHandle(pv.Spec.CSI.VolumeHandle); lvolID != "" {
-		return []string{lvolID}, nil
+	vh, ok := volumehandle.Parse(pv.Spec.CSI.VolumeHandle)
+	if !ok {
+		return nil, nil
 	}
-	return nil, nil
-}
-
-// lvolIDFromVolumeHandle extracts the trailing lvol ID from a CSI volume handle
-// of the form "<clusterID>:<poolID>:<lvolID>", or "" if it is not well-formed.
-// (pkg/util owns the full handle parser, but importing it here would create an
-// import cycle, so the cache layer extracts just the field it indexes on.)
-func lvolIDFromVolumeHandle(handle string) string {
-	parts := strings.Split(handle, ":")
-	if len(parts) != 3 {
-		return ""
-	}
-	return parts[2]
+	return []string{vh.VolumeID}, nil
 }
 
 // PersistentVolumesByDriver returns every PersistentVolume provisioned by the
@@ -138,7 +129,10 @@ func (m *Manager) PersistentVolumeByLogicalVolumeID(ctx context.Context, lvolID 
 	}
 	for i := range list.Items {
 		pv := &list.Items[i]
-		if pv.Spec.CSI != nil && lvolIDFromVolumeHandle(pv.Spec.CSI.VolumeHandle) == lvolID {
+		if pv.Spec.CSI == nil {
+			continue
+		}
+		if vh, ok := volumehandle.Parse(pv.Spec.CSI.VolumeHandle); ok && vh.VolumeID == lvolID {
 			return pv, nil
 		}
 	}

--- a/pkg/kubernetes/persistent_volumes.go
+++ b/pkg/kubernetes/persistent_volumes.go
@@ -1,0 +1,83 @@
+package kubernetes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+// indexPersistentVolumeByCSIDriver is the IndexFunc that groups
+// PersistentVolumes by their CSI driver name.
+func indexPersistentVolumeByCSIDriver(obj interface{}) ([]string, error) {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok || pv.Spec.CSI == nil {
+		return nil, nil
+	}
+	return []string{pv.Spec.CSI.Driver}, nil
+}
+
+// PersistentVolumesByDriver returns every PersistentVolume provisioned by the
+// given CSI driver. It is served from the cache when synced, otherwise listed
+// directly from the API and filtered client-side (the API server has no
+// spec.csi.driver field selector for PVs). Returns nil on a nil Manager.
+func (m *Manager) PersistentVolumesByDriver(ctx context.Context, driver string) ([]*corev1.PersistentVolume, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	if m.pvInformer.HasSynced() {
+		objs, err := m.pvInformer.GetIndexer().ByIndex(csiDriverIndex, driver)
+		if err == nil {
+			pvs := make([]*corev1.PersistentVolume, 0, len(objs))
+			for _, obj := range objs {
+				if pv, ok := obj.(*corev1.PersistentVolume); ok {
+					pvs = append(pvs, pv)
+				}
+			}
+			return pvs, nil
+		}
+		klog.Warningf("kubernetes cache manager: %q index lookup failed, falling back to API: %v", csiDriverIndex, err)
+	}
+
+	list, err := m.client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	pvs := make([]*corev1.PersistentVolume, 0, len(list.Items))
+	for i := range list.Items {
+		pv := &list.Items[i]
+		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == driver {
+			pvs = append(pvs, pv)
+		}
+	}
+	return pvs, nil
+}
+
+// PersistentVolumeByName returns the PersistentVolume with the given name.
+// PersistentVolumes are cluster-scoped, so the name alone is the cache key.
+// Served from the cache when synced, otherwise fetched directly from the API.
+// A missing PV is reported as a NotFound error from either path.
+func (m *Manager) PersistentVolumeByName(ctx context.Context, name string) (*corev1.PersistentVolume, error) {
+	if m == nil {
+		return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumes"), name)
+	}
+
+	if m.pvInformer.HasSynced() {
+		obj, exists, err := m.pvInformer.GetStore().GetByKey(name)
+		if err == nil {
+			if !exists {
+				return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumes"), name)
+			}
+			if pv, ok := obj.(*corev1.PersistentVolume); ok {
+				return pv, nil
+			}
+		} else {
+			klog.Warningf("kubernetes cache manager: PersistentVolume %q lookup failed, falling back to API: %v", name, err)
+		}
+	}
+
+	return m.client.CoreV1().PersistentVolumes().Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/kubernetes/persistent_volumes.go
+++ b/pkg/kubernetes/persistent_volumes.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +18,31 @@ func indexPersistentVolumeByCSIDriver(obj interface{}) ([]string, error) {
 		return nil, nil
 	}
 	return []string{pv.Spec.CSI.Driver}, nil
+}
+
+// indexPersistentVolumeByLvolID is the IndexFunc that maps PersistentVolumes by
+// the lvol ID in their CSI volume handle ("<clusterID>:<poolID>:<lvolID>").
+func indexPersistentVolumeByLvolID(obj interface{}) ([]string, error) {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok || pv.Spec.CSI == nil {
+		return nil, nil
+	}
+	if lvolID := lvolIDFromVolumeHandle(pv.Spec.CSI.VolumeHandle); lvolID != "" {
+		return []string{lvolID}, nil
+	}
+	return nil, nil
+}
+
+// lvolIDFromVolumeHandle extracts the trailing lvol ID from a CSI volume handle
+// of the form "<clusterID>:<poolID>:<lvolID>", or "" if it is not well-formed.
+// (pkg/util owns the full handle parser, but importing it here would create an
+// import cycle, so the cache layer extracts just the field it indexes on.)
+func lvolIDFromVolumeHandle(handle string) string {
+	parts := strings.Split(handle, ":")
+	if len(parts) != 3 {
+		return ""
+	}
+	return parts[2]
 }
 
 // PersistentVolumesByDriver returns every PersistentVolume provisioned by the
@@ -80,4 +106,41 @@ func (m *Manager) PersistentVolumeByName(ctx context.Context, name string) (*cor
 	}
 
 	return m.client.CoreV1().PersistentVolumes().Get(ctx, name, metav1.GetOptions{})
+}
+
+// PersistentVolumeByLogicalVolumeID returns the PersistentVolume whose CSI
+// volume handle ("<clusterID>:<poolID>:<lvolID>") carries the given lvol ID.
+// Served from the cache when synced, otherwise listed from the API and matched
+// client-side (the handle is not an API-queryable field). A missing or
+// ambiguous lvol ID is reported as a NotFound error.
+func (m *Manager) PersistentVolumeByLogicalVolumeID(ctx context.Context, lvolID string) (*corev1.PersistentVolume, error) {
+	if m == nil {
+		return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumes"), lvolID)
+	}
+
+	if m.pvInformer.HasSynced() {
+		objs, err := m.pvInformer.GetIndexer().ByIndex(lvolIndex, lvolID)
+		if err == nil {
+			if len(objs) == 0 {
+				return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumes"), lvolID)
+			}
+			if pv, ok := objs[0].(*corev1.PersistentVolume); ok {
+				return pv, nil
+			}
+		} else {
+			klog.Warningf("kubernetes cache manager: %q index lookup failed, falling back to API: %v", lvolIndex, err)
+		}
+	}
+
+	list, err := m.client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		pv := &list.Items[i]
+		if pv.Spec.CSI != nil && lvolIDFromVolumeHandle(pv.Spec.CSI.VolumeHandle) == lvolID {
+			return pv, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(corev1.Resource("persistentvolumes"), lvolID)
 }

--- a/pkg/kubernetes/volumehandle/index.go
+++ b/pkg/kubernetes/volumehandle/index.go
@@ -1,0 +1,52 @@
+package volumehandle
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type VolumeHandle struct {
+	ClusterID string
+	PoolID    string
+	VolumeID  string
+}
+
+var NilVolumeHandle = VolumeHandle{}
+
+// uuidRegex matches a standard UUID (8-4-4-4-12 hex, with hyphens). Compiled
+// once at package scope so isUUID stays allocation-free per call.
+var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// isUUID reports whether s is a standard UUID (8-4-4-4-12 hex, with hyphens).
+func isUUID(s string) bool {
+	return uuidRegex.MatchString(s)
+}
+
+// Parse splits a CSI volume handle of the form "{clusterID}:{poolID}:{lvolID}"
+// into its three components. clusterID and lvolID must be UUIDs; poolID may be
+// either a pool UUID or a pool name, so it only has to be non-empty. The second
+// return value is false (and the handle is the zero value) when the input is
+// not exactly three colon-separated parts or any part fails its check.
+func Parse(handle string) (VolumeHandle, bool) {
+	ids := strings.Split(strings.TrimSpace(handle), ":")
+	if len(ids) != 3 {
+		return NilVolumeHandle, false
+	}
+	clusterID, poolID, lvolID := ids[0], ids[1], ids[2]
+	if !isUUID(clusterID) || poolID == "" || !isUUID(lvolID) {
+		return NilVolumeHandle, false
+	}
+	return VolumeHandle{clusterID, poolID, lvolID}, true
+}
+
+// MustParse is like Parse but panics if the handle is malformed. Use it only
+// for handles already known to be valid (constructed internally or in tests),
+// never for cluster- or user-supplied input.
+func MustParse(handle string) VolumeHandle {
+	parsed, ok := Parse(handle)
+	if !ok {
+		panic(fmt.Sprintf("volumehandle: invalid handle %q (expected {clusterID}:{poolID}:{lvolID} with UUID cluster/lvol)", handle))
+	}
+	return parsed
+}

--- a/pkg/kubernetes/volumehandle/index_test.go
+++ b/pkg/kubernetes/volumehandle/index_test.go
@@ -1,0 +1,122 @@
+package volumehandle
+
+import "testing"
+
+const (
+	testCluster  = "8ffac363-0c46-4714-a71b-f9c0b58a1269"
+	testPoolUUID = "df34f16c-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+	testLvol     = "8e2dcb9d-1b2c-4f3a-9d4e-5f6a7b8c9d0e"
+)
+
+func parseCases() []struct {
+	name    string
+	handle  string
+	wantOK  bool
+	cluster string
+	pool    string
+	lvol    string
+} {
+	return []struct {
+		name    string
+		handle  string
+		wantOK  bool
+		cluster string
+		pool    string
+		lvol    string
+	}{
+		{
+			name:   "all UUIDs",
+			handle: testCluster + ":" + testPoolUUID + ":" + testLvol,
+			wantOK: true, cluster: testCluster, pool: testPoolUUID, lvol: testLvol,
+		},
+		{
+			name:   "pool is a name",
+			handle: testCluster + ":my-pool:" + testLvol,
+			wantOK: true, cluster: testCluster, pool: "my-pool", lvol: testLvol,
+		},
+		{
+			name:   "surrounding whitespace trimmed",
+			handle: "  " + testCluster + ":my-pool:" + testLvol + "  ",
+			wantOK: true, cluster: testCluster, pool: "my-pool", lvol: testLvol,
+		},
+		{name: "empty handle", handle: ""},
+		{name: "two parts", handle: testCluster + ":" + testLvol},
+		{name: "four parts", handle: testCluster + ":p:" + testLvol + ":extra"},
+		{name: "cluster not a UUID", handle: "not-a-uuid:my-pool:" + testLvol},
+		{name: "lvol not a UUID", handle: testCluster + ":my-pool:not-a-uuid"},
+		{name: "empty pool", handle: testCluster + "::" + testLvol},
+		{name: "empty cluster", handle: ":my-pool:" + testLvol},
+		{name: "empty lvol", handle: testCluster + ":my-pool:"},
+	}
+}
+
+func TestParse(t *testing.T) {
+	for _, tc := range parseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Parse(tc.handle)
+			if ok != tc.wantOK {
+				t.Fatalf("Parse(%q) ok = %v, want %v", tc.handle, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				if got != NilVolumeHandle {
+					t.Fatalf("Parse(%q) returned %+v on failure, want zero value", tc.handle, got)
+				}
+				return
+			}
+			if got.ClusterID != tc.cluster || got.PoolID != tc.pool || got.VolumeID != tc.lvol {
+				t.Fatalf("Parse(%q) = %+v, want {%q %q %q}",
+					tc.handle, got, tc.cluster, tc.pool, tc.lvol)
+			}
+		})
+	}
+}
+
+func TestMustParse(t *testing.T) {
+	for _, tc := range parseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tc.wantOK && r != nil {
+					t.Fatalf("MustParse(%q) panicked unexpectedly: %v", tc.handle, r)
+				}
+				if !tc.wantOK && r == nil {
+					t.Fatalf("MustParse(%q) did not panic, want panic", tc.handle)
+				}
+			}()
+			got := MustParse(tc.handle)
+			if got.ClusterID != tc.cluster || got.PoolID != tc.pool || got.VolumeID != tc.lvol {
+				t.Fatalf("MustParse(%q) = %+v, want {%q %q %q}",
+					tc.handle, got, tc.cluster, tc.pool, tc.lvol)
+			}
+		})
+	}
+}
+
+func TestIsUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"lowercase", "8ffac363-0c46-4714-a71b-f9c0b58a1269", true},
+		{"uppercase", "8FFAC363-0C46-4714-A71B-F9C0B58A1269", true},
+		{"mixed case", "8ffAC363-0c46-4714-A71b-f9C0b58a1269", true},
+		{"empty", "", false},
+		{"pool name", "my-pool", false},
+		{"missing hyphens", "8ffac3630c464714a71bf9c0b58a1269", false},
+		{"too short", "8ffac363-0c46-4714-a71b-f9c0b58a126", false},
+		{"too long", "8ffac363-0c46-4714-a71b-f9c0b58a12690", false},
+		{"non-hex digit", "8ffac363-0c46-4714-a71b-f9c0b58a126g", false},
+		{"hyphens misplaced", "8ffac3630-c46-4714-a71b-f9c0b58a1269", false},
+		{"leading space", " 8ffac363-0c46-4714-a71b-f9c0b58a1269", false},
+		{"trailing space", "8ffac363-0c46-4714-a71b-f9c0b58a1269 ", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUUID(tc.in); got != tc.want {
+				t.Fatalf("isUUID(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -698,15 +698,15 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 func parseVolumeID(csiVolumeID string) (*spdkVolume, error) {
 	// csiVolumeID format: {clusterUUID}:{poolUUID}:{lvolUUID}
 	// e.g. 8ffac363-0c46-4714-a71b-f9c0b58a1269:df34f16c-...:8e2dcb9d-...
-	ids := strings.Split(csiVolumeID, ":")
-	if len(ids) == 3 {
-		return &spdkVolume{
-			clusterID: ids[0],
-			poolID:    ids[1],
-			lvolID:    ids[2],
-		}, nil
+	clusterID, poolID, lvolID, err := util.ParseVolumeHandle(csiVolumeID)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("missing clusterID or poolID in volume: %s", csiVolumeID)
+	return &spdkVolume{
+		clusterID: clusterID,
+		poolID:    poolID,
+		lvolID:    lvolID,
+	}, nil
 }
 
 func parseSnapshotID(csiSnapshotID string) (*spdkSnapshot, error) {

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/spdk/spdk-csi/pkg/kubernetes/volumehandle"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -698,14 +699,14 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 func parseVolumeID(csiVolumeID string) (*spdkVolume, error) {
 	// csiVolumeID format: {clusterUUID}:{poolUUID}:{lvolUUID}
 	// e.g. 8ffac363-0c46-4714-a71b-f9c0b58a1269:df34f16c-...:8e2dcb9d-...
-	clusterID, poolID, lvolID, err := util.ParseVolumeHandle(csiVolumeID)
-	if err != nil {
-		return nil, err
+	vh, ok := volumehandle.Parse(csiVolumeID)
+	if !ok {
+		return nil, fmt.Errorf("invalid volume handle %q (expected {clusterID}:{poolID}:{lvolID})", csiVolumeID)
 	}
 	return &spdkVolume{
-		clusterID: clusterID,
-		poolID:    poolID,
-		lvolID:    lvolID,
+		clusterID: vh.ClusterID,
+		poolID:    vh.PoolID,
+		lvolID:    vh.VolumeID,
 	}, nil
 }
 

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -368,19 +368,14 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
 
-	// If the staging mount died (total NVMe-oF path loss removed the device),
-	// repair it before bind-mounting into the pod — otherwise the pod inherits
-	// the dead (EIO) mount. kubelet skips NodeStage when the volume is still
-	// referenced by another pod on this node (e.g. a same-node pod replacement),
-	// so NodePublish is the reliable place to heal. Filesystem volumes only.
-	if req.GetVolumeCapability().GetMount() != nil {
-		stagingTargetPath := getStagingTargetPath(req)
-		if ns.stagingMountDead(stagingTargetPath) {
-			if err := ns.restageVolume(ctx, volumeID, stagingTargetPath, req.GetStagingTargetPath(), req.GetVolumeCapability()); err != nil {
-				klog.Errorf("failed to restage dead volume %s before publish: %v", volumeID, err)
-				return nil, status.Errorf(codes.Internal, "restage dead volume %s: %v", volumeID, err)
-			}
-		}
+	// If the backing NVMe-oF device was lost (total path loss), repair it before
+	// bind-mounting into the pod — otherwise the pod inherits the dead mount/
+	// missing device. kubelet skips NodeStage when the volume is still referenced
+	// on this node (e.g. a same-node pod replacement), so NodePublish is the
+	// reliable place to heal.
+	if err := ns.healVolumeBeforePublish(ctx, req); err != nil {
+		klog.Errorf("failed to heal volume %s before publish: %v", volumeID, err)
+		return nil, status.Errorf(codes.Internal, "heal volume %s before publish: %v", volumeID, err)
 	}
 
 	err := ns.publishVolume(getStagingTargetPath(req), req) // idempotent
@@ -608,6 +603,64 @@ func (ns *nodeServer) forceUnmountStaging(stagingPath string) error {
 		return fmt.Errorf("lazy unmount %s: %w (%s)", stagingPath, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// healVolumeBeforePublish repairs a volume whose backing NVMe-oF device was lost
+// (total path loss) before it is bind-mounted into a (replacement) pod. For
+// filesystem volumes it restages the dead staging mount; for block volumes it
+// reconnects the missing device. No-op when the volume is healthy.
+func (ns *nodeServer) healVolumeBeforePublish(ctx context.Context, req *csi.NodePublishVolumeRequest) error {
+	volCap := req.GetVolumeCapability()
+	stagingParentPath := req.GetStagingTargetPath()
+
+	switch {
+	case volCap.GetBlock() != nil:
+		return ns.ensureDeviceConnected(ctx, req.GetVolumeId(), stagingParentPath)
+	case volCap.GetMount() != nil:
+		stagingTargetPath := getStagingTargetPath(req)
+		if ns.stagingMountDead(stagingTargetPath) {
+			return ns.restageVolume(ctx, req.GetVolumeId(), stagingTargetPath, stagingParentPath, volCap)
+		}
+	}
+	return nil
+}
+
+// ensureDeviceConnected reconnects a block volume's NVMe-oF device if it has
+// gone away. The by-id device path is stable across reconnects, so only the
+// connection needs re-establishing (no mount). Idempotent.
+func (ns *nodeServer) ensureDeviceConnected(ctx context.Context, volumeID, stagingParentPath string) error {
+	volumeContext, err := util.LookupVolumeContext(stagingParentPath)
+	if err != nil {
+		return fmt.Errorf("lookup volume context: %w", err)
+	}
+	if devicePath := volumeContext["devicePath"]; devicePath != "" && deviceExists(devicePath) {
+		return nil
+	}
+
+	klog.Warningf("block volume %s device is gone; reconnecting NVMe-oF", volumeID)
+	initiator, err := util.NewSpdkCsiInitiator(volumeContext)
+	if err != nil {
+		return fmt.Errorf("new initiator: %w", err)
+	}
+	devicePath, err := initiator.Connect(ctx) // idempotent
+	if err != nil {
+		return fmt.Errorf("reconnect device: %w", err)
+	}
+	if volumeContext["devicePath"] != devicePath {
+		volumeContext["devicePath"] = devicePath
+		if err := util.StashVolumeContext(volumeContext, stagingParentPath); err != nil {
+			klog.Warningf("ensureDeviceConnected: re-stash volume context for %s: %v", volumeID, err)
+		}
+	}
+	klog.Infof("reconnected block volume %s device %s", volumeID, devicePath)
+	return nil
+}
+
+// deviceExists reports whether path resolves to an existing device, following
+// symlinks such as /dev/disk/by-id/nvme-<uuid>_ha_1.
+func deviceExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // restageVolume repairs a staging mount whose backing NVMe-oF device was lost

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -84,7 +84,7 @@ func newNodeServer(d *csicommon.CSIDriver) (*nodeServer, error) {
 		if ns.guardian != nil {
 			ns.guardian.MarkBrokenLvol(lvolID)
 		}
-	})
+	}, ns.kubeClient)
 
 	return ns, nil
 }

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -242,7 +242,17 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if isStaged {
-		klog.Warning("volume already staged")
+		// A staged volume whose backing NVMe-oF device was lost leaves a dead
+		// (EIO) mount that isStaged still reports as staged. Repair it in place
+		// instead of short-circuiting.
+		if !ns.stagingMountDead(stagingTargetPath) {
+			klog.Warning("volume already staged")
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
+		klog.Warningf("volume %s already staged but its mount is dead; restaging", volumeID)
+		if err := ns.restageVolume(ctx, volumeID, stagingTargetPath, stagingParentPath, req.GetVolumeCapability()); err != nil {
+			return nil, status.Errorf(codes.Internal, "restage volume %s: %v", volumeID, err)
+		}
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
@@ -357,6 +367,21 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volumeID := req.GetVolumeId()
 	unlock := ns.volumeLocks.Lock(volumeID)
 	defer unlock()
+
+	// If the staging mount died (total NVMe-oF path loss removed the device),
+	// repair it before bind-mounting into the pod — otherwise the pod inherits
+	// the dead (EIO) mount. kubelet skips NodeStage when the volume is still
+	// referenced by another pod on this node (e.g. a same-node pod replacement),
+	// so NodePublish is the reliable place to heal. Filesystem volumes only.
+	if req.GetVolumeCapability().GetMount() != nil {
+		stagingTargetPath := getStagingTargetPath(req)
+		if ns.stagingMountDead(stagingTargetPath) {
+			if err := ns.restageVolume(ctx, volumeID, stagingTargetPath, req.GetStagingTargetPath(), req.GetVolumeCapability()); err != nil {
+				klog.Errorf("failed to restage dead volume %s before publish: %v", volumeID, err)
+				return nil, status.Errorf(codes.Internal, "restage dead volume %s: %v", volumeID, err)
+			}
+		}
+	}
 
 	err := ns.publishVolume(getStagingTargetPath(req), req) // idempotent
 	if err != nil {
@@ -491,32 +516,9 @@ func (ns *nodeServer) stageVolume(devicePath, stagingPath string, req *csi.NodeS
 	if mounted {
 		return nil
 	}
-	fsType := req.GetVolumeCapability().GetMount().GetFsType()
-	// if fsType is not specified, use ext4 as default
-	if fsType == "" {
-		fsType = "ext4"
-	}
-
-	mntFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
+	fsType := fsTypeOrDefault(req.GetVolumeCapability())
+	mntFlags := stagingMountFlags(req.GetVolumeCapability())
 	formatOptions := []string{}
-
-	if fsType == "xfs" {
-		// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
-		// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
-		mntFlags = append(mntFlags, "nouuid")
-	}
-
-	switch req.GetVolumeCapability().GetAccessMode().GetMode() {
-	case csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
-		csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
-		mntFlags = append(mntFlags, "ro")
-	case csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER:
-	case csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER:
-	case csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
-	case csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER:
-	case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:
-	case csi.VolumeCapability_AccessMode_UNKNOWN:
-	}
 
 	klog.Infof("mount %s to %s, fstype: %s, flags: %v", devicePath, stagingPath, fsType, mntFlags)
 	klog.Infof("formatOptions %v", formatOptions)
@@ -541,6 +543,117 @@ func (ns *nodeServer) stageVolume(devicePath, stagingPath string, req *csi.NodeS
 		}
 	}
 
+	return nil
+}
+
+// fsTypeOrDefault returns the requested filesystem type, defaulting to ext4.
+func fsTypeOrDefault(volCap *csi.VolumeCapability) string {
+	if fsType := volCap.GetMount().GetFsType(); fsType != "" {
+		return fsType
+	}
+	return "ext4"
+}
+
+// stagingMountFlags builds the mount flags used when mounting a volume at its
+// staging path, so the initial stage and a later restage stay consistent.
+func stagingMountFlags(volCap *csi.VolumeCapability) []string {
+	flags := append([]string{}, volCap.GetMount().GetMountFlags()...)
+
+	if volCap.GetMount().GetFsType() == "xfs" {
+		// xfs refuses to mount two filesystems with the same uuid; nouuid lets a
+		// volume and its clone/restored snapshot mount on the same node.
+		flags = append(flags, "nouuid")
+	}
+
+	switch volCap.GetAccessMode().GetMode() {
+	case csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
+		flags = append(flags, "ro")
+	case csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		csi.VolumeCapability_AccessMode_UNKNOWN:
+	}
+	return flags
+}
+
+// stagingMountDead reports whether stagingPath is a dead/corrupted mount — the
+// state left behind when total NVMe-oF path loss makes the kernel remove the
+// backing device. Such a mount returns ENOTCONN/ESTALE/EIO on access, which
+// mount.IsCorruptedMnt detects.
+func (ns *nodeServer) stagingMountDead(stagingPath string) bool {
+	if _, err := ns.mounter.IsMountPoint(stagingPath); err != nil {
+		return mount.IsCorruptedMnt(err)
+	}
+	// IsMountPoint can still succeed on a mount whose device just vanished;
+	// a stat of the path then fails with an EIO-class error.
+	if _, err := os.Stat(stagingPath); err != nil {
+		return mount.IsCorruptedMnt(err)
+	}
+	return false
+}
+
+// forceUnmountStaging detaches a dead staging mount. A lazy unmount (umount -l)
+// is used because a normal unmount can hang or fail when the backing device is
+// gone. The staging directory itself is preserved for the remount.
+func (ns *nodeServer) forceUnmountStaging(stagingPath string) error {
+	out, err := osexec.Command("umount", "-l", stagingPath).CombinedOutput()
+	if err != nil {
+		msg := strings.ToLower(string(out))
+		if strings.Contains(msg, "not mounted") || strings.Contains(msg, "not found") {
+			return nil
+		}
+		return fmt.Errorf("lazy unmount %s: %w (%s)", stagingPath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// restageVolume repairs a staging mount whose backing NVMe-oF device was lost
+// (total path loss → the kernel removed the device, leaving a dead EIO mount).
+// It force-unmounts the dead mount, reconnects the volume, and remounts the
+// EXISTING filesystem in place. It never reformats — the volume already holds
+// data. Filesystem (mount) volumes only; block volumes have no staging mount.
+func (ns *nodeServer) restageVolume(ctx context.Context, volumeID, stagingTargetPath, stagingParentPath string, volCap *csi.VolumeCapability) error {
+	if volCap.GetMount() == nil {
+		klog.Warningf("restageVolume: volume %s is not a filesystem volume; skipping", volumeID)
+		return nil
+	}
+	klog.Warningf("restaging volume %s: staging mount %s is dead, reconnecting NVMe-oF and remounting", volumeID, stagingTargetPath)
+
+	volumeContext, err := util.LookupVolumeContext(stagingParentPath)
+	if err != nil {
+		return fmt.Errorf("lookup volume context: %w", err)
+	}
+
+	if err := ns.forceUnmountStaging(stagingTargetPath); err != nil {
+		return fmt.Errorf("unmount dead staging mount: %w", err)
+	}
+
+	initiator, err := util.NewSpdkCsiInitiator(volumeContext)
+	if err != nil {
+		return fmt.Errorf("new initiator: %w", err)
+	}
+	devicePath, err := initiator.Connect(ctx) // idempotent: re-establishes the lost device
+	if err != nil {
+		return fmt.Errorf("reconnect device: %w", err)
+	}
+
+	if _, err := ns.createMountPoint(stagingTargetPath); err != nil {
+		return fmt.Errorf("recreate staging dir: %w", err)
+	}
+	// Plain Mount, not FormatAndMount: the volume already holds a filesystem and
+	// reformatting would destroy data.
+	if err := ns.mounter.Mount(devicePath, stagingTargetPath, fsTypeOrDefault(volCap), stagingMountFlags(volCap)); err != nil {
+		return fmt.Errorf("remount device %s at %s: %w", devicePath, stagingTargetPath, err)
+	}
+
+	volumeContext["devicePath"] = devicePath
+	if err := util.StashVolumeContext(volumeContext, stagingParentPath); err != nil {
+		klog.Warningf("restageVolume: failed to re-stash volume context for %s: %v", volumeID, err)
+	}
+	klog.Infof("restaged volume %s on fresh device %s", volumeID, devicePath)
 	return nil
 }
 

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	csicommon "github.com/spdk/spdk-csi/pkg/csi-common"
+	sbkube "github.com/spdk/spdk-csi/pkg/kubernetes"
 	"github.com/spdk/spdk-csi/pkg/util"
 )
 
@@ -71,9 +72,18 @@ func newNodeServer(d *csicommon.CSIDriver) (*nodeServer, error) {
 		}
 	}
 
+	// Build one Kubernetes cache manager and share it across the node plugin:
+	// the reconnect loop reads PVs every ~3s and the guardian reads PVs/PVCs
+	// per pod on every poll, so a single shared instance means a single PV
+	// Watch and a single PVC Watch. The manager serves reads from cache once
+	// synced and transparently falls back to the API until then (and if it
+	// never syncs), so consumers need no fallback of their own.
+	manager := sbkube.NewManager(ns.kubeClient)
+	manager.Start(context.Background())
+
 	nodeName := ns.Driver.GetNodeID()
 	gcfg := util.NewDefaultGuardianConfig(nodeName)
-	guardian, gerr := util.StartGuardian(context.Background(), gcfg)
+	guardian, gerr := util.StartGuardian(context.Background(), gcfg, manager)
 	if gerr != nil {
 		klog.Errorf("failed to start guardian: %v", gerr)
 	} else {
@@ -84,7 +94,7 @@ func newNodeServer(d *csicommon.CSIDriver) (*nodeServer, error) {
 		if ns.guardian != nil {
 			ns.guardian.MarkBrokenLvol(lvolID)
 		}
-	}, ns.kubeClient)
+	}, manager, ns.Driver.GetName())
 
 	return ns, nil
 }

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -17,8 +17,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+
+	sbkube "github.com/spdk/spdk-csi/pkg/kubernetes"
 )
 
 // defaultBrokenLvolGracePeriod is the default value for BrokenLvolGracePeriod.
@@ -101,7 +102,13 @@ type LvolState struct {
 type Guardian struct {
 	cfg GuardianConfig
 
-	cs *kubernetes.Clientset
+	// Kubernetes cache manager shared with the rest of the node plugin. It
+	// serves PV/PVC reads from a watch-backed cache and transparently falls
+	// back to the API, so the guardian needs no fallback of its own. Pods and
+	// StorageClasses (which the manager does not cache) are read via its
+	// Client.
+	manager *sbkube.Manager
+	cs      kubernetes.Interface
 
 	mu sync.Mutex
 
@@ -170,8 +177,11 @@ func (g *Guardian) loadState() {
 	)
 }
 
-// StartGuardian starts the guardian loop in a goroutine.
-func StartGuardian(ctx context.Context, cfg GuardianConfig) (*Guardian, error) {
+// StartGuardian starts the guardian loop in a goroutine. The cache manager is
+// shared with the rest of the node plugin so the guardian reads PV/PVC state
+// from memory rather than issuing a Get per PVC per pod on every poll; it falls
+// back to the API transparently, and a nil manager degrades to API-only reads.
+func StartGuardian(ctx context.Context, cfg GuardianConfig, manager *sbkube.Manager) (*Guardian, error) {
 	if cfg.NodeName == "" {
 		return nil, fmt.Errorf("guardian requires NodeName")
 	}
@@ -197,18 +207,14 @@ func StartGuardian(ctx context.Context, cfg GuardianConfig) (*Guardian, error) {
 		cfg.CSIDriverName = "csi.simplyblock.io"
 	}
 
-	rc, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("guardian in-cluster config: %w", err)
-	}
-	cs, err := kubernetes.NewForConfig(rc)
-	if err != nil {
-		return nil, fmt.Errorf("guardian clientset: %w", err)
+	if manager == nil {
+		return nil, fmt.Errorf("guardian requires a Kubernetes cache manager")
 	}
 
 	g := &Guardian{
 		cfg:                cfg,
-		cs:                 cs,
+		manager:            manager,
+		cs:                 manager.Client(),
 		lvols:              map[string]*LvolState{},
 		lastRestart:        map[string]time.Time{},
 		clusterWasInactive: map[string]bool{},
@@ -706,7 +712,7 @@ func (g *Guardian) podUsesOptedInSimplyBlockStorageClass(ctx context.Context, po
 		}
 		seenPVCs[pvcKey] = struct{}{}
 
-		pvc, err := g.cs.CoreV1().PersistentVolumeClaims(pod.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
+		pvc, err := g.manager.PersistentVolumeClaimByNamespaceAndName(ctx, pod.Namespace, pvcName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Warningf("Guardian: PVC %s not found for pod %s/%s", pvcKey, pod.Namespace, pod.Name)
@@ -720,7 +726,7 @@ func (g *Guardian) podUsesOptedInSimplyBlockStorageClass(ctx context.Context, po
 			continue
 		}
 
-		pv, err := g.cs.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+		pv, err := g.manager.PersistentVolumeByName(ctx, pvName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Warningf("Guardian: PV %s not found for PVC %s", pvName, pvcKey)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -614,8 +614,10 @@ func simplyblockLvolSet(ctx context.Context, cs kubernetes.Interface) map[string
 		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != simplyblockCSIDriver {
 			continue
 		}
-		if h := strings.TrimSpace(pv.Spec.CSI.VolumeHandle); h != "" {
-			set[h] = struct{}{}
+		// The reconnect loop matches against the lvol ID alone, so store only
+		// the trailing lvol ID rather than the whole handle.
+		if _, _, lvolID, err := ParseVolumeHandle(pv.Spec.CSI.VolumeHandle); err == nil {
+			set[lvolID] = struct{}{}
 		}
 	}
 	return set

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
 
 	sbkube "github.com/spdk/spdk-csi/pkg/kubernetes"
@@ -595,41 +596,12 @@ func parseAddress(address string) string {
 	return ""
 }
 
-// simplyblockLvolSet returns the set of lvolIDs whose PersistentVolumes are
- // provisioned by the given CSI driver, read through the Kubernetes cache
-// manager (cache when synced, API otherwise). Returns nil when manager is nil
-// or the read fails, so callers can treat a nil map as "allow all" (degraded);
-// a non-nil but empty map means the read succeeded and no matching PVs exist.
-func simplyblockLvolSet(manager *sbkube.Manager, driver string) map[string]struct{} {
-	if manager == nil {
-		return nil
-	}
-	pvs, err := manager.PersistentVolumesByDriver(context.Background(), driver)
-	if err != nil {
-		klog.Warningf("reconnect: failed to read PersistentVolumes, skipping PV ownership check: %v", err)
-		return nil
-	}
-	set := make(map[string]struct{}, len(pvs))
-	for _, pv := range pvs {
-		if pv.Spec.CSI == nil {
-			continue
-		}
-		// The reconnect loop matches against the lvol ID alone, so store only
-		// the trailing lvol ID rather than the whole handle.
-		if _, _, lvolID, err := ParseVolumeHandle(pv.Spec.CSI.VolumeHandle); err == nil {
-			set[lvolID] = struct{}{}
-		}
-	}
-	return set
-}
-
 func reconnectSubsystems(markBroken func(lvolID string), manager *sbkube.Manager, driver string) error {
 	devices, err := getNVMeDeviceInfos()
 	if err != nil {
 		return fmt.Errorf("failed to get NVMe device paths: %v", err)
 	}
 
-	managedLvols := simplyblockLvolSet(manager, driver)
 	currentDevices := make(map[string]bool)
 
 	for _, device := range devices {
@@ -654,12 +626,14 @@ func reconnectSubsystems(markBroken func(lvolID string), manager *sbkube.Manager
 					lvolID = nqnLvolID
 				}
 
-				// Only act on CSI driver managed PVs
-				if managedLvols != nil {
-					if _, ok := managedLvols[lvolID]; !ok {
-						klog.Infof("reconnect: skipping NQN %s — lvolID %s not found in simplyblock PVs", subsystem.NQN, lvolID)
-						continue
-					}
+				managedLvol, err := manager.PersistentVolumeByLogicalVolumeID(context.Background(), lvolID)
+				if !apierrors.IsNotFound(err) {
+					klog.Errorf("reconnect: failed to read PersistentVolume for lvolID %s: %v", lvolID, err)
+					continue
+				}
+				if managedLvol == nil {
+					// Only act on CSI driver managed PVs
+					continue
 				}
 
 				// Only mark the device present once we have a confirmed lvolID,

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -33,6 +33,8 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
@@ -46,6 +48,8 @@ const (
 
 	// DefaultCtrlLossTmo is the NVMe-oF controller loss timeout in seconds.
 	DefaultCtrlLossTmo = 60
+
+	simplyblockCSIDriver = "csi.simplyblock.io"
 )
 
 // SpdkCsiInitiator defines interface for NVMeoF/iSCSI initiator
@@ -593,12 +597,37 @@ func parseAddress(address string) string {
 	return ""
 }
 
-func reconnectSubsystems(markBroken func(lvolID string)) error {
+// simplyblockLvolSet returns the set of lvolIDs whose PersistentVolumes are
+// provisioned by the simplyblock CSI driver. Returns nil when cs is nil so
+// callers can treat a nil map as "allow all" (degraded / no kube client).
+func simplyblockLvolSet(ctx context.Context, cs kubernetes.Interface) map[string]struct{} {
+	if cs == nil {
+		return nil
+	}
+	pvList, err := cs.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		klog.Warningf("reconnect: failed to list PersistentVolumes, skipping PV ownership check: %v", err)
+		return nil
+	}
+	set := make(map[string]struct{}, len(pvList.Items))
+	for _, pv := range pvList.Items {
+		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != simplyblockCSIDriver {
+			continue
+		}
+		if h := strings.TrimSpace(pv.Spec.CSI.VolumeHandle); h != "" {
+			set[h] = struct{}{}
+		}
+	}
+	return set
+}
+
+func reconnectSubsystems(markBroken func(lvolID string), cs kubernetes.Interface) error {
 	devices, err := getNVMeDeviceInfos()
 	if err != nil {
 		return fmt.Errorf("failed to get NVMe device paths: %v", err)
 	}
 
+	managedLvols := simplyblockLvolSet(context.Background(), cs)
 	currentDevices := make(map[string]bool)
 
 	for _, device := range devices {
@@ -621,6 +650,14 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 				lvolID := device.lvolID
 				if lvolID == "" {
 					lvolID = nqnLvolID
+				}
+
+				// Only act on CSI driver managed PVs
+				if managedLvols != nil {
+					if _, ok := managedLvols[lvolID]; !ok {
+						klog.Infof("reconnect: skipping NQN %s — lvolID %s not found in simplyblock PVs", subsystem.NQN, lvolID)
+						continue
+					}
 				}
 
 				// Only mark the device present once we have a confirmed lvolID,
@@ -818,14 +855,14 @@ const (
 	monitorCircuitCooldown = 30 * time.Second
 )
 
-func MonitorConnection(markBroken func(lvolID string)) {
+func MonitorConnection(markBroken func(lvolID string), cs kubernetes.Interface) {
 	var (
 		consecutiveErrors int
 		backoff           = monitorBaseInterval
 	)
 
 	for {
-		err := reconnectSubsystems(markBroken)
+		err := reconnectSubsystems(markBroken, cs)
 		if err != nil {
 			consecutiveErrors++
 			klog.Errorf("MonitorConnection error (%d consecutive): %v", consecutiveErrors, err)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -33,9 +33,9 @@ import (
 	"sync"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+
+	sbkube "github.com/spdk/spdk-csi/pkg/kubernetes"
 )
 
 const (
@@ -48,8 +48,6 @@ const (
 
 	// DefaultCtrlLossTmo is the NVMe-oF controller loss timeout in seconds.
 	DefaultCtrlLossTmo = 60
-
-	simplyblockCSIDriver = "csi.simplyblock.io"
 )
 
 // SpdkCsiInitiator defines interface for NVMeoF/iSCSI initiator
@@ -598,20 +596,22 @@ func parseAddress(address string) string {
 }
 
 // simplyblockLvolSet returns the set of lvolIDs whose PersistentVolumes are
-// provisioned by the simplyblock CSI driver. Returns nil when cs is nil so
-// callers can treat a nil map as "allow all" (degraded / no kube client).
-func simplyblockLvolSet(ctx context.Context, cs kubernetes.Interface) map[string]struct{} {
-	if cs == nil {
+ // provisioned by the given CSI driver, read through the Kubernetes cache
+// manager (cache when synced, API otherwise). Returns nil when manager is nil
+// or the read fails, so callers can treat a nil map as "allow all" (degraded);
+// a non-nil but empty map means the read succeeded and no matching PVs exist.
+func simplyblockLvolSet(manager *sbkube.Manager, driver string) map[string]struct{} {
+	if manager == nil {
 		return nil
 	}
-	pvList, err := cs.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	pvs, err := manager.PersistentVolumesByDriver(context.Background(), driver)
 	if err != nil {
-		klog.Warningf("reconnect: failed to list PersistentVolumes, skipping PV ownership check: %v", err)
+		klog.Warningf("reconnect: failed to read PersistentVolumes, skipping PV ownership check: %v", err)
 		return nil
 	}
-	set := make(map[string]struct{}, len(pvList.Items))
-	for _, pv := range pvList.Items {
-		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != simplyblockCSIDriver {
+	set := make(map[string]struct{}, len(pvs))
+	for _, pv := range pvs {
+		if pv.Spec.CSI == nil {
 			continue
 		}
 		// The reconnect loop matches against the lvol ID alone, so store only
@@ -623,13 +623,13 @@ func simplyblockLvolSet(ctx context.Context, cs kubernetes.Interface) map[string
 	return set
 }
 
-func reconnectSubsystems(markBroken func(lvolID string), cs kubernetes.Interface) error {
+func reconnectSubsystems(markBroken func(lvolID string), manager *sbkube.Manager, driver string) error {
 	devices, err := getNVMeDeviceInfos()
 	if err != nil {
 		return fmt.Errorf("failed to get NVMe device paths: %v", err)
 	}
 
-	managedLvols := simplyblockLvolSet(context.Background(), cs)
+	managedLvols := simplyblockLvolSet(manager, driver)
 	currentDevices := make(map[string]bool)
 
 	for _, device := range devices {
@@ -857,14 +857,14 @@ const (
 	monitorCircuitCooldown = 30 * time.Second
 )
 
-func MonitorConnection(markBroken func(lvolID string), cs kubernetes.Interface) {
+func MonitorConnection(markBroken func(lvolID string), manager *sbkube.Manager, driver string) {
 	var (
 		consecutiveErrors int
 		backoff           = monitorBaseInterval
 	)
 
 	for {
-		err := reconnectSubsystems(markBroken, cs)
+		err := reconnectSubsystems(markBroken, manager, driver)
 		if err != nil {
 			consecutiveErrors++
 			klog.Errorf("MonitorConnection error (%d consecutive): %v", consecutiveErrors, err)

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -596,6 +596,20 @@ func parseAddress(address string) string {
 	return ""
 }
 
+// isManagedLvol reports whether lvolID is backed by a PersistentVolume
+// provisioned by the given CSI driver. Only such lvols are reconnected;
+// benchmark and foreign (non-simplyblock, or other-driver) volumes are skipped.
+func isManagedLvol(manager *sbkube.Manager, lvolID, driver string) bool {
+	pv, err := manager.PersistentVolumeByLogicalVolumeID(context.Background(), lvolID)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("reconnect: failed to read PersistentVolume for lvolID %s: %v", lvolID, err)
+		}
+		return false
+	}
+	return pv.Spec.CSI != nil && pv.Spec.CSI.Driver == driver
+}
+
 func reconnectSubsystems(markBroken func(lvolID string), manager *sbkube.Manager, driver string) error {
 	devices, err := getNVMeDeviceInfos()
 	if err != nil {
@@ -626,13 +640,9 @@ func reconnectSubsystems(markBroken func(lvolID string), manager *sbkube.Manager
 					lvolID = nqnLvolID
 				}
 
-				managedLvol, err := manager.PersistentVolumeByLogicalVolumeID(context.Background(), lvolID)
-				if !apierrors.IsNotFound(err) {
-					klog.Errorf("reconnect: failed to read PersistentVolume for lvolID %s: %v", lvolID, err)
-					continue
-				}
-				if managedLvol == nil {
-					// Only act on CSI driver managed PVs
+				// Only act on lvols backed by a PV from our CSI driver; skip
+				// benchmark and foreign volumes.
+				if !isManagedLvol(manager, lvolID, driver) {
 					continue
 				}
 

--- a/pkg/util/reconnect_test.go
+++ b/pkg/util/reconnect_test.go
@@ -1,0 +1,68 @@
+// whitebox test of the reconnect PV-ownership gate
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	sbkube "github.com/spdk/spdk-csi/pkg/kubernetes"
+)
+
+func pvWithHandle(name, driver, handle string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: driver, VolumeHandle: handle},
+			},
+		},
+	}
+}
+
+func TestIsManagedLvol(t *testing.T) {
+	const (
+		driver        = "csi.simplyblock.io"
+		clusterUUID   = "8ffac363-0c46-4714-a71b-f9c0b58a1269"
+		poolName      = "pool-1"
+		lvolManaged   = "a1111111-1111-4111-8111-111111111111"
+		lvolForeign   = "b2222222-2222-4222-8222-222222222222"
+		lvolBenchmark = "c3333333-3333-4333-8333-333333333333"
+	)
+	handle := func(lvolID string) string { return clusterUUID + ":" + poolName + ":" + lvolID }
+
+	client := fake.NewSimpleClientset(
+		pvWithHandle("pv-managed", driver, handle(lvolManaged)),
+		pvWithHandle("pv-foreign", "other.csi.io", handle(lvolForeign)),
+	)
+	// No Start: the manager's API fallback serves these reads deterministically.
+	m := sbkube.NewManager(client)
+
+	cases := []struct {
+		name string
+		lvol string
+		want bool
+	}{
+		{"managed simplyblock volume", lvolManaged, true},
+		{"foreign-driver volume with same lvol handle shape", lvolForeign, false},
+		{"unknown lvol (e.g. benchmark volume, no PV)", lvolBenchmark, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isManagedLvol(m, tc.lvol, driver); got != tc.want {
+				t.Fatalf("isManagedLvol(%q, %q) = %v, want %v", tc.lvol, driver, got, tc.want)
+			}
+		})
+	}
+}
+
+// A nil manager (no in-cluster client) must degrade to "not managed" so the
+// reconnect loop simply skips ownership-gated work rather than panicking.
+func TestIsManagedLvolNilManager(t *testing.T) {
+	if isManagedLvol(nil, "lvol-x", "csi.simplyblock.io") {
+		t.Fatal("isManagedLvol(nil, ...) = true, want false")
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -55,6 +55,17 @@ func ParseJSONFile(fileName string, result interface{}) error {
 	return json.Unmarshal(bytes, result)
 }
 
+// ParseVolumeHandle splits a CSI volume handle of the form
+// "{clusterID}:{poolID}:{lvolID}" into its three components. It returns an
+// error if the handle is empty or is not exactly three colon-separated parts.
+func ParseVolumeHandle(handle string) (clusterID, poolID, lvolID string, err error) {
+	ids := strings.Split(strings.TrimSpace(handle), ":")
+	if len(ids) != 3 || ids[0] == "" || ids[1] == "" || ids[2] == "" {
+		return "", "", "", fmt.Errorf("invalid volume handle %q (expected {clusterID}:{poolID}:{lvolID})", handle)
+	}
+	return ids[0], ids[1], ids[2], nil
+}
+
 // ToMiB rounds up bytes to megabytes
 func ToMiB(bytes int64) int64 {
 	return (bytes + MIB - 1) / MIB

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -55,17 +55,6 @@ func ParseJSONFile(fileName string, result interface{}) error {
 	return json.Unmarshal(bytes, result)
 }
 
-// ParseVolumeHandle splits a CSI volume handle of the form
-// "{clusterID}:{poolID}:{lvolID}" into its three components. It returns an
-// error if the handle is empty or is not exactly three colon-separated parts.
-func ParseVolumeHandle(handle string) (clusterID, poolID, lvolID string, err error) {
-	ids := strings.Split(strings.TrimSpace(handle), ":")
-	if len(ids) != 3 || ids[0] == "" || ids[1] == "" || ids[2] == "" {
-		return "", "", "", fmt.Errorf("invalid volume handle %q (expected {clusterID}:{poolID}:{lvolID})", handle)
-	}
-	return ids[0], ids[1], ids[2], nil
-}
-
 // ToMiB rounds up bytes to megabytes
 func ToMiB(bytes int64) int64 {
 	return (bytes + MIB - 1) / MIB


### PR DESCRIPTION
The NVMe-oF reconnect loop in the node plugin searches for all *:lvol:* subsystems and tries to reconnect every path it finds, regardless of whether the volume is managed by our CSI driver. This causes two problems:

- The driver relentlessly reconnects the multiple paths of benchmark volumes (and any other non-PV lvols), which it has no business touching.
- It risks acting on non-simplyblock volumes if anything else ever adopts a similar NQN naming pattern.

The fix is to reconnect only subsystems whose lvol is backed by a simplyblock-provisioned PersistentVolume. Implementing that surfaced a latent bug and motivated a small caching layer so the ownership check doesn't hammer the API server.

## What this PR does

1. **Gate reconnect on PV/PVC ownership:** The reconnect loop now builds the set of lvol IDs owned by simplyblock PVs and only reconnects subsystems in that set. Benchmark and foreign volumes are left alone.

2. **Fix and centralize CSI volume-handle parsing:** The ownership check originally compared the full volume handle (<clusterID>:<poolID>:<lvolID>) against the bare lvolID, so it never matched. Handle parsing is now a single canonical helper, util.ParseVolumeHandle, used everywhere:
   - pkg/spdk/controllerserver.go: getSPDKVol/getSnapshot became parseVolumeID/parseSnapshotID, delegating to the shared parser instead of ad-hoc strings.Split.
   - The reconnect path extracts the lvol ID through the same parser.
  
3. **New pkg/kubernetes cache Manager:** A watch-backed, in-memory cache of PersistentVolumes and PersistentVolumeClaims with transparent API fallback: reads are served from the informer cache once it has synced, and fall back to a direct API read until then (and if it never syncs) — so callers never deal with cache setup/sync failures.
   - Single shared instance ⇒ one PV watch + one PVC watch per node (replacing a full PV List every ~3s on the reconnect loop and a PV/PVC Get per pod on every guardian poll).
   - Informer indexes by CSI driver and by lvol ID, giving O(1) lookups: PersistentVolumesByDriver, PersistentVolumeByName, PersistentVolumeByLogicalVolumeID, and PersistentVolumeClaimByNamespaceAndName.
   - The initial sync is automatic via the informer's LIST→WATCH; no manual sync barrier.

4. **Wiring:**
   - pkg/spdk/nodeserver.go constructs one Manager, starts it, and shares it with both the reconnect loop and the guardian.
   - pkg/util/guardian.go reads PV/PVC through the manager (cache-or-API) instead of issuing its own Gets, and sources its client from the manager.
   - pkg/csi-common/driver.go gains GetName() so the node plugin passes the actual configured driver name to the ownership filter.

**Behavior & impact:**

  - Reconnect acts strictly on CSI-managed lvols; benchmark/foreign volumes are ignored.
  - Steady-state API load drops from per-tick List / per-pod Get to two long-lived watches per node.
  - Degraded modes are preserved: with no in-cluster client the reconnect loop allows all (as before), and PV/PVC reads transparently use the API whenever the cache isn't ready.
