### PR TITLE
Fix: Guardian Premature Pod Restart on Broken Lvol

### DIFF
--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/klog"
 )
 
+// defaultBrokenLvolGracePeriod is the default value for BrokenLvolGracePeriod.
+const defaultBrokenLvolGracePeriod = 90 * time.Second
+
 type GuardianConfig struct {
 	NodeName         string
 	PollInterval     time.Duration
@@ -63,7 +66,7 @@ func NewDefaultGuardianConfig(nodeName string) GuardianConfig {
 		),
 		BrokenLvolGracePeriod: parseDurationFromEnv(
 			"GUARDIAN_BROKEN_LVOL_GRACE_PERIOD",
-			90*time.Second,
+			defaultBrokenLvolGracePeriod,
 		),
 		StatePath:     "/var/run/simplyblock/guardian/state.json",
 		CSIDriverName: "csi.simplyblock.io",
@@ -360,14 +363,14 @@ func (g *Guardian) tick(ctx context.Context) {
 
 	// Build the earliest broken-lvol timestamp per cluster so we can enforce
 	// BrokenLvolGracePeriod before evaluating cluster status.
-	clusterFirstBroken := map[string]time.Time{}
+	earliestLvolBrokenAt := map[string]time.Time{}
 	for lvolID, ts := range lvolBrokenAt {
 		cid := lvolCluster[lvolID]
 		if cid == "" {
 			continue
 		}
-		if t, ok := clusterFirstBroken[cid]; !ok || ts.Before(t) {
-			clusterFirstBroken[cid] = ts
+		if t, ok := earliestLvolBrokenAt[cid]; !ok || ts.Before(t) {
+			earliestLvolBrokenAt[cid] = ts
 		}
 	}
 
@@ -383,7 +386,7 @@ func (g *Guardian) tick(ctx context.Context) {
 
 		// If any lvol on this cluster broke recently, wait for the grace period
 		// before checking status — the cluster may still be transitioning to suspended.
-		if firstBroken, hasBroken := clusterFirstBroken[cid]; hasBroken {
+		if firstBroken, hasBroken := earliestLvolBrokenAt[cid]; hasBroken {
 			if time.Since(firstBroken) < g.cfg.BrokenLvolGracePeriod {
 				klog.Infof("Guardian: cluster=%s has broken lvols detected %.0fs ago, waiting for grace period (%.0fs) before status check",
 					cid, time.Since(firstBroken).Seconds(), g.cfg.BrokenLvolGracePeriod.Seconds())

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -35,6 +35,12 @@ type GuardianConfig struct {
 	// Minimum time a lvol must remain "broken" before we restart pods after cluster is active.
 	MinBrokenFor time.Duration
 
+	// BrokenLvolGracePeriod is how long to wait after the first broken lvol
+	// is detected before checking cluster status. This gives the cluster time
+	// to transition from active to suspended before the guardian evaluates
+	// whether to restart pods.
+	BrokenLvolGracePeriod time.Duration
+
 	StatePath     string
 	CSIDriverName string
 }
@@ -54,6 +60,10 @@ func NewDefaultGuardianConfig(nodeName string) GuardianConfig {
 		MinBrokenFor: parseDurationFromEnv(
 			"GUARDIAN_MIN_BROKEN_FOR",
 			30*time.Second,
+		),
+		BrokenLvolGracePeriod: parseDurationFromEnv(
+			"GUARDIAN_BROKEN_LVOL_GRACE_PERIOD",
+			90*time.Second,
 		),
 		StatePath:     "/var/run/simplyblock/guardian/state.json",
 		CSIDriverName: "csi.simplyblock.io",
@@ -170,6 +180,9 @@ func StartGuardian(ctx context.Context, cfg GuardianConfig) (*Guardian, error) {
 	}
 	if cfg.MinBrokenFor <= 0 {
 		cfg.MinBrokenFor = 30 * time.Second
+	}
+	if cfg.BrokenLvolGracePeriod <= 0 {
+		cfg.BrokenLvolGracePeriod = 90 * time.Second
 	}
 	if cfg.OptInLabelKey == "" {
 		cfg.OptInLabelKey = "simplyblock.io/auto-restart-on-pathloss"
@@ -345,6 +358,19 @@ func (g *Guardian) tick(ctx context.Context) {
 	}
 	g.mu.Unlock()
 
+	// Build the earliest broken-lvol timestamp per cluster so we can enforce
+	// BrokenLvolGracePeriod before evaluating cluster status.
+	clusterFirstBroken := map[string]time.Time{}
+	for lvolID, ts := range lvolBrokenAt {
+		cid := lvolCluster[lvolID]
+		if cid == "" {
+			continue
+		}
+		if t, ok := clusterFirstBroken[cid]; !ok || ts.Before(t) {
+			clusterFirstBroken[cid] = ts
+		}
+	}
+
 	activeNow := map[string]bool{}
 
 	justBecameActive := map[string]bool{} // clusterID -> true
@@ -353,6 +379,16 @@ func (g *Guardian) tick(ctx context.Context) {
 		cid := c.ClusterID
 		if cid == "" {
 			continue
+		}
+
+		// If any lvol on this cluster broke recently, wait for the grace period
+		// before checking status — the cluster may still be transitioning to suspended.
+		if firstBroken, hasBroken := clusterFirstBroken[cid]; hasBroken {
+			if time.Since(firstBroken) < g.cfg.BrokenLvolGracePeriod {
+				klog.Infof("Guardian: cluster=%s has broken lvols detected %.0fs ago, waiting for grace period (%.0fs) before status check",
+					cid, time.Since(firstBroken).Seconds(), g.cfg.BrokenLvolGracePeriod.Seconds())
+				continue
+			}
 		}
 
 		active, realStatus, err := g.isClusterActiveByID(cid)


### PR DESCRIPTION
…→suspended transition on broken lvol

### Problem

When a broken lvol is detected, the cluster may still report `active` for a
brief period while it transitions to `suspended`. The guardian was immediately
checking cluster status after detecting a broken lvol, seeing `active`, and
proceeding to restart pods — before the cluster had finished transitioning.
This caused unnecessary pod restarts during what should have been a clean
failover window.

### Fix

Added a `BrokenLvolGracePeriod` (default `90s`) to `GuardianConfig`. When the
first broken lvol is detected for a cluster, the guardian skips the cluster
status check entirely for that cluster until the grace period has elapsed. This
gives the cluster time to fully transition from `active` to `suspended` before
any restart decision is made.

On the next poll tick (after the grace period expires), the cluster status is
evaluated normally:
- If the cluster is `suspended` → no restarts triggered
- If the cluster is still `active` → pod restarts proceed as expected
