### PR TITLE
Remove ndcs and npcs from volume create API

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -496,15 +496,6 @@ func getBoolParameter(params map[string]string, key string) bool {
 func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, capacityBytes int64) (*util.CreateLVolData, error) {
 	params := req.GetParameters()
 
-	distrNdcs, err := getIntParameter(params, "distr_ndcs", 1)
-	if err != nil {
-		return nil, err
-	}
-	distrNpcs, err := getIntParameter(params, "distr_npcs", 1)
-	if err != nil {
-		return nil, err
-	}
-
 	priorClass, err := getIntParameter(params, "lvol_priority_class", 0)
 	if err != nil {
 		return nil, err
@@ -570,8 +561,6 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 		Compression:  compression,
 		Encryption:   encryption,
 		Replicate:    replicate,
-		DistNdcs:     distrNdcs,
-		DistNpcs:     distrNpcs,
 		HostID:       hostID,
 		LvolID:       lvolID,
 		Namespaced:   maxNamespace > 1,

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	osexec "os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -492,17 +491,6 @@ func (ns *nodeServer) stageVolume(devicePath, stagingPath string, req *csi.NodeS
 	formatOptions := []string{}
 
 	if fsType == "xfs" {
-		if rawNdcs := volumeContext["distr_ndcs"]; rawNdcs != "" {
-			distrNdcs, err := strconv.Atoi(rawNdcs)
-			if err != nil {
-				return fmt.Errorf("invalid distr_ndcs %q: %w", rawNdcs, err)
-			}
-			if distrNdcs <= 0 {
-				return fmt.Errorf("invalid distr_ndcs %d: must be greater than 0", distrNdcs)
-			}
-			formatOptions = append(formatOptions, "-d", fmt.Sprintf("sunit=%d,swidth=%d", 8*distrNdcs, 8*distrNdcs), "-l", fmt.Sprintf("sunit=%d", 8*distrNdcs))
-		}
-
 		// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
 		// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
 		mntFlags = append(mntFlags, "nouuid")

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -207,8 +207,6 @@ type CreateLVolData struct {
 	MaxWmBytes   string `json:"max_w_mbytes"`
 	MaxSize      string `json:"max_size"`
 	MaxNamespace int    `json:"max_namespace_per_subsys"`
-	DistNdcs     int    `json:"ndcs"`
-	DistNpcs     int    `json:"npcs"`
 	PriorClass   int    `json:"priority_class"`
 	HostID       string `json:"host_id"`
 	LvolID       string `json:"uid"`


### PR DESCRIPTION
## Summary

remove ndcs and npcs support from volume create API. `ndcs` and `npcs` values are set during cluster create and passing incorrect values as a part of the lvol create could break the cluster so removing the support for this from the API

## Test plan

- [x] Create a volume using a StorageClass without `distr_ndcs`/`distr_npcs` — provision succeeds
- [x] Create a volume using a legacy StorageClass that still has `distr_ndcs`/`distr_npcs` — provision succeeds (params ignored)
- [x] `go build ./pkg/...` passes