### PR TITLE
use e2fsprogs 1.47.0

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -41,8 +41,10 @@ jobs:
         SHORT_SHA=$(echo ${{ env.SHA }} | head -c 8)
         docker buildx ls
         docker buildx create --name mybuilder --bootstrap --use
-        docker buildx build --platform linux/amd64,linux/arm64 -t simplyblock/spdkcsi:base_image \
-        -t public.ecr.aws/simply-block/spdkcsi:base_image -f deploy/image/Dockerfile_base . --push
-        echo "::notice title=Docker.com::simplyblock/spdkcsi:base_image
-        echo "::notice title=AWS-ECR::public.ecr.aws/simply-block/spdkcsi:base_image
+        docker buildx build --platform linux/amd64,linux/arm64 \
+        -t simplyblock/spdkcsi:base_image_e2fsprogs \
+        -t public.ecr.aws/simply-block/spdkcsi:base_image_e2fsprogs \
+        -f deploy/image/Dockerfile_base . --push
+        echo "::notice title=Docker.com::simplyblock/spdkcsi:base_image_e2fsprogs
+        echo "::notice title=AWS-ECR::public.ecr.aws/simply-block/spdkcsi:base_image_e2fsprogs
         

--- a/deploy/image/Dockerfile
+++ b/deploy/image/Dockerfile
@@ -13,7 +13,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -buildvcs=false -o spdkcsi ./cmd/
 
-FROM simplyblock/spdkcsi:base_image
+FROM simplyblock/spdkcsi:base_image_e2fsprogs
 
 USER root
 WORKDIR /app

--- a/deploy/image/Dockerfile_base
+++ b/deploy/image/Dockerfile_base
@@ -1,3 +1,14 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.8 AS e2fsprogs-builder
+RUN dnf install -y gcc make gzip tar wget --nogpgcheck && \
+    wget -q https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.0/e2fsprogs-1.47.0.tar.gz \
+        -O /tmp/e2fsprogs.tar.gz && \
+    echo "0b4fe723d779b0927fb83c9ae709bc7b40f66d7df36433bef143e41c54257084  /tmp/e2fsprogs.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/e2fsprogs.tar.gz -C /tmp && \
+    cd /tmp/e2fsprogs-1.47.0 && \
+    ./configure --prefix=/usr --sbindir=/usr/sbin --disable-elf-shlibs && \
+    make -j$(nproc) && \
+    make install DESTDIR=/e2fsprogs-dist
+
 FROM registry.access.redhat.com/ubi9/ubi:9.8
 LABEL name="simplyblock"
 LABEL vendor="Simplyblock"
@@ -21,6 +32,13 @@ RUN dnf update -y  --nogpgcheck
 RUN dnf install -y nvme-cli iscsi-initiator-utils e2fsprogs xfsprogs util-linux kmod wget sudo rpm --nogpgcheck && \
     dnf remove -y python3-urllib3 python3-requests python3-idna --nogpgcheck && \
     dnf clean all
+
+# overwrite e2fsprogs 1.47.0 binaries (statically linked) over the OL9-packaged 1.46.5 version.
+# --disable-elf-shlibs builds against static internal libs so no .so files need copying.
+COPY --from=e2fsprogs-builder /e2fsprogs-dist/usr/sbin/tune2fs /usr/sbin/tune2fs
+COPY --from=e2fsprogs-builder /e2fsprogs-dist/usr/sbin/mke2fs  /usr/sbin/mke2fs
+COPY --from=e2fsprogs-builder /e2fsprogs-dist/usr/sbin/e2fsck  /usr/sbin/e2fsck
+
 RUN useradd -ms /bin/bash simplyblock
 RUN echo "simplyblock  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER simplyblock


### PR DESCRIPTION
Before moving to RHEL9 as base image, we had Alpine as a base image. In image, tune2fs was using 1.47.0. But the RHEL9 is using 1.46.5. 

During an upgrade path from version 25.10 to 26.2.6 we observe that pod restarts are failing due to:

```
I0615 18:34:05.280951       1 nodeserver.go:523] mount /dev/disk/by-id/nvme-8615e063-e39a-4848-ac02-5499c15d459b_ha_1 to /var/lib/kubelet/plugins/kubernetes.io/csi/csi.simplyblock.io/90aa25f2b243e16931230a86b24c940d966c274b1c63c7bd307d53ed4235df93/globalmount/fbfda901-7969-44d4-8dd3-2f40c7afc19f:testing1:8615e063-e39a-4848-ac02-5499c15d459b, fstype: ext4, flags: []
I0615 18:34:05.280995       1 nodeserver.go:524] formatOptions []
I0615 18:34:05.430391       1 mount_linux.go:544] `fsck` error fsck from util-linux 2.37.4
/dev/nvme0n1 has unsupported feature(s): FEATURE_C12 FEATURE_R16
e2fsck: Get a newer version of e2fsck!
E0615 18:34:05.617514       1 nodeserver.go:537] Failed to apply tune2fs -m 0 on /dev/disk/by-id/nvme-8615e063-e39a-4848-ac02-5499c15d459b_ha_1: exit status 1
Output: tune2fs: Filesystem has unsupported read-only feature(s) while trying to open /dev/disk/by-id/nvme-8615e063-e39a-4848-ac02-5499c15d459b_ha_1
Couldn't find valid filesystem superblock.
tune2fs 1.46.5 (30-Dec-2021)
E0615 18:34:05.617609       1 nodeserver.go:294] failed to stage volume, volumeID: fbfda901-7969-44d4-8dd3-2f40c7afc19f:testing1:8615e063-e39a-4848-ac02-5499c15d459b devicePath:/dev/disk/by-id/nvme-8615e063-e39a-4848-ac02-5499c15d459b_ha_1 err: tune2fs failed: exit status 1
I0615 18:34:05.638299       1 initiator.go:424] Disconnecting device nvme1
```


as a solution to this, downloading the version: `1.47.0` and building it and over writing the existing one. 

### testing

This relevant code path related to this is only triggered when the storage class has `tune2fs_reserved_blocks` present on it. 

Tested this by:
* created a pod with the older version
* updated the csi node pod with the version from this PR
* restarted the pod --> this works and the pod got mounted. 


