### PR TITLE
Authenticate CSI via service token in K8s deployments

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
@@ -130,7 +130,7 @@ spec:
               fieldPath: spec.nodeName
         {{- include "simplyblock.tlsEnv" . | nindent 8 }}
         {{- if .Values.controller.saAuth.enabled }}
-        - name: SPDKCSI_SA_TOKEN
+        - name: SPDKCSI_API_TOKEN_PATH
           value: /var/run/secrets/kubernetes.io/serviceaccount/token
         {{- end }}
         volumeMounts:

--- a/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
@@ -129,7 +129,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         {{- include "simplyblock.tlsEnv" . | nindent 8 }}
-        {{- if .Values.controller.saAuth.enabled }}
+        {{- if .Values.controller.serviceAccountAuth.enabled }}
         - name: SPDKCSI_API_TOKEN_PATH
           value: /var/run/secrets/kubernetes.io/serviceaccount/token
         {{- end }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/controller.yaml
@@ -129,6 +129,10 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         {{- include "simplyblock.tlsEnv" . | nindent 8 }}
+        {{- if .Values.controller.saAuth.enabled }}
+        - name: SPDKCSI_SA_TOKEN
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        {{- end }}
         volumeMounts:
         - name: socket-dir
           mountPath: /csi

--- a/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
@@ -92,7 +92,7 @@ spec:
               fieldPath: spec.nodeName
         - name: GUARDIAN_MIN_BROKEN_FOR
           value: "30s"
-        {{- if .Values.node.saAuth.enabled }}
+        {{- if .Values.node.serviceAccountAuth.enabled }}
         - name: SPDKCSI_API_TOKEN_PATH
           value: /var/run/secrets/kubernetes.io/serviceaccount/token
         {{- end }}

--- a/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/node.yaml
@@ -92,6 +92,10 @@ spec:
               fieldPath: spec.nodeName
         - name: GUARDIAN_MIN_BROKEN_FOR
           value: "30s"
+        {{- if .Values.node.saAuth.enabled }}
+        - name: SPDKCSI_API_TOKEN_PATH
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        {{- end }}
         {{- include "simplyblock.tlsEnv" . | nindent 8 }}
         lifecycle:
           postStart:

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -67,6 +67,12 @@ rbac:
 
 controller:
   replicas: 1
+  saAuth:
+    # When enabled, the CSI driver authenticates with the simplyblock API using
+    # the pod's Kubernetes service account JWT instead of the static cluster_secret.
+    # The service account must be added to SB_K8S_ADMIN_SERVICE_ACCOUNTS on the
+    # simplyblock control plane: system:serviceaccount:<namespace>:simplyblock-csi-controller-sa
+    enabled: false
   tolerations:
     create: false
     list:

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -78,12 +78,20 @@ controller:
     list:
     - operator: Exists
       effect:
-      key: 
+      key:
       value:
   nodeSelector:
     create: false
-    key: 
+    key:
     value:
+
+node:
+  saAuth:
+    # When enabled, the CSI node DaemonSet authenticates with the simplyblock API using
+    # the pod's Kubernetes service account JWT instead of the static cluster_secret.
+    # The service account must be added to SB_K8S_ADMIN_SERVICE_ACCOUNTS on the
+    # simplyblock control plane: system:serviceaccount:<namespace>:simplyblock-csi-node-sa
+    enabled: false
 
 storageclass:
   create: true

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -67,7 +67,7 @@ rbac:
 
 controller:
   replicas: 1
-  saAuth:
+  serviceAccountAuth:
     # When enabled, the CSI driver authenticates with the simplyblock API using
     # the pod's Kubernetes service account JWT instead of the static cluster_secret.
     # The service account must be added to SB_K8S_ADMIN_SERVICE_ACCOUNTS on the
@@ -84,14 +84,6 @@ controller:
     create: false
     key:
     value:
-
-node:
-  saAuth:
-    # When enabled, the CSI node DaemonSet authenticates with the simplyblock API using
-    # the pod's Kubernetes service account JWT instead of the static cluster_secret.
-    # The service account must be added to SB_K8S_ADMIN_SERVICE_ACCOUNTS on the
-    # simplyblock control plane: system:serviceaccount:<namespace>:simplyblock-csi-node-sa
-    enabled: false
 
 storageclass:
   create: true
@@ -166,16 +158,22 @@ benchmarks: 0
 autoClusterActivate: false 
 
 node:
+  serviceAccountAuth:
+    # When enabled, the CSI node DaemonSet authenticates with the simplyblock API using
+    # the pod's Kubernetes service account JWT instead of the static cluster_secret.
+    # The service account must be added to SB_K8S_ADMIN_SERVICE_ACCOUNTS on the
+    # simplyblock control plane: system:serviceaccount:<namespace>:simplyblock-csi-node-sa
+    enabled: false
   tolerations:
     create: false
     list:
     - operator: Exists
       effect:
-      key: 
+      key:
       value:
   nodeSelector:
     create: false
-    key: 
+    key:
     value:
 
 storagenode:

--- a/deploy/kubernetes/node.yaml
+++ b/deploy/kubernetes/node.yaml
@@ -60,6 +60,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SPDKCSI_API_TOKEN_PATH
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
         lifecycle:
           postStart:
             exec:

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -154,18 +154,18 @@ func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (
 		return nil, fmt.Errorf("invalid cluster configuration for clusterID %s: missing endpoint", clusterID)
 	}
 
-	// Use SA token when SPDKCSI_SA_TOKEN is explicitly set; otherwise fall back to cluster_secret.
+	// Use API token when SPDKCSI_API_TOKEN_PATH is explicitly set; otherwise fall back to cluster_secret.
 	credential := clusterConfig.ClusterSecret
-	if tokenPath := os.Getenv("SPDKCSI_SA_TOKEN"); tokenPath != "" {
+	if tokenPath := os.Getenv("SPDKCSI_API_TOKEN_PATH"); tokenPath != "" {
 		if tokenBytes, err := os.ReadFile(tokenPath); err == nil {
 			if token := strings.TrimSpace(string(tokenBytes)); token != "" {
 				credential = token
-				klog.Infof("Using Kubernetes service account JWT for cluster %s", clusterID)
+				klog.Infof("Using API token from file for cluster %s", clusterID)
 			}
 		}
 	}
 	if credential == "" {
-		return nil, fmt.Errorf("invalid cluster configuration for clusterID %s: no cluster_secret and no SA token available", clusterID)
+		return nil, fmt.Errorf("invalid cluster configuration for clusterID %s: no cluster_secret and no API token available", clusterID)
 	}
 
 	klog.Infof("Simplyblock client created for ClusterID:%s, Endpoint:%s",

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-
 	"net/http"
 	"os"
 	"os/exec"
@@ -151,8 +150,22 @@ func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (
 		return nil, fmt.Errorf("failed to find secret for clusterID %s", clusterID)
 	}
 
-	if clusterConfig.ClusterEndpoint == "" || clusterConfig.ClusterSecret == "" {
-		return nil, fmt.Errorf("invalid cluster configuration for clusterID %s", clusterID)
+	if clusterConfig.ClusterEndpoint == "" {
+		return nil, fmt.Errorf("invalid cluster configuration for clusterID %s: missing endpoint", clusterID)
+	}
+
+	// Use SA token when SPDKCSI_SA_TOKEN is explicitly set; otherwise fall back to cluster_secret.
+	credential := clusterConfig.ClusterSecret
+	if tokenPath := os.Getenv("SPDKCSI_SA_TOKEN"); tokenPath != "" {
+		if tokenBytes, err := os.ReadFile(tokenPath); err == nil {
+			if token := strings.TrimSpace(string(tokenBytes)); token != "" {
+				credential = token
+				klog.Infof("Using Kubernetes service account JWT for cluster %s", clusterID)
+			}
+		}
+	}
+	if credential == "" {
+		return nil, fmt.Errorf("invalid cluster configuration for clusterID %s: no cluster_secret and no SA token available", clusterID)
 	}
 
 	klog.Infof("Simplyblock client created for ClusterID:%s, Endpoint:%s",
@@ -166,9 +179,9 @@ func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (
 	}
 	c := &ClusterClient{
 		API: &APIClient{
-			ClusterID:     clusterID,
-			ClusterSecret: clusterConfig.ClusterSecret,
-			conn:          conn,
+			ClusterID:  clusterID,
+			Credential: credential,
+			conn:       conn,
 		},
 	}
 

--- a/pkg/util/initiator_test.go
+++ b/pkg/util/initiator_test.go
@@ -19,6 +19,8 @@ package util
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -58,4 +60,107 @@ func runExecWithTimeout(cmdLine []string, timeout int) (int, error) {
 	err := execWithTimeout(context.Background(), cmdLine, timeout)
 	elapsed := int(time.Since(start) / time.Second)
 	return elapsed, err
+}
+
+// writeTempFile creates a temp file with the given content and registers cleanup.
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "spdkcsi-test-*")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(f.Name()) })
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+const testSecretJSON = `{"clusters":[{"cluster_id":"test-cluster","cluster_endpoint":"http://localhost","cluster_secret":"static-secret"}]}`
+const testSecretNoCredJSON = `{"clusters":[{"cluster_id":"test-cluster","cluster_endpoint":"http://localhost","cluster_secret":""}]}`
+
+// TestCredentialSATokenUsed verifies that when SPDKCSI_SA_TOKEN points to a
+// file containing a valid token, that token is used as the credential instead
+// of the cluster_secret from the secret file.
+func TestCredentialSATokenUsed(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretJSON)
+	tokenFile := writeTempFile(t, "sa-jwt-token")
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_SA_TOKEN", tokenFile)
+
+	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.API.Credential != "sa-jwt-token" {
+		t.Errorf("expected SA token %q as credential, got %q", "sa-jwt-token", node.API.Credential)
+	}
+}
+
+// TestCredentialClusterSecretFallback verifies that when SPDKCSI_SA_TOKEN is
+// not set, the cluster_secret from the secret file is used unchanged.
+func TestCredentialClusterSecretFallback(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretJSON)
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_SA_TOKEN", "")
+
+	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.API.Credential != "static-secret" {
+		t.Errorf("expected cluster_secret %q, got %q", "static-secret", node.API.Credential)
+	}
+}
+
+// TestCredentialSATokenWhitespaceTrimmed verifies that leading/trailing
+// whitespace in the SA token file is stripped before use.
+func TestCredentialSATokenWhitespaceTrimmed(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretJSON)
+	tokenFile := writeTempFile(t, " tok \n")
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_SA_TOKEN", tokenFile)
+
+	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.API.Credential != "tok" {
+		t.Errorf("expected trimmed token %q, got %q", "tok", node.API.Credential)
+	}
+}
+
+// TestCredentialSATokenWithEmptyClusterSecret verifies that SA token auth
+// succeeds even when cluster_secret is empty in the secret file.
+func TestCredentialSATokenWithEmptyClusterSecret(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretNoCredJSON)
+	tokenFile := writeTempFile(t, "sa-jwt-token")
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_SA_TOKEN", tokenFile)
+
+	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.API.Credential != "sa-jwt-token" {
+		t.Errorf("expected SA token %q, got %q", "sa-jwt-token", node.API.Credential)
+	}
+}
+
+// TestCredentialBothMissingReturnsError verifies that when SPDKCSI_SA_TOKEN is
+// unset and cluster_secret is empty, NewsimplyBlockClient returns an error.
+func TestCredentialBothMissingReturnsError(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretNoCredJSON)
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_SA_TOKEN", "")
+
+	_, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err == nil {
+		t.Fatal("expected error when both cluster_secret and SA token are missing, got nil")
+	}
+	const want = "no cluster_secret and no SA token available"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err.Error(), want)
+	}
 }

