### PR TITLE
ci: restructure and move unit tests to `test.yaml` file

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,4 +1,4 @@
-name: Linux Unit tests and docker push
+name: Docker Build and Push
 
 on:
   push:
@@ -20,17 +20,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-
-    - name: Tidy Go modules
-      run: go mod tidy
-
-    - name: Test
-      run: make test
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,58 +1,28 @@
-name: SPDK E2E TEST
+name: Unit and Sanity Tests
 
 on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
   workflow_dispatch:
-    inputs:
-      uuid:
-        description: ''
-        required: true
-        default: '79276661-5f8a-405d-ab6d-651b88326206'
-      ip:
-        description: ''
-        required: true
-        default: '18.218.243.112'
-      secret:
-        description: ''
-        required: true
-        default: '8K9BVlNfYo6aiLamu1c2'
+
 jobs:
-  build:
-    name: Build
-    runs-on:  ubuntu-latest
+  unit-test:
+    name: Unit Test
+    runs-on: ubuntu-latest
     steps:
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Set up Go 1.x
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-      id: go
-      
-    - name: Install kubectl
-      run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-    - name: Install Helm
-      run: |
-        curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-        chmod 700 get_helm.sh
-        ./get_helm.sh
+    - name: Tidy Go modules
+      run: go mod tidy
 
-    - name: Authenticate with Kubernetes cluster
-      run: |
-        mkdir -p "${HOME}/.kube"
-        echo ${{ secrets.KUBE_CONFIG_DATA }} | base64 --decode >  ${HOME}/.kube/config
+    - name: Test
+      run: make test
 
-    - name: Install SPDK-CSI using Helm
-      run: |
-        cd spdk-csi/charts/spdk-csi
-        helm install spdk-csi ./ \
-          --set csiConfig.simplybk.uuid=${{ github.event.inputs.uuid }} \
-          --set csiConfig.simplybk.ip=${{ github.event.inputs.ip }} \
-          --set csiSecret.simplybk.secret=${{ github.event.inputs.secret }} \
-          --set logicalVolume.pool_name=testing1
-
-    - name: Run tests
-      run: make e2e-test


### PR DESCRIPTION
Currently unit tests are run as a part of Docker Build .github/workflows/linux.yaml. This seems like a wrong place.  

Now that we have CSI sanity tests too coming, I think it might be have all the tests in separate file. 

Also removing the existing code to e2e tests as it's not used as all.
 