### PR TITLE
fix: use sysfs namespace UUID as lvolID for namespaced LVols instead …

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -598,11 +598,11 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 				if nqnLvolID == "" {
 					continue
 				}
-				// Prefer the sysfs UUID for namespaced LVols — it identifies the
-				// exact tenant LVol rather than the hub LVol embedded in the NQN.
-				lvolID := nqnLvolID
-				if device.lvolID != "" {
-					lvolID = device.lvolID
+				// Prefer the sysfs UUID when available — it always identifies the
+				// exact namespace LVol. Falls back to the NQN-derived ID.
+				lvolID := device.lvolID
+				if lvolID == "" {
+					lvolID = nqnLvolID
 				}
 
 				// Only mark the device present once we have a confirmed lvolID,

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -444,15 +444,19 @@ func disconnectDevicePath(ctx context.Context, devicePath string) error {
 	return nil
 }
 
-// nvmeDeviceUUID reads /sys/block/<dev>/uuid for a device path like /dev/nvme0n2.
-// Returns an empty string if the file is absent or unreadable.
-func nvmeDeviceUUID(devicePath string) string {
+// logicalVolumeIdByDevicePath reads /sys/block/<dev>/uuid for a device path like /dev/nvme0n2.
+// Returns an empty string if the file is absent, unreadable, or not a valid UUID.
+func logicalVolumeIdByDevicePath(devicePath string) string {
 	name := filepath.Base(devicePath)
 	data, err := os.ReadFile(filepath.Join("/sys/block", name, "uuid"))
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(data))
+	uuid := strings.TrimSpace(string(data))
+	if !isUUID(uuid) {
+		return ""
+	}
+	return uuid
 }
 
 func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
@@ -482,7 +486,7 @@ func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
 					dp := "/dev/" + ns.NameSpace
 					devices = append(devices, nvmeDeviceInfo{
 						devicePath: dp,
-						lvolID:     nvmeDeviceUUID(dp),
+						lvolID:     logicalVolumeIdByDevicePath(dp),
 					})
 				}
 			}
