### PR TITLE
take XFS stripe geometry (su and sw) as storage class parameters

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/storageclass.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/storageclass.yaml
@@ -29,6 +29,10 @@ parameters:
   fabric: "{{ .Values.logicalVolume.fabric }}"
   max_namespace_per_subsys: "{{ .Values.logicalVolume.max_namespace_per_subsys }}"
   tune2fs_reserved_blocks: "{{ .Values.logicalVolume.tune2fs_reserved_blocks }}"
+{{- if and .Values.logicalVolume.xfs_su .Values.logicalVolume.xfs_sw }}
+  xfs_su: "{{ .Values.logicalVolume.xfs_su }}"
+  xfs_sw: "{{ .Values.logicalVolume.xfs_sw }}"
+{{- end }}
 {{- if .Values.storageclass.zoneClusterMap }}
   zone_cluster_map: |
     {{ .Values.storageclass.zoneClusterMap | toJson }}

--- a/charts/spdk-csi/latest/spdk-csi/values.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/values.yaml
@@ -135,6 +135,10 @@ logicalVolume:
   lvol_priority_class: "0"
   max_namespace_per_subsys: "1"
   tune2fs_reserved_blocks: "0"
+  # xfs_su and xfs_sw set the XFS stripe unit/width (mkfs.xfs -d su=,sw=).
+  # Both must be set together; if unset here, the CSI driver defaults to su=16k, sw=1.
+  xfs_su: ""
+  xfs_sw: ""
   fabric: tcp
 
 podAnnotations: {}

--- a/deploy/kubernetes/storageclass.yaml
+++ b/deploy/kubernetes/storageclass.yaml
@@ -21,6 +21,10 @@ parameters:
   distr_npcs: "1"
   lvol_priority_class: "0"
   tune2fs_reserved_blocks: "0"
+  # xfs_su and xfs_sw set the XFS stripe unit/width (mkfs.xfs -d su=,sw=).
+  # Both must be set together; if unset, they default to su=16k, sw=1.
+  # xfs_su: "16k"
+  # xfs_sw: "1"
   zone_cluster_map: |
     {"us-east-1a":"cluster-uuid-1","us-east-1b":"cluster-uuid-2"}
 reclaimPolicy: Delete

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	osexec "os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -496,6 +497,37 @@ func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	return &csi.NodeExpandVolumeResponse{}, nil
 }
 
+// defaultXFSStripeUnit and defaultXFSStripeWidth are the fallback mkfs.xfs
+// stripe geometry used when the StorageClass does not override xfs_su/xfs_sw.
+// These are a starting point based on initial testing, not a computed value
+// derived from cluster NDCS (which did not reliably improve performance).
+const (
+	defaultXFSStripeUnit  = "16k"
+	defaultXFSStripeWidth = "1"
+)
+
+// xfsStripeOptions returns mkfs.xfs format options that set the stripe geometry
+// from the StorageClass-provided xfs_su/xfs_sw parameters, falling back to
+// defaultXFSStripeUnit/defaultXFSStripeWidth when unset. Both parameters must
+// be set together; if only one is set, the defaults are used instead.
+func xfsStripeOptions(volumeContext map[string]string) []string {
+	su := volumeContext["xfs_su"]
+	sw := volumeContext["xfs_sw"]
+	switch {
+	case su == "" && sw == "":
+		su, sw = defaultXFSStripeUnit, defaultXFSStripeWidth
+	case su == "" || sw == "":
+		klog.Warningf("xfsStripeOptions: xfs_su and xfs_sw must both be set; got xfs_su=%q xfs_sw=%q, falling back to defaults su=%s,sw=%s",
+			su, sw, defaultXFSStripeUnit, defaultXFSStripeWidth)
+		su, sw = defaultXFSStripeUnit, defaultXFSStripeWidth
+	}
+	if swVal, err := strconv.Atoi(sw); err != nil || swVal <= 0 {
+		klog.Warningf("xfsStripeOptions: xfs_sw must be a positive integer, got %q, skipping stripe alignment", sw)
+		return nil
+	}
+	return []string{"-d", fmt.Sprintf("su=%s,sw=%s", su, sw), "-l", fmt.Sprintf("su=%s", su)}
+}
+
 // must be idempotent
 //
 //nolint:cyclop // many cases in switch increases complexity
@@ -515,6 +547,10 @@ func (ns *nodeServer) stageVolume(devicePath, stagingPath string, req *csi.NodeS
 	fsType := fsTypeOrDefault(req.GetVolumeCapability())
 	mntFlags := stagingMountFlags(req.GetVolumeCapability())
 	formatOptions := []string{}
+
+	if fsType == "xfs" {
+		formatOptions = append(formatOptions, xfsStripeOptions(volumeContext)...)
+	}
 
 	klog.Infof("mount %s to %s, fstype: %s, flags: %v", devicePath, stagingPath, fsType, mntFlags)
 	klog.Infof("formatOptions %v", formatOptions)


### PR DESCRIPTION
fixes: https://github.com/simplyblock/simplyblock-operator/issues/264

When XFS fileystem is requested, the users can override the values of `su` and `sw` using the storage class parameters. Otherwise the default value of su=16k and sw=1 will be used. 

The chosen values are supported by test results. Where the random 4K read writes works the best with su=16k and sw=1


<img width="2126" height="1459" alt="Unknown" src="https://github.com/user-attachments/assets/8f2e7ce3-d3b9-4e1b-b5d9-41b25adac0e2" />


