### PR TITLE
fix: use namespace-qualified PVC name in snapshot and volume clone op…

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -522,11 +522,9 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 	pvcName, pvcNameSelected := params[CSIStorageNameKey]
 	pvcNamespace, pvcNamespaceSelected := params[CSIStorageNamespaceKey]
 
-	var pvcFullName string
+	pvcFullName := pvcName
 	if pvcNameSelected && pvcNamespaceSelected {
 		pvcFullName = fmt.Sprintf("%s/%s", pvcNamespace, pvcName)
-	} else {
-		pvcFullName = pvcName
 	}
 
 	pvcAnns, err := fetchPVCAnnotations(ctx, pvcName, pvcNamespace)
@@ -930,11 +928,9 @@ func (cs *controllerServer) handleSnapshotSource(ctx context.Context, snapshot *
 	pvcName, pvcNameSelected := params[CSIStorageNameKey]
 	pvcNamespace, pvcNamespaceSelected := params[CSIStorageNamespaceKey]
 
-	var pvcFullName string
+	pvcFullName := pvcName
 	if pvcNameSelected && pvcNamespaceSelected {
 		pvcFullName = fmt.Sprintf("%s/%s", pvcNamespace, pvcName)
-	} else {
-		pvcFullName = pvcName
 	}
 	// Use raw bytes to avoid decimal/binary unit ambiguity in clone sizing.
 	newSize := strconv.FormatInt(sizeBytes, 10)
@@ -961,11 +957,9 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 	params := req.GetParameters()
 	pvcName, pvcNameSelected := params[CSIStorageNameKey]
 	pvcNamespace, pvcNamespaceSelected := params[CSIStorageNamespaceKey]
-	var pvcFullName string
+	pvcFullName := pvcName
 	if pvcNameSelected && pvcNamespaceSelected {
 		pvcFullName = fmt.Sprintf("%s/%s", pvcNamespace, pvcName)
-	} else {
-		pvcFullName = pvcName
 	}
 
 	spdkVol, err := getSPDKVol(srcVolumeID)

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -927,10 +927,18 @@ func (cs *controllerServer) handleSnapshotSource(ctx context.Context, snapshot *
 	klog.Infof("CreateSnapshot : snapshotID=%s", sbSnapshot.snapshotID)
 	snapshotName := req.GetName()
 	params := req.GetParameters()
-	pvcName, _ := params[CSIStorageNameKey]
+	pvcName, pvcNameSelected := params[CSIStorageNameKey]
+	pvcNamespace, pvcNamespaceSelected := params[CSIStorageNamespaceKey]
+
+	var pvcFullName string
+	if pvcNameSelected && pvcNamespaceSelected {
+		pvcFullName = fmt.Sprintf("%s/%s", pvcNamespace, pvcName)
+	} else {
+		pvcFullName = pvcName
+	}
 	// Use raw bytes to avoid decimal/binary unit ambiguity in clone sizing.
 	newSize := strconv.FormatInt(sizeBytes, 10)
-	volumeID, err := sbclient.CloneSnapshot(ctx, sbSnapshot.snapshotID, snapshotName, newSize, pvcName)
+	volumeID, err := sbclient.CloneSnapshot(ctx, sbSnapshot.snapshotID, snapshotName, newSize, pvcFullName)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
@@ -951,7 +959,14 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 
 	cloneName := req.GetName()
 	params := req.GetParameters()
-	pvcName, _ := params[CSIStorageNameKey]
+	pvcName, pvcNameSelected := params[CSIStorageNameKey]
+	pvcNamespace, pvcNamespaceSelected := params[CSIStorageNamespaceKey]
+	var pvcFullName string
+	if pvcNameSelected && pvcNamespaceSelected {
+		pvcFullName = fmt.Sprintf("%s/%s", pvcNamespace, pvcName)
+	} else {
+		pvcFullName = pvcName
+	}
 
 	spdkVol, err := getSPDKVol(srcVolumeID)
 	if err != nil {
@@ -967,7 +982,7 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 	// Use raw bytes to avoid decimal/binary unit ambiguity in clone sizing.
 	newSize := strconv.FormatInt(sizeBytes, 10)
 	klog.Infof("CloneVolume : cloneName=%s", cloneName)
-	volumeID, err := sbclient.CloneVolume(ctx, spdkVol.lvolID, cloneName, newSize, pvcName)
+	volumeID, err := sbclient.CloneVolume(ctx, spdkVol.lvolID, cloneName, newSize, pvcFullName)
 	if err != nil {
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err


### PR DESCRIPTION
…erations

## Summary

During snapshot clone and volume clone operations, only the PVC name was passed to the backend — missing the namespace prefix. This caused ambiguity when the same PVC name exists in multiple namespaces.

This PR aligns clone operations with normal PVC creation by constructing the full `namespace/name` identifier when both `csi.storage.k8s.io/pvc/name` and `csi.storage.k8s.io/pvc/namespace` parameters are present.

## Changes

- `handleSnapshotSource` — passes `namespace/pvcName` to `CloneSnapshot`
- `handleVolumeSource` — passes `namespace/pvcName` to `CloneVolume`