@@ -510,7 +514,7 @@ func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
 		devices = append(devices, nvmeDeviceInfo{
 			devicePath:   dev.DevicePath,
 			serialNumber: dev.SerialNumber,
-			lvolID:       nvmeDeviceUUID(dev.DevicePath),
+			lvolID:       logicalVolumeIdByDevicePath(dev.DevicePath),
 		})
 	}
 	return devices, nil

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"net"
 
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -100,6 +101,7 @@ type NodeInfo struct {
 type nvmeDeviceInfo struct {
 	devicePath   string
 	serialNumber string
+	lvolID       string // UUID from /sys/block/<dev>/uuid — set for namespaced LVols
 }
 
 var (
@@ -442,6 +444,17 @@ func disconnectDevicePath(ctx context.Context, devicePath string) error {
 	return nil
 }
 
+// nvmeDeviceUUID reads /sys/block/<dev>/uuid for a device path like /dev/nvme0n2.
+// Returns an empty string if the file is absent or unreadable.
+func nvmeDeviceUUID(devicePath string) string {
+	name := filepath.Base(devicePath)
+	data, err := os.ReadFile(filepath.Join("/sys/block", name, "uuid"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
 	cmd := exec.Command("nvme", "list", "-o", "json")
 	output, err := cmd.Output()
@@ -466,8 +479,10 @@ func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
 					if ns.NameSpace == "" {
 						continue
 					}
+					dp := "/dev/" + ns.NameSpace
 					devices = append(devices, nvmeDeviceInfo{
-						devicePath: "/dev/" + ns.NameSpace,
+						devicePath: dp,
+						lvolID:     nvmeDeviceUUID(dp),
 					})
 				}
 			}
@@ -495,6 +510,7 @@ func getNVMeDeviceInfos() ([]nvmeDeviceInfo, error) {
 		devices = append(devices, nvmeDeviceInfo{
 			devicePath:   dev.DevicePath,
 			serialNumber: dev.SerialNumber,
+			lvolID:       nvmeDeviceUUID(dev.DevicePath),
 		})
 	}
 	return devices, nil
@@ -578,9 +594,15 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 
 		for _, host := range subsystems {
 			for _, subsystem := range host.Subsystems {
-				clusterID, lvolID := getLvolIDFromNQN(subsystem.NQN)
-				if lvolID == "" {
+				clusterID, nqnLvolID := getLvolIDFromNQN(subsystem.NQN)
+				if nqnLvolID == "" {
 					continue
+				}
+				// Prefer the sysfs UUID for namespaced LVols — it identifies the
+				// exact tenant LVol rather than the hub LVol embedded in the NQN.
+				lvolID := nqnLvolID
+				if device.lvolID != "" {
+					lvolID = device.lvolID
 				}
 
 				mu.Lock()

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -588,10 +588,6 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 
 		currentDevices[device.devicePath] = true
 
-		mu.Lock()
-		devicePresentMap[device.devicePath] = true
-		mu.Unlock()
-
 		for _, host := range subsystems {
 			for _, subsystem := range host.Subsystems {
 				clusterID, nqnLvolID := getLvolIDFromNQN(subsystem.NQN)
@@ -605,7 +601,10 @@ func reconnectSubsystems(markBroken func(lvolID string)) error {
 					lvolID = device.lvolID
 				}
 
+				// Only mark the device present once we have a confirmed lvolID,
+				// so the cleanup loop never sees a device without a mapping.
 				mu.Lock()
+				devicePresentMap[device.devicePath] = true
 				deviceToLvolIDMap[device.devicePath] = lvolID
 				mu.Unlock()
 


### PR DESCRIPTION
…of NQN-derived lvolID

## Summary

- Add `lvolID` field to `nvmeDeviceInfo` populated from `/sys/block/<dev>/uuid`
- Add `nvmeDeviceUUID` helper to read the sysfs namespace UUID for a given device path
- Use the sysfs UUID as the authoritative `lvolID` in `reconnectSubsystems` for namespaced LVols, falling back to the NQN-derived ID for non-namespaced LVols

## Motivation

In the namespaced LVol model, multiple tenant LVols share the same NVMe subsystem NQN. `getLvolIDFromNQN` extracts the hub/master LVol ID embedded in the NQN, not the actual tenant LVol ID. This caused `resolveExpectedPathCount` and `recoverPathsWithANA` to query the wrong volume, breaking path recovery and broken-device detection for namespaced LVols.

The exact tenant LVol ID is available in the kernel via `/sys/block/nvme0nX/uuid` (e.g. `cat /sys/block/nvme0n2/uuid`), which maps directly to the simplyblock LVol UUID.

## Test plan

- [x] Verify path recovery triggers correctly for a namespaced LVol when one path goes down
- [x] Verify `deviceToLvolIDMap` contains the tenant LVol UUID (not the hub UUID) after a monitor cycle
- [x] Verify fallback to NQN-derived ID works correctly for non-namespaced LVols
- [x] Confirm `/sys/block/<dev>/uuid` is readable inside the CSI node container


Confirmed the lvol connection reconnect was done using the lvol ID not the ID from the NQN

```
[simplyblock@israel-storage-node-1 app]$ sbctl lvol list
+--------------------------------------+-------+---------+------+----------------------------+----+------------+--------------------------------------+--------+---+--------+--------+-------+------+--------+---------------+
| Id                                   | Name  | Size    | Used | Hostname                   | HA | BlobID     | LVolUUID                             | Status | M | IO Err | Health | NS ID | Mode | Policy | Replicated On |
+--------------------------------------+-------+---------+------+----------------------------+----+------------+--------------------------------------+--------+---+--------+--------+-------+------+--------+---------------+
| 4b1fdcdf-fe30-4fc3-a1e3-5ff296992968 | lvol2 | 4.7 GiB | 0 B  | israel-storage-node-1_4420 | ha | 4294967298 | 47e6f20a-389d-4d64-a3ff-3c63da6865b2 | online |   | False  | True   | 2     | 1x1  |        |               |
| 8ea9bcda-1777-401e-9d4b-96c9b5f7536e | lvol3 | 4.7 GiB | 0 B  | israel-storage-node-1_4420 | ha | 4294967297 | 37159639-79dc-4778-b30d-3d2bd6c1ee6b | online |   | False  | True   | 1     | 1x1  |        |               |
+--------------------------------------+-------+---------+------+----------------------------+----+------------+--------------------------------------+--------+---+--------+--------+-------+------+--------+---------------+
[simplyblock@israel-storage-node-1 app]$ sbctl lvol connect 4b1fdcdf-fe30-4fc3-a1e3-5ff296992968
sudo nvme connect --reconnect-delay=2 --ctrl-loss-tmo=3600 --fast_io_fail_tmo=1 --nr-io-queues=3 --keep-alive-tmo=4 --transport=tcp --traddr=10.0.2.2 --trsvcid=4426 --nqn=nqn.2023-02.io.simplyblock:65c33f67-da41-4a79-ba6d-c94e9b553e6f:lvol:b3a74ba7-b0b7-4787-93f7-c22e4c015c88 
sudo nvme connect --reconnect-delay=2 --ctrl-loss-tmo=3600 --fast_io_fail_tmo=1 --nr-io-queues=3 --keep-alive-tmo=4 --transport=tcp --traddr=10.0.2.4 --trsvcid=4426 --nqn=nqn.2023-02.io.simplyblock:65c33f67-da41-4a79-ba6d-c94e9b553e6f:lvol:b3a74ba7-b0b7-4787-93f7-c22e4c015c88 
```

```
2026-06-08 15:17:12,762 INFO 10.42.1.1 "GET /api/v2/clusters/65c33f67-da41-4a79-ba6d-c94e9b553e6f/storage-pools/90785f16-db9e-49b4-aba3-c955fa5372de/volumes/4b1fdcdf-fe30-4fc3-a1e3-5ff296992968/connect" 200 - 1153 23.01ms "Go-http-client/1.1"
```

