### PR TITLE
fix(csi): detect and recover from stale NVMe mounts; populate VolumeCondition

### DIFF
--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -156,18 +156,50 @@ func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 		return nil, status.Error(codes.InvalidArgument, "volume_path is required")
 	}
 
+	// Check the backing NVMe device is still present using the stashed VolumeContext.
+	// IsMountPoint and os.Stat on the mount directory both succeed for silently stale
+	// NVMe mounts (kernel has the inode cached), so we must verify the by-id device
+	// path independently.
+	if stagingPath := req.GetStagingTargetPath(); stagingPath != "" {
+		if vc, err := util.LookupVolumeContext(stagingPath); err == nil {
+			if devicePath, ok := vc["devicePath"]; ok && devicePath != "" {
+				if _, statErr := os.Stat(devicePath); os.IsNotExist(statErr) {
+					return &csi.NodeGetVolumeStatsResponse{
+						VolumeCondition: &csi.VolumeCondition{
+							Abnormal: true,
+							Message:  fmt.Sprintf("NVMe device %s not found; volume has disconnected", devicePath),
+						},
+					}, nil
+				}
+			}
+		}
+	}
+
 	st, err := os.Stat(volumePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, status.Error(codes.NotFound, "volume_path not found")
 		}
-		return nil, status.Errorf(codes.Internal, "stat volume_path %q: %v", volumePath, err)
+		// Any other stat error (EIO, ENOTCONN) means the mount is unhealthy.
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: true,
+				Message:  fmt.Sprintf("stat %q failed: %v", volumePath, err),
+			},
+		}, nil
 	}
 
 	if st.IsDir() {
 		var s unix.Statfs_t
 		if err := unix.Statfs(volumePath, &s); err != nil {
-			return nil, status.Errorf(codes.Internal, "statfs %q: %v", volumePath, err)
+			// statfs failing on a mounted directory means the backing device has
+			// gone away (stale NVMe/TCP mount surfaces as EIO or ENOTCONN here).
+			return &csi.NodeGetVolumeStatsResponse{
+				VolumeCondition: &csi.VolumeCondition{
+					Abnormal: true,
+					Message:  fmt.Sprintf("statfs %q failed: %v", volumePath, err),
+				},
+			}, nil
 		}
 
 		totalBytes := int64(s.Blocks) * int64(s.Bsize)
@@ -199,12 +231,18 @@ func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 					Available: availInodes,
 				},
 			},
+			VolumeCondition: &csi.VolumeCondition{Abnormal: false},
 		}, nil
 	}
 
 	sizeBytes, err := getBlockSizeBytes(volumePath)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "get block size for %q: %v", volumePath, err)
+		return &csi.NodeGetVolumeStatsResponse{
+			VolumeCondition: &csi.VolumeCondition{
+				Abnormal: true,
+				Message:  fmt.Sprintf("get block size for %q failed: %v", volumePath, err),
+			},
+		}, nil
 	}
 
 	return &csi.NodeGetVolumeStatsResponse{
@@ -216,6 +254,7 @@ func (ns *nodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 				Available: int64(sizeBytes),
 			},
 		},
+		VolumeCondition: &csi.VolumeCondition{Abnormal: false},
 	}, nil
 }
 
