### PR TITLE
csi.Snapshot: pass SourceVolumeId and CreationTime

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -806,7 +807,7 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 }
 
 // ListSnapshots lists all snapshots across all clusters
-func (cs *controllerServer) ListSnapshots(ctx context.Context, _ *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 
 	var entries []*util.SnapshotResp
 	clusters, err := ListClusters()
@@ -828,19 +829,43 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, _ *csi.ListSnapsh
 		entries = append(entries, snapshotEntries...)
 	}
 
-	var vca []*csi.ListSnapshotsResponse_Entry
+	var all []*csi.ListSnapshotsResponse_Entry
 	for _, entry := range entries {
-		snapshotData := &csi.Snapshot{
-			SizeBytes:  entry.Size,
-			SnapshotId: fmt.Sprintf("%s:%s:%s", entry.ClusterID, entry.PoolID, entry.UUID),
-			ReadyToUse: true,
+		snapshotID := fmt.Sprintf("%s:%s:%s", entry.ClusterID, entry.PoolID, entry.UUID)
+		sourceVolumeID := lvolIDFromURL(entry.LvolURL)
+
+		if req.GetSnapshotId() != "" && req.GetSnapshotId() != snapshotID {
+			continue
 		}
-		vca = append(vca, &csi.ListSnapshotsResponse_Entry{Snapshot: snapshotData})
+		if req.GetSourceVolumeId() != "" && req.GetSourceVolumeId() != sourceVolumeID {
+			continue
+		}
+
+		createdAt, _ := time.Parse(time.RFC3339Nano, entry.CreatedAt)
+		all = append(all, &csi.ListSnapshotsResponse_Entry{
+			Snapshot: &csi.Snapshot{
+				SizeBytes:      entry.Size,
+				SnapshotId:     snapshotID,
+				SourceVolumeId: sourceVolumeID,
+				CreationTime:   timestamppb.New(createdAt),
+				ReadyToUse:     true,
+			},
+		})
 	}
 
 	return &csi.ListSnapshotsResponse{
-		Entries: vca,
+		Entries: all,
 	}, nil
+}
+
+// lvolIDFromURL extracts the volume UUID from a URL path like
+// /api/v2/clusters/{id}/storage-pools/{id}/volumes/{volume_id}
+func lvolIDFromURL(lvolURL string) string {
+	u := strings.TrimRight(lvolURL, "/")
+	if idx := strings.LastIndex(u, "/"); idx >= 0 {
+		return u[idx+1:]
+	}
+	return lvolURL
 }
 
 func ListClusters() (clusterIds []string, err error) {

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -42,7 +42,7 @@ var (
 	ErrVolumeUnpublished = errors.New("volume not published")
 )
 
-// HTTPError implements error 
+// HTTPError implements error
 type HTTPError struct {
 	Method     string
 	StatusCode int
@@ -157,8 +157,9 @@ type SnapshotResp struct {
 	UUID      string `json:"id"`
 	Size      int64  `json:"size"`
 	LvolURL   string `json:"lvol"` // URL path to source volume (may be empty in list responses)
-	PoolID    string `json:"-"`    // populated after fetch, not from JSON
-	ClusterID string `json:"-"`    // populated after fetch, not from JSON
+	CreatedAt string `json:"created_at"`
+	PoolID    string `json:"-"` // populated after fetch, not from JSON
+	ClusterID string `json:"-"` // populated after fetch, not from JSON
 }
 
 // CreateVolResp is the response for volume create (legacy, kept for compat)
@@ -701,4 +702,3 @@ func extractErrorMessage(body []byte) string {
 	}
 	return string(body)
 }
-


### PR DESCRIPTION
these changes depend on a PR from sbcli: https://github.com/simplyblock/sbcli/pull/1113. So should be merged after that PR is merged.

as per the spec, the response of `ListSnapshots` should also include 
* SourceVolumeId
* CreationTime

sbcli already returns this information as a part of this snapshot API.

`SourceVolumeId` --> needs to be extracted from the `lvol` field of the snapshot response. This field is an URL link to lvol
`CreatedAt` --> returns RFC3339 timestamp


This PR fixes these 2 failures
```
  [FAIL] ListSnapshots [Controller Server] [It] should return snapshots that match the specified snapshot id
  [FAIL] ListSnapshots [Controller Server] [It] should return snapshots that match the specified source volume id
```




