### PR TITLE
Harden token-based authentication code path

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -157,11 +157,13 @@ func NewsimplyBlockClient(ctx context.Context, clusterID, poolIDOrName string) (
 	// Use API token when SPDKCSI_API_TOKEN_PATH is explicitly set; otherwise fall back to cluster_secret.
 	credential := clusterConfig.ClusterSecret
 	if tokenPath := os.Getenv("SPDKCSI_API_TOKEN_PATH"); tokenPath != "" {
-		if tokenBytes, err := os.ReadFile(tokenPath); err == nil {
-			if token := strings.TrimSpace(string(tokenBytes)); token != "" {
-				credential = token
-				klog.Infof("Using API token from file for cluster %s", clusterID)
-			}
+		if tokenBytes, err := os.ReadFile(tokenPath); err != nil {
+			klog.Warningf("SPDKCSI_API_TOKEN_PATH is set but token file %q could not be read for cluster %s: %v; falling back to cluster_secret", tokenPath, clusterID, err)
+		} else if token := strings.TrimSpace(string(tokenBytes)); token == "" {
+			klog.Warningf("SPDKCSI_API_TOKEN_PATH is set but token file %q is empty for cluster %s; falling back to cluster_secret", tokenPath, clusterID)
+		} else {
+			credential = token
+			klog.Infof("Using API token from file for cluster %s", clusterID)
 		}
 	}
 	if credential == "" {

--- a/pkg/util/initiator_test.go
+++ b/pkg/util/initiator_test.go
@@ -164,3 +164,38 @@ func TestCredentialBothMissingReturnsError(t *testing.T) {
 		t.Errorf("error %q does not contain %q", err.Error(), want)
 	}
 }
+
+// TestCredentialAPITokenFileUnreadableFallsBackToClusterSecret verifies that when
+// SPDKCSI_API_TOKEN_PATH points to a nonexistent file, the driver falls back to
+// cluster_secret rather than failing silently or crashing.
+func TestCredentialAPITokenFileUnreadableFallsBackToClusterSecret(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretJSON)
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", "/nonexistent/path/to/token")
+
+	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.API.Credential != "static-secret" {
+		t.Errorf("expected fallback to cluster_secret %q, got %q", "static-secret", node.API.Credential)
+	}
+}
+
+// TestCredentialAPITokenFileEmptyFallsBackToClusterSecret verifies that when
+// SPDKCSI_API_TOKEN_PATH points to a file that is empty (or whitespace-only),
+// the driver falls back to cluster_secret.
+func TestCredentialAPITokenFileEmptyFallsBackToClusterSecret(t *testing.T) {
+	secretFile := writeTempFile(t, testSecretJSON)
+	tokenFile := writeTempFile(t, "   \n")
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+	t.Setenv("SPDKCSI_API_TOKEN_PATH", tokenFile)
+
+	node, err := NewsimplyBlockClient(context.Background(), "test-cluster", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node.API.Credential != "static-secret" {
+		t.Errorf("expected fallback to cluster_secret %q, got %q", "static-secret", node.API.Credential)
+	}
+}


### PR DESCRIPTION
The existing code may have silently failed on empty or unreadable token files, this catches these errors.