--- a/pkg/util/initiator_test.go
+++ b/pkg/util/initiator_test.go
@@ -80,30 +80,30 @@ func writeTempFile(t *testing.T, content string) string {
 const testSecretJSON = `{"clusters":[{"cluster_id":"test-cluster","cluster_endpoint":"http://localhost","cluster_secret":"static-secret"}]}`
 const testSecretNoCredJSON = `{"clusters":[{"cluster_id":"test-cluster","cluster_endpoint":"http://localhost","cluster_secret":""}]}`
 
-// TestCredentialSATokenUsed verifies that when SPDKCSI_SA_TOKEN points to a
+// TestCredentialAPITokenUsed verifies that when SPDKCSI_API_TOKEN_PATH points to a
 // file containing a valid token, that token is used as the credential instead
 // of the cluster_secret from the secret file.
-func TestCredentialSATokenUsed(t *testing.T) {
+func TestCredentialAPITokenUsed(t *testing.T) {
 	secretFile := writeTempFile(t, testSecretJSON)
 	tokenFile := writeTempFile(t, "sa-jwt-token")
 	t.Setenv("SPDKCSI_SECRET", secretFile)
-	t.Setenv("SPDKCSI_SA_TOKEN", tokenFile)
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", tokenFile)
 
 	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if node.API.Credential != "sa-jwt-token" {
-		t.Errorf("expected SA token %q as credential, got %q", "sa-jwt-token", node.API.Credential)
+		t.Errorf("expected API token %q as credential, got %q", "sa-jwt-token", node.API.Credential)
 	}
 }
 
-// TestCredentialClusterSecretFallback verifies that when SPDKCSI_SA_TOKEN is
+// TestCredentialClusterSecretFallback verifies that when SPDKCSI_API_TOKEN_PATH is
 // not set, the cluster_secret from the secret file is used unchanged.
 func TestCredentialClusterSecretFallback(t *testing.T) {
 	secretFile := writeTempFile(t, testSecretJSON)
 	t.Setenv("SPDKCSI_SECRET", secretFile)
-	t.Setenv("SPDKCSI_SA_TOKEN", "")
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", "")
 
 	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
 	if err != nil {
@@ -114,13 +114,13 @@ func TestCredentialClusterSecretFallback(t *testing.T) {
 	}
 }
 
-// TestCredentialSATokenWhitespaceTrimmed verifies that leading/trailing
-// whitespace in the SA token file is stripped before use.
-func TestCredentialSATokenWhitespaceTrimmed(t *testing.T) {
+// TestCredentialAPITokenWhitespaceTrimmed verifies that leading/trailing
+// whitespace in the API token file is stripped before use.
+func TestCredentialAPITokenWhitespaceTrimmed(t *testing.T) {
 	secretFile := writeTempFile(t, testSecretJSON)
 	tokenFile := writeTempFile(t, " tok \n")
 	t.Setenv("SPDKCSI_SECRET", secretFile)
-	t.Setenv("SPDKCSI_SA_TOKEN", tokenFile)
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", tokenFile)
 
 	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
 	if err != nil {
@@ -131,35 +131,35 @@ func TestCredentialSATokenWhitespaceTrimmed(t *testing.T) {
 	}
 }
 
-// TestCredentialSATokenWithEmptyClusterSecret verifies that SA token auth
+// TestCredentialAPITokenWithEmptyClusterSecret verifies that API token auth
 // succeeds even when cluster_secret is empty in the secret file.
-func TestCredentialSATokenWithEmptyClusterSecret(t *testing.T) {
+func TestCredentialAPITokenWithEmptyClusterSecret(t *testing.T) {
 	secretFile := writeTempFile(t, testSecretNoCredJSON)
 	tokenFile := writeTempFile(t, "sa-jwt-token")
 	t.Setenv("SPDKCSI_SECRET", secretFile)
-	t.Setenv("SPDKCSI_SA_TOKEN", tokenFile)
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", tokenFile)
 
 	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if node.API.Credential != "sa-jwt-token" {
-		t.Errorf("expected SA token %q, got %q", "sa-jwt-token", node.API.Credential)
+		t.Errorf("expected API token %q, got %q", "sa-jwt-token", node.API.Credential)
 	}
 }
 
-// TestCredentialBothMissingReturnsError verifies that when SPDKCSI_SA_TOKEN is
+// TestCredentialBothMissingReturnsError verifies that when SPDKCSI_API_TOKEN_PATH is
 // unset and cluster_secret is empty, NewsimplyBlockClient returns an error.
 func TestCredentialBothMissingReturnsError(t *testing.T) {
 	secretFile := writeTempFile(t, testSecretNoCredJSON)
 	t.Setenv("SPDKCSI_SECRET", secretFile)
-	t.Setenv("SPDKCSI_SA_TOKEN", "")
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", "")
 
 	_, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
 	if err == nil {
-		t.Fatal("expected error when both cluster_secret and SA token are missing, got nil")
+		t.Fatal("expected error when both cluster_secret and API token are missing, got nil")
 	}
-	const want = "no cluster_secret and no SA token available"
+	const want = "no cluster_secret and no API token available"
 	if !strings.Contains(err.Error(), want) {
 		t.Errorf("error %q does not contain %q", err.Error(), want)
 	}

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -123,9 +123,9 @@ type Connection struct {
 // and borrows a Connection to reach the webappapi service.
 // It is immutable after construction; pool scoping is handled by the caller.
 type APIClient struct {
-	ClusterID     string
-	ClusterSecret string
-	conn          *Connection
+	ClusterID  string
+	Credential string // cluster_secret for v1, or SA JWT / cluster_secret for v2 Bearer auth
+	conn       *Connection
 }
 
 // ClusterStatus is a partial view of the GET /clusters/{id}/ response in v2.
@@ -644,9 +644,9 @@ func (client APIClient) do(ctx context.Context, method, path string, body any) (
 
 func (client APIClient) authorizationHeader(path string) string {
 	if strings.HasPrefix(path, "api/v2/") {
-		return "Bearer " + client.ClusterSecret
+		return "Bearer " + client.Credential
 	}
-	return client.ClusterID + " " + client.ClusterSecret
+	return client.ClusterID + " " + client.Credential
 }
 
 // locationToUUID extracts the last path segment from a Location header value.

--- a/pkg/util/jsonrpc_test.go
+++ b/pkg/util/jsonrpc_test.go
@@ -21,8 +21,8 @@ const (
 
 func newTestClient(transport roundTripFunc) *APIClient {
 	return &APIClient{
-		ClusterID:     "cluster-id",
-		ClusterSecret: "cluster-secret",
+		ClusterID:  "cluster-id",
+		Credential: "cluster-secret",
 		conn: &Connection{
 			Endpoint: "http://api.example.com",
 			HTTP:     &http.Client{Transport: transport},

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -170,9 +170,9 @@ func NewClusterClient(clusterID, endpoint, clusterSecret string) (*ClusterClient
 		return nil, err
 	}
 	client := APIClient{
-		ClusterID:     clusterID,
-		ClusterSecret: clusterSecret,
-		conn:          conn,
+		ClusterID:  clusterID,
+		Credential: clusterSecret,
+		conn:       conn,
 	}
 	return &ClusterClient{API: &client}, nil
 }


### PR DESCRIPTION
This adds an alternate authentication mode to the API. If `SPDKCSI_SA_TOKEN` is set, the token present at this path will be passed to the API. This is done instead of resolving the cluster secrets.

Corresponding PRs: https://github.com/simplyblock/sbcli/pull/1085, https://github.com/simplyblock/simplyblock-operator/pull/233, https://github.com/simplyblock/helm-charts/pull/16.