@@ -233,8 +272,36 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if isStaged {
-		klog.Warning("volume already staged")
-		return &csi.NodeStageVolumeResponse{}, nil
+		// A mount point exists, but we must verify staging actually completed and
+		// the backing NVMe device is still alive.
+		//
+		// Two failure modes that IsMountPoint cannot distinguish:
+		//   1. Stash file absent: staging was interrupted after FormatAndMount but
+		//      before StashVolumeContext (e.g. tune2fs failure).  The mount exists
+		//      but is orphaned — the NVMe device has since been disconnected.
+		//   2. Stash file present, device gone: staging completed successfully, but
+		//      the NVMe/TCP connection dropped later.  IsMountPoint still returns
+		//      true because the kernel has the directory inode cached.
+		// In both cases, unmount and fall through to a fresh connect + mount.
+		if vc, ctxErr := util.LookupVolumeContext(stagingParentPath); ctxErr != nil {
+			klog.Warningf("mount exists at %s but no stash found (%v); unmounting for re-stage", stagingTargetPath, ctxErr)
+			if umountErr := ns.mounter.Unmount(stagingTargetPath); umountErr != nil {
+				klog.Warningf("failed to unmount orphaned staging path %s: %v", stagingTargetPath, umountErr)
+			}
+			isStaged = false
+		} else if devicePath, ok := vc["devicePath"]; ok && devicePath != "" {
+			if _, statErr := os.Stat(devicePath); os.IsNotExist(statErr) {
+				klog.Warningf("stale NVMe mount at %s: device %s is gone; unmounting for re-stage", stagingTargetPath, devicePath)
+				if umountErr := ns.mounter.Unmount(stagingTargetPath); umountErr != nil {
+					klog.Warningf("failed to unmount stale staging path %s: %v", stagingTargetPath, umountErr)
+				}
+				isStaged = false
+			}
+		}
+		if isStaged {
+			klog.Warning("volume already staged")
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
 	}
 
 	var initiator util.SpdkCsiInitiator
@@ -553,7 +620,13 @@ func (ns *nodeServer) isStaged(stagingPath string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		} else if mount.IsCorruptedMnt(err) {
-			return true, nil
+			// Corrupted mount — clean it up so NodeStageVolume performs a fresh
+			// mount rather than falsely declaring the volume staged.
+			klog.Warningf("corrupted mount at %s; unmounting for re-stage", stagingPath)
+			if umountErr := ns.mounter.Unmount(stagingPath); umountErr != nil {
+				klog.Warningf("failed to unmount corrupted staging path %s: %v", stagingPath, umountErr)
+			}
+			return false, nil
 		}
 		klog.Warningf("check is stage error: %v", err)
 		return false, err


### PR DESCRIPTION
## Motivation

During an R25→R26.2 cluster upgrade we hit two independent but related bugs that left workload pods stuck in \`ContainerCreating\` with no automatic recovery path.

### Root cause chain

Staging runs: \`Connect()\` → \`FormatAndMount\` → \`tune2fs\` → \`StashVolumeContext\`.

In our case \`tune2fs\` aborted on an unrecognised ext4 feature flag (\`FEATURE_C12\`/\`FEATURE_R16\`, added in e2fsprogs 1.47.0), so \`StashVolumeContext\` was never called.  The bind mount already existed, but the NVMe device was subsequently disconnected.

This triggered a cascade:

1. **Orphaned mount** — the staging directory appeared mounted in \`/proc/mounts\` even though the backing NVMe device was gone.
2. **Stale VolumeAttachment** — because staging never completed cleanly, the driver never emitted a signal that the volume was unhealthy.  The \`VolumeAttachment\` object for \`pvc-d41f23be\` on worker-3 remained in place 14 hours after the failure.
3. **Multi-Attach error** — when the pod was rescheduled to a different node, the \`external-attacher\` refused to create a new \`VolumeAttachment\` because the old one was still present, producing:
   ```
   Multi-Attach error for volume "pvc-d41f23be": Volume is already exclusively attached to one node and can't be attached to another
   ```
   The pod stayed in \`ContainerCreating\` indefinitely.  Resolution required manually deleting the stale \`VolumeAttachment\`.

### Bug 1 — re-stage always short-circuits on an orphaned mount

On the next \`NodeStageVolume\` call after the failure:
- \`isStaged()\` → \`IsMountPoint\` returned **true** (mount directory still in \`/proc/mounts\`)
- Driver returned \`NodeStageVolumeResponse{}\` immediately — silent success on a dead mount
- No reconnect, no re-mount, pod I/O fails silently

### Bug 2 — NVMe disconnect after successful staging

When the NVMe/TCP session drops post-staging, the kernel keeps the directory inode cached.  \`/proc/mounts\` still contains the entry, so \`IsMountPoint\` returns true and the driver short-circuits again.

### Bug 3 — VolumeCondition never populated

The driver already advertised \`RPC_VOLUME_CONDITION\` in its capability set, but the \`VolumeCondition\` field was never populated in \`NodeGetVolumeStats\`.  This meant the \`external-health-monitor\` sidecar had no signal to work with — it could not mark the volume abnormal, which in turn prevented any automated remediation of the stale \`VolumeAttachment\`.

### Why NVMe stale mounts are silent (vs NFS)

\`mount.IsCorruptedMnt\` catches \`ESTALE\` — the POSIX error NFS surfaces on a stale filehandle.  NVMe block device disconnects produce no mount-level error; the mount _looks_ healthy at \`IsMountPoint\` time.  There is no equivalent kernel signal until a process actually tries I/O through it.

---

## Idiomatic CSI solution

Three targeted fixes in \`pkg/spdk/nodeserver.go\`:

### 1. \`isStaged()\` — fix \`IsCorruptedMnt\` branch

Previously returned \`true\` when the kernel itself reported a corrupted mount, causing \`NodeStageVolume\` to return success without re-mounting.  Now unmounts and returns \`false\`:

```go
} else if mount.IsCorruptedMnt(err) {
    klog.Warningf("corrupted mount at %s; unmounting for re-stage", stagingPath)
    ns.mounter.Unmount(stagingPath)
    return false, nil
}
```

### 2. \`NodeStageVolume\` — stale-mount verification when \`isStaged()\` returns true

After \`IsMountPoint\` confirms a mount point, two additional checks run before the driver returns early:

| Condition | Action |
|-----------|--------|
| Stash file absent | staging was interrupted; unmount + re-stage |
| Stash file present, \`devicePath\` not found via \`os.Stat\` | NVMe disconnected; unmount + re-stage |

The stash file (written by \`StashVolumeContext\` at the end of a successful staging sequence) acts as an idiomatic staging-completion marker — a pattern used by several in-tree CSI drivers.

### 3. \`NodeGetVolumeStats\` — populate \`VolumeCondition\`

Now actually populates the field the driver already advertised:

- Device path gone (\`os.IsNotExist\`) → \`VolumeCondition{Abnormal: true}\` before attempting \`statfs\`
- \`os.Stat\` or \`unix.Statfs\` fails (EIO, ENOTCONN) → \`VolumeCondition{Abnormal: true}\` with the error, instead of a gRPC \`Internal\` error the sidecar cannot interpret
- Healthy mount → \`VolumeCondition{Abnormal: false}\` alongside the usual byte/inode usage stats

With \`Abnormal: true\` flowing through the \`external-health-monitor\` sidecar, the kubelet and cluster-level controllers gain the signal needed to force-detach stale \`VolumeAttachment\` objects automatically — eliminating the need for manual intervention.

---

## Test plan

- [ ] Stage a volume, kill the NVMe/TCP session, trigger \`NodeStageVolume\` again — confirm the driver reconnects and re-mounts instead of silently returning success
- [ ] Stage a volume with \`tune2fs\` failing mid-way, verify driver re-stages cleanly on retry (no stash file → unmount + re-stage)
- [ ] Confirm \`NodeGetVolumeStats\` returns \`Abnormal: true\` after NVMe disconnect and \`Abnormal: false\` on a healthy mount
- [ ] Verify stale \`VolumeAttachment\` is eventually cleaned up automatically via health monitor when \`Abnormal: true\` is set
- [ ] Regression: normal attach/detach/pod lifecycle unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)