### PR TITLE
Volume and snapshot HTTP status handling corrections

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -317,13 +317,13 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if _, isStatus := status.FromError(err); isStatus {
 			return nil, err
 		}
-		return nil, status.Error(codes.Unavailable, err.Error())
+		return nil, classifyCreateVolumeError(err)
 	}
 
 	volumeInfo, err := cs.publishVolume(ctx, csiVolume.GetVolumeId(), sbClient)
 	if err != nil {
 		klog.Errorf("failed to publish volume, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Unavailable, err.Error())
+		return nil, classifyCreateVolumeError(err)
 	}
 
 	// copy volume info. node needs these info to contact target(ip, port, nqn, ...)
@@ -379,7 +379,7 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		klog.Warningf("volume not published: %s", volumeID)
 	case err != nil:
 		klog.Errorf("failed to unpublish volume, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Unavailable, err.Error())
+		return nil, classifyDeleteVolumeError(err)
 	}
 
 	// no harm if volume already deleted
@@ -389,7 +389,7 @@ func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		klog.Warningf("volume not exists: %s", volumeID)
 	} else if err != nil {
 		klog.Errorf("failed to delete volume, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Unavailable, err.Error())
+		return nil, classifyDeleteVolumeError(err)
 	}
 
 	return &csi.DeleteVolumeResponse{}, nil
@@ -413,7 +413,7 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if _, err := sbclient.VolumeInfo(ctx, spdkVol.lvolID, ""); err != nil {
-		return nil, status.Errorf(codes.NotFound, "volume %q not found: %v", volumeID, err)
+		return nil, classifyValidateVolumeCapabilitiesError(err)
 	}
 
 	// make sure we support all requested caps
@@ -434,6 +434,40 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 			VolumeCapabilities: req.GetVolumeCapabilities(),
 		},
 	}, nil
+}
+
+// reconcileExistingSnapshot handles a 409 from CreateSnapshot: the control plane
+// says a snapshot with this name already exists. It lists snapshots and, if the
+// existing one has the same source volume, returns it as success (CSI
+// idempotency — this is our own snapshot from an earlier attempt). If the source
+// differs, it is a real name conflict → AlreadyExists.
+func reconcileExistingSnapshot(ctx context.Context, sbclient util.ClusterAPI, sourceLvolID, snapshotName string) (*csi.CreateSnapshotResponse, error) {
+	snaps, err := sbclient.ListSnapshots(ctx)
+	if err != nil {
+		return nil, classifyCreateSnapshotError(err)
+	}
+	for _, s := range snaps {
+		if s.Name != snapshotName {
+			continue
+		}
+		if lvolIDFromURL(s.LvolURL) != sourceLvolID {
+			return nil, status.Errorf(codes.AlreadyExists, "snapshot %q already exists with a different source volume", snapshotName)
+		}
+		creationTime := timestamppb.Now()
+		if ts, perr := time.Parse(time.RFC3339Nano, s.CreatedAt); perr == nil {
+			creationTime = timestamppb.New(ts)
+		}
+		return &csi.CreateSnapshotResponse{
+			Snapshot: &csi.Snapshot{
+				SizeBytes:      s.Size,
+				SnapshotId:     fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), s.UUID),
+				SourceVolumeId: sourceLvolID,
+				CreationTime:   creationTime,
+				ReadyToUse:     true,
+			},
+		}, nil
+	}
+	return nil, status.Errorf(codes.Internal, "snapshot %q reported as existing but was not found", snapshotName)
 }
 
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
@@ -462,27 +496,32 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return nil, status.Error(codes.Unavailable, err.Error())
 	}
 
-	snapshotID, err := sbclient.CreateSnapshot(ctx, spdkVol.lvolID, snapshotName)
-	klog.Infof("CreateSnapshot : snapshotID=%s", snapshotID)
-	if err != nil {
-		klog.Errorf("failed to create snapshot, volumeID: %s snapshotName: %s err: %v", volumeID, snapshotName, err)
-		if errors.Is(err, util.ErrSnapshotExists) {
-			return nil, status.Errorf(codes.AlreadyExists, "snapshot %q already exists with a different source volume", snapshotName)
-		}
-		return nil, status.Error(codes.Unavailable, err.Error())
-	}
-
 	volSize, err := sbclient.GetVolumeSize(ctx, spdkVol.lvolID)
 	klog.Infof("CreateSnapshot : volSize=%s", volSize)
 	if err != nil {
 		klog.Errorf("failed to get volume info, volumeID: %s err: %v", volumeID, err)
-		return nil, status.Error(codes.Unavailable, err.Error())
+		return nil, classifyCreateSnapshotError(err)
 	}
 	size, err := strconv.ParseInt(volSize, 10, 64)
 	if err != nil {
 		klog.Errorf("failed to parse volume size, size: %s err: %v", volSize, err)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+
+	snapshotID, err := sbclient.CreateSnapshot(ctx, spdkVol.lvolID, snapshotName)
+	klog.Infof("CreateSnapshot : snapshotID=%s", snapshotID)
+	if err != nil {
+		d := classifyCreateSnapshotError(err)
+		if d.IsIdempotent() {
+			// 409: the snapshot already exists. Reconcile — if it is ours (same
+			// source) return it as success (CSI idempotency); if it belongs to a
+			// different source, it is a genuine name conflict.
+			return reconcileExistingSnapshot(ctx, sbclient, spdkVol.lvolID, snapshotName)
+		}
+		klog.Errorf("failed to create snapshot, volumeID: %s snapshotName: %s err: %v", volumeID, snapshotName, err)
+		return nil, d
+	}
+
 	creationTime := timestamppb.Now()
 	snapshotData := csi.Snapshot{
 		SizeBytes:      size,
@@ -522,8 +561,12 @@ func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 
 	err = sbclient.DeleteSnapshot(ctx, sbSnapshot.snapshotID)
 	if err != nil {
-		klog.Errorf("failed to delete snapshot, snapshotID: %s err: %v", csiSnapshotID, err)
-		return nil, status.Error(codes.Unavailable, err.Error())
+		if d := classifyDeleteSnapshotError(err); !d.IsSuccess() {
+			klog.Errorf("failed to delete snapshot, snapshotID: %s err: %v", csiSnapshotID, err)
+			return nil, d
+		}
+		// already gone — idempotent success
+		klog.Warningf("snapshot not found, treating as already deleted: %s", csiSnapshotID)
 	}
 
 	return &csi.DeleteSnapshotResponse{}, nil
@@ -799,7 +842,7 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	err = sbclient.ResizeVolume(ctx, spdkVol.lvolID, capacityBytes)
 	if err != nil {
 		klog.Errorf("failed to resize lvol, LVolID: %s err: %v", spdkVol.lvolID, err)
-		return nil, err
+		return nil, classifyControllerExpandVolumeError(err)
 	}
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         capacityBytes,
@@ -825,7 +868,7 @@ func (cs *controllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnap
 
 		snapshotEntries, err := sbclient.ListSnapshots(ctx)
 		if err != nil {
-			return nil, err
+			return nil, classifyListSnapshotsError(err)
 		}
 		entries = append(entries, snapshotEntries...)
 	}

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -667,6 +667,39 @@ func prepareCreateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest, c
 	return &createVolReq, nil
 }
 
+// reconcileExistingVolume handles a 409 (name already exists) on a volume create
+// or clone. If an online volume with the name exists it is reused (after a size
+// check); a non-online leftover from a failed earlier attempt is deleted so the
+// caller can recreate. It returns the existing volume's UUID to reuse, "" to
+// recreate, or an error (a size conflict, or a list/delete failure).
+func reconcileExistingVolume(ctx context.Context, sbclient util.ClusterAPI, name string, requiredBytes int64) (string, error) {
+	volumes, err := sbclient.ListVolumes(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, v := range volumes {
+		if v.Name != name {
+			continue
+		}
+		if strings.EqualFold(v.Status, "online") {
+			if requiredBytes > 0 {
+				aligned := util.AlignToGiBBytes(requiredBytes)
+				if v.LvolSize != aligned {
+					return "", status.Errorf(codes.AlreadyExists, "volume %q exists with size %d but requested %d", name, v.LvolSize, aligned)
+				}
+			}
+			klog.Infof("reconcile: reusing online existing volume %q id=%s", name, v.UUID)
+			return v.UUID, nil
+		}
+		// Non-online leftover from a failed attempt: it will never come online.
+		klog.Warningf("reconcile: deleting non-online leftover volume %q id=%s status=%s", name, v.UUID, v.Status)
+		if delErr := sbclient.DeleteVolume(ctx, v.UUID); delErr != nil {
+			return "", delErr
+		}
+	}
+	return "", nil
+}
+
 func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVolumeRequest, sbclient util.ClusterAPI) (*csi.Volume, error) {
 	size := req.GetCapacityRange().GetRequiredBytes()
 	if size == 0 {
@@ -708,27 +741,23 @@ func (cs *controllerServer) createVolume(ctx context.Context, req *csi.CreateVol
 	volumeID, err := sbclient.CreateVolume(ctx, createVolReq)
 	if err != nil {
 		if errors.Is(err, util.ErrVolumeExists) {
-			klog.Infof("createVolume: volume %q already exists, searching for online match", req.GetName())
-			volumes, listErr := sbclient.ListVolumes(ctx)
-			if listErr != nil {
-				klog.Errorf("createVolume: failed to list volumes during exists fallback: %v", listErr)
-				return nil, listErr
+			klog.Infof("createVolume: volume %q already exists, reconciling", req.GetName())
+			existingUUID, rerr := reconcileExistingVolume(ctx, sbclient, req.GetName(), req.GetCapacityRange().GetRequiredBytes())
+			if rerr != nil {
+				return nil, rerr
 			}
-			for _, v := range volumes {
-				if v.Name == req.GetName() && strings.EqualFold(v.Status, "online") {
-					klog.Infof("createVolume: found online existing volume %q id=%s", req.GetName(), v.UUID)
-					if req.GetCapacityRange().GetRequiredBytes() > 0 {
-						alignedRequired := util.AlignToGiBBytes(req.GetCapacityRange().GetRequiredBytes())
-						if v.LvolSize != alignedRequired {
-							return nil, status.Errorf(codes.AlreadyExists, "volume %q exists with size %d but requested %d", req.GetName(), v.LvolSize, alignedRequired)
-						}
-					}
-					vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), v.UUID)
-					return &vol, nil
-				}
+			if existingUUID != "" {
+				vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), existingUUID)
+				return &vol, nil
 			}
-			klog.Errorf("createVolume: volume %q exists but is not online yet", req.GetName())
-			return nil, status.Errorf(codes.AlreadyExists, "volume %q exists but is not online yet", req.GetName())
+			// The non-online leftover (if any) has been cleaned up; create fresh.
+			volumeID, err = sbclient.CreateVolume(ctx, createVolReq)
+			if err != nil {
+				klog.Errorf("createVolume: recreate after cleanup failed: %v", err)
+				return nil, err
+			}
+			vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volumeID)
+			return &vol, nil
 		}
 		klog.Errorf("error creating simplyBlock volume: %v", err)
 		return nil, err
@@ -1091,8 +1120,24 @@ func (cs *controllerServer) handleSnapshotSource(ctx context.Context, snapshot *
 	newSize := strconv.FormatInt(sizeBytes, 10)
 	volumeID, err := sbclient.CloneSnapshot(ctx, sbSnapshot.snapshotID, snapshotName, newSize, pvcFullName)
 	if err != nil {
-		klog.Errorf("error creating simplyBlock volume: %v", err)
-		return nil, err
+		if !classifyCreateVolumeError(err).IsIdempotent() {
+			klog.Errorf("error cloning snapshot: %v", err)
+			return nil, err
+		}
+		// 409: a clone with this name already exists — reconcile it.
+		existingUUID, rerr := reconcileExistingVolume(ctx, sbclient, snapshotName, sizeBytes)
+		if rerr != nil {
+			return nil, rerr
+		}
+		if existingUUID != "" {
+			vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), existingUUID)
+			return vol, nil
+		}
+		volumeID, err = sbclient.CloneSnapshot(ctx, sbSnapshot.snapshotID, snapshotName, newSize, pvcFullName)
+		if err != nil {
+			klog.Errorf("error re-cloning snapshot after cleanup: %v", err)
+			return nil, err
+		}
 	}
 	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volumeID)
 	klog.V(5).Info("successfully Restored Snapshot from Simplyblock with Volume ID: ", vol.GetVolumeId())
@@ -1124,6 +1169,7 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 	}
 	// Volume clone goes to the same pool as the source volume.
 	sbclient, err := util.NewsimplyBlockClient(ctx, spdkVol.clusterID, spdkVol.poolID)
+
 	if err != nil {
 		klog.Errorf("failed to create spdk client: %v", err)
 		return nil, status.Error(codes.Unavailable, err.Error())
@@ -1133,8 +1179,24 @@ func (cs *controllerServer) handleVolumeSource(ctx context.Context, srcVolume *c
 	klog.Infof("CloneVolume : cloneName=%s", cloneName)
 	volumeID, err := sbclient.CloneVolume(ctx, spdkVol.lvolID, cloneName, newSize, pvcFullName)
 	if err != nil {
-		klog.Errorf("error creating simplyBlock volume: %v", err)
-		return nil, err
+		if !classifyCreateVolumeError(err).IsIdempotent() {
+			klog.Errorf("error cloning volume: %v", err)
+			return nil, err
+		}
+		// 409: a clone with this name already exists — reconcile it.
+		existingUUID, rerr := reconcileExistingVolume(ctx, sbclient, cloneName, sizeBytes)
+		if rerr != nil {
+			return nil, rerr
+		}
+		if existingUUID != "" {
+			vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), existingUUID)
+			return vol, nil
+		}
+		volumeID, err = sbclient.CloneVolume(ctx, spdkVol.lvolID, cloneName, newSize, pvcFullName)
+		if err != nil {
+			klog.Errorf("error re-cloning volume after cleanup: %v", err)
+			return nil, err
+		}
 	}
 	vol.VolumeId = fmt.Sprintf("%s:%s:%s", sbclient.ClusterID(), sbclient.PoolID(), volumeID)
 	klog.V(5).Info("successfully created clone volume from Simplyblock with Volume ID: ", vol.GetVolumeId())

--- a/pkg/spdk/controllerserver_provisioner_test.go
+++ b/pkg/spdk/controllerserver_provisioner_test.go
@@ -1,0 +1,164 @@
+package spdk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	csicommon "github.com/spdk/spdk-csi/pkg/csi-common"
+)
+
+// startCSIController boots the real controller behind a gRPC server (exactly as
+// TestSanity does) and returns a CSI ControllerClient dialed to it — so calls
+// go PVC-shim -> gRPC -> Simplyblock CSI driver -> mock control plane.
+func startCSIController(t *testing.T, mock *mockSBCLI) csi.ControllerClient {
+	t.Helper()
+	writeMockSecret(t, mock)
+
+	cd := csicommon.NewCSIDriver(testDriverName, "test", "test-node")
+	cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+	})
+	cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+	})
+
+	ids := newIdentityServer(cd)
+	cs, err := newControllerServer(cd)
+	if err != nil {
+		t.Fatalf("newControllerServer: %v", err)
+	}
+	ns := &stubNodeServer{DefaultNodeServer: csicommon.NewDefaultNodeServer(cd)}
+
+	// Keep the socket path short: unix socket paths are capped (~104 bytes on
+	// macOS) and t.TempDir() embeds the long test name.
+	sockDir, err := os.MkdirTemp("", "sbcsi")
+	if err != nil {
+		t.Fatalf("mkdir socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	endpoint := "unix://" + filepath.Join(sockDir, "c.sock")
+	grpcSrv := csicommon.NewNonBlockingGRPCServer()
+	grpcSrv.Start(endpoint, ids, cs, ns)
+	t.Cleanup(grpcSrv.ForceStop)
+
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial controller: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return csi.NewControllerClient(conn)
+}
+
+// fakeProvisioner is a minimal stand-in for the Kubernetes external-provisioner
+// sidecar: it names the volume pvc-<uid>, calls CreateVolume over gRPC, and on
+// success writes a bound PV. On error it leaves the PVC Pending, to be retried —
+// exactly the loop that ran 225k times in the incident.
+type fakeProvisioner struct {
+	client   csi.ControllerClient
+	kube     k8sclient.Interface
+	scParams map[string]string
+}
+
+func (p *fakeProvisioner) provision(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	volName := "pvc-" + string(pvc.UID)
+	resp, err := p.client.CreateVolume(ctx, &csi.CreateVolumeRequest{
+		Name: volName,
+		VolumeCapabilities: []*csi.VolumeCapability{{
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+		}},
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 1 << 30},
+		Parameters:    p.scParams,
+	})
+	if err != nil {
+		return err // PVC stays Pending; the provisioner will retry.
+	}
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: volName},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: testDriverName, VolumeHandle: resp.GetVolume().GetVolumeId()},
+			},
+			ClaimRef: &corev1.ObjectReference{Namespace: pvc.Namespace, Name: pvc.Name, UID: pvc.UID},
+		},
+	}
+	if _, err := p.kube.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	pvc.Spec.VolumeName = volName
+	pvc.Status.Phase = corev1.ClaimBound
+	_, err = p.kube.CoreV1().PersistentVolumeClaims(pvc.Namespace).UpdateStatus(ctx, pvc, metav1.UpdateOptions{})
+	return err
+}
+
+// TestProvisioning_APIError_LeaksVolumesWhilePVCStaysPending drives a PVC through
+// the real provisioning path (shim provisioner -> gRPC -> driver -> mock control
+// plane) and proves the incident behavior: while a control-plane failure keeps
+// the PVC Pending, every provisioning retry leaks a fresh volume.
+//
+// The control plane here does not enforce volume-name uniqueness and fails the
+// post-create publish (GET) step, so each CreateVolume creates a new lvol yet
+// still returns an error. The driver relies on the control plane for idempotency
+// and has no client-side dedup, so volumes pile up one-per-retry — the PVC never
+// binds. This test asserts at most one volume survives; it is RED today.
+func TestProvisioning_APIError_LeaksVolumesWhilePVCStaysPending(t *testing.T) {
+	mock := newMockSBCLI()
+	defer mock.Close()
+	mock.allowDuplicateNames = true // control plane does not dedupe by name
+	mock.failGetVolume = true       // publish (GET) fails after the volume is created
+
+	ctx := context.Background()
+	client := startCSIController(t, mock)
+	kube := fake.NewSimpleClientset()
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data",
+			UID:       types.UID("11111111-2222-3333-4444-555555555555"),
+		},
+	}
+	if _, err := kube.CoreV1().PersistentVolumeClaims("default").Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pvc: %v", err)
+	}
+
+	prov := &fakeProvisioner{
+		client:   client,
+		kube:     kube,
+		scParams: map[string]string{"cluster_id": sanityClusterID, "pool_name": sanityPoolName},
+	}
+
+	const retries = 5
+	for attempt := 1; attempt <= retries; attempt++ {
+		if err := prov.provision(ctx, pvc); err == nil {
+			t.Fatalf("attempt %d: provisioning unexpectedly succeeded despite the control-plane error", attempt)
+		}
+	}
+
+	// The PVC never bound.
+	if pvc.Status.Phase == corev1.ClaimBound {
+		t.Fatal("PVC unexpectedly bound")
+	}
+
+	// The bug: each retry leaked a new volume on the control plane.
+	mock.mu.Lock()
+	leaked := len(mock.volumes)
+	mock.mu.Unlock()
+	if leaked > 1 {
+		t.Fatalf("control plane leaked %d volumes across %d provisioning retries while the PVC "+
+			"stayed Pending; CreateVolume must be idempotent (reuse or clean up the volume) "+
+			"instead of creating a new one every attempt", leaked, retries)
+	}
+}

--- a/pkg/spdk/controllerserver_provisioner_test.go
+++ b/pkg/spdk/controllerserver_provisioner_test.go
@@ -103,21 +103,25 @@ func (p *fakeProvisioner) provision(ctx context.Context, pvc *corev1.PersistentV
 	return err
 }
 
-// TestProvisioning_APIError_LeaksVolumesWhilePVCStaysPending drives a PVC through
-// the real provisioning path (shim provisioner -> gRPC -> driver -> mock control
-// plane) and proves the incident behavior: while a control-plane failure keeps
-// the PVC Pending, every provisioning retry leaks a fresh volume.
+// TestProvisioning_RetryIsIdempotentUnderNameUniqueness drives a PVC through the
+// real provisioning path (shim provisioner -> gRPC -> driver -> mock control
+// plane) while the post-create publish keeps failing, so the PVC stays Pending
+// and the provisioner retries. It asserts that the retries do NOT leak: exactly
+// one volume exists on the control plane no matter how many times CreateVolume
+// is re-issued.
 //
-// The control plane here does not enforce volume-name uniqueness and fails the
-// post-create publish (GET) step, so each CreateVolume creates a new lvol yet
-// still returns an error. The driver relies on the control plane for idempotency
-// and has no client-side dedup, so volumes pile up one-per-retry — the PVC never
-// binds. This test asserts at most one volume survives; it is RED today.
-func TestProvisioning_APIError_LeaksVolumesWhilePVCStaysPending(t *testing.T) {
+// This idempotency depends on the control plane enforcing volume-name uniqueness
+// (409 on a duplicate name): the driver sends a stable name (pvc-<uid>) and
+// relies on the 409 to detect and reconcile its own prior volume. A control
+// plane that does NOT enforce name-uniqueness would instead create a fresh lvol
+// on every retry — one leaked volume per attempt — but that is a control-plane
+// contract violation, not a driver bug, so it is out of scope here.
+func TestProvisioning_RetryIsIdempotentUnderNameUniqueness(t *testing.T) {
 	mock := newMockSBCLI()
 	defer mock.Close()
-	mock.allowDuplicateNames = true // control plane does not dedupe by name
-	mock.failGetVolume = true       // publish (GET) fails after the volume is created
+	// Control plane enforces name-uniqueness (default: 409 on duplicate) and the
+	// post-create publish (GET) fails, keeping the PVC Pending across retries.
+	mock.failGetVolume = true
 
 	ctx := context.Background()
 	client := startCSIController(t, mock)
@@ -143,22 +147,21 @@ func TestProvisioning_APIError_LeaksVolumesWhilePVCStaysPending(t *testing.T) {
 	const retries = 5
 	for attempt := 1; attempt <= retries; attempt++ {
 		if err := prov.provision(ctx, pvc); err == nil {
-			t.Fatalf("attempt %d: provisioning unexpectedly succeeded despite the control-plane error", attempt)
+			t.Fatalf("attempt %d: provisioning unexpectedly succeeded despite the publish failure", attempt)
 		}
 	}
 
-	// The PVC never bound.
+	// The PVC never bound (publish kept failing).
 	if pvc.Status.Phase == corev1.ClaimBound {
 		t.Fatal("PVC unexpectedly bound")
 	}
 
-	// The bug: each retry leaked a new volume on the control plane.
+	// No leak: the retries reconciled to the same single volume.
 	mock.mu.Lock()
-	leaked := len(mock.volumes)
+	count := len(mock.volumes)
 	mock.mu.Unlock()
-	if leaked > 1 {
-		t.Fatalf("control plane leaked %d volumes across %d provisioning retries while the PVC "+
-			"stayed Pending; CreateVolume must be idempotent (reuse or clean up the volume) "+
-			"instead of creating a new one every attempt", leaked, retries)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 volume on the control plane after %d retries, got %d "+
+			"(retries must reconcile, not leak)", retries, count)
 	}
 }

--- a/pkg/spdk/controllerserver_snapshot_test.go
+++ b/pkg/spdk/controllerserver_snapshot_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/spdk/spdk-csi/pkg/util"
 )
@@ -325,14 +322,17 @@ func TestCreateSnapshot_ReconcilesLeftoverOnRetry(t *testing.T) {
 // codes.Unavailable and returns. It neither repairs nor cleans up the dangling
 // PV left on the Kubernetes side. This test asserts the PV is cleaned up after
 // the clone error; it is RED today.
-func TestCreateVolumeFromSnapshot_CloneError_LeavesPVDangling(t *testing.T) {
+// TestCreateVolumeFromSnapshot_ReconcilesLeftoverOnRetry: the clone-from-snapshot
+// path must reconcile a leftover on retry (like the plain-create path), not leak a
+// duplicate or dead-end. Attempt 1's clone is created but publish fails, leaving a
+// cloned volume behind; the retry must reuse it, not create a second clone.
+func TestCreateVolumeFromSnapshot_ReconcilesLeftoverOnRetry(t *testing.T) {
 	mock := newMockSBCLI()
 	defer mock.Close()
-
 	cs := newTestControllerServer(t, mock)
 	ctx := context.Background()
 
-	// A source snapshot the clone will read from.
+	// A source snapshot the clone reads from.
 	srcVolID := createSourceVolume(t, cs, "pvc-clone-source")
 	src, err := parseVolumeID(srcVolID)
 	if err != nil {
@@ -344,31 +344,54 @@ func TestCreateVolumeFromSnapshot_CloneError_LeavesPVDangling(t *testing.T) {
 	mock.mu.Unlock()
 	csiSnapshotID := sanityClusterID + ":" + sanityPoolUUID + ":" + snapID
 
-	const pvName = "pvc-clone-target"
-	const orphanLvolID = "88888888-8888-8888-8888-888888888888"
-
-	// The Kubernetes side already holds a broken PV for this clone claim.
-	kube := fake.NewSimpleClientset(brokenPV(pvName, orphanLvolID))
-
-	// The control plane fails the clone create.
-	mock.failCreateOnce = true
-	req := basicCreateVolumeRequest(pvName)
+	const cloneName = "pvc-clone-target"
+	req := basicCreateVolumeRequest(cloneName)
 	req.VolumeContentSource = &csi.VolumeContentSource{
 		Type: &csi.VolumeContentSource_Snapshot{
 			Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: csiSnapshotID},
 		},
 	}
-	if _, err := cs.CreateVolume(ctx, req); err == nil {
-		t.Fatal("expected CreateVolume-from-snapshot to fail when the clone API errors")
+
+	countClones := func() int {
+		n := 0
+		for _, v := range mock.volumes {
+			if v.Name == cloneName {
+				n++
+			}
+		}
+		return n
 	}
 
-	pv, err := kube.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
-	if err == nil {
-		t.Fatalf("failed PV %q was left dangling after the clone API error "+
-			"(volume handle %q); CreateVolume neither repaired nor cleaned it up",
-			pvName, pv.Spec.CSI.VolumeHandle)
+	// Attempt 1: the clone is created, but publish (GET) fails → CreateVolume errors,
+	// leaving a cloned volume behind.
+	mock.mu.Lock()
+	mock.failGetVolume = true
+	mock.mu.Unlock()
+	if _, err := cs.CreateVolume(ctx, req); err == nil {
+		t.Fatal("expected attempt 1 to fail at publish")
 	}
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("unexpected error reading PV %q: %v", pvName, err)
+	mock.mu.Lock()
+	leftover := countClones()
+	mock.mu.Unlock()
+	if leftover != 1 {
+		t.Fatalf("expected exactly 1 leftover clone after attempt 1, got %d", leftover)
+	}
+
+	// Attempt 2 (retry): the control plane is healthy → must reconcile the leftover
+	// clone, no duplicate.
+	mock.mu.Lock()
+	mock.failGetVolume = false
+	mock.mu.Unlock()
+	resp, err := cs.CreateVolume(ctx, req)
+	if err != nil {
+		t.Fatalf("retry did not reconcile the leftover clone: %v", err)
+	}
+	if resp.GetVolume().GetVolumeId() == "" {
+		t.Fatal("retry returned no volume id")
+	}
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if got := countClones(); got != 1 {
+		t.Fatalf("retry created a duplicate clone: %d, want 1", got)
 	}
 }

--- a/pkg/spdk/controllerserver_snapshot_test.go
+++ b/pkg/spdk/controllerserver_snapshot_test.go
@@ -1,0 +1,383 @@
+package spdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/spdk/spdk-csi/pkg/util"
+)
+
+// createSourceVolume provisions a normal volume through the controller and
+// returns its CSI volume ID ("{clusterID}:{poolID}:{lvolID}").
+func createSourceVolume(t *testing.T, cs *controllerServer, name string) string {
+	t.Helper()
+	resp, err := cs.CreateVolume(context.Background(), basicCreateVolumeRequest(name))
+	if err != nil {
+		t.Fatalf("failed to create source volume %q: %v", name, err)
+	}
+	return resp.GetVolume().GetVolumeId()
+}
+
+// assertControlPlaneErrorMapping is the ~27-case-per-RPC response matrix: it drives
+// an RPC through every control-plane response (each HTTP status + transport
+// failures) by injecting it on the RPC's first API call, and asserts the RPC
+// returns the gRPC code its classifier prescribes. This is what verifies the
+// error classification is actually wired into the RPC — every response mapped to
+// its correct gRPC code, not a blanket Unavailable.
+//
+//	classify: the RPC's classify*Error function (source of the expected code).
+//	invoke:   performs the RPC against the mock and returns its error.
+func assertControlPlaneErrorMapping(
+	t *testing.T,
+	classify func(error) classifiedError,
+	invoke func(t *testing.T, ctx context.Context, mock *mockSBCLI) error,
+) {
+	t.Helper()
+
+	check := func(t *testing.T, repr, actual error) {
+		t.Helper()
+		if want, got := status.Code(classify(repr)), status.Code(actual); got != want {
+			t.Errorf("got code %s, want %s (rpc err: %v)", got, want, actual)
+		}
+	}
+
+	// Every HTTP status the classifier knows about.
+	statuses := []int{
+		400, 401, 403, 404, 405, 406, 408, 409, 410, 411, 412, 413, 414, 415, 422, 429,
+		500, 501, 502, 503, 504, 505, 507, 508, 511,
+	}
+	for _, s := range statuses {
+		s := s
+		t.Run(fmt.Sprintf("http_%d", s), func(t *testing.T) {
+			mock := newMockSBCLI()
+			defer mock.Close()
+			mock.mu.Lock()
+			mock.injectStatus = func(*http.Request) int { return s }
+			mock.mu.Unlock()
+			check(t, &util.HTTPError{StatusCode: s}, invoke(t, context.Background(), mock))
+		})
+	}
+
+	// Transport failures (no HTTP status).
+	t.Run("timeout", func(t *testing.T) {
+		mock := newMockSBCLI()
+		defer mock.Close()
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		check(t, fmt.Errorf("POST: %w", context.DeadlineExceeded), invoke(t, ctx, mock))
+	})
+	t.Run("connection_refused", func(t *testing.T) {
+		mock := newMockSBCLI()
+		mock.Close() // dead endpoint; the secret still captures its URL string
+		check(t, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}, invoke(t, context.Background(), mock))
+	})
+}
+
+// TestCreateSnapshot_ControlPlaneErrorMapping drives CreateSnapshot through every
+// control-plane response and asserts the gRPC code, plus the operation-specific
+// 409 idempotency semantics (which are success/AlreadyExists, not a plain code).
+func TestCreateSnapshot_ControlPlaneErrorMapping(t *testing.T) {
+	const snapName = "snap-map"
+	srcVolID := sanityClusterID + ":" + sanityPoolUUID + ":99999999-9999-9999-9999-999999999999"
+
+	assertControlPlaneErrorMapping(t, classifyCreateSnapshotError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{SourceVolumeId: srcVolID, Name: snapName})
+			return err
+		})
+
+	// 409 with the SAME source is our own already-created snapshot -> idempotent
+	// success returning the existing snapshot.
+	t.Run("http_409_same_source_is_idempotent_success", func(t *testing.T) {
+		mock := newMockSBCLI()
+		defer mock.Close()
+		src := seedSnapshotSource(mock)
+		parsed, _ := parseVolumeID(src)
+		existingID := uuid.New().String()
+		mock.mu.Lock()
+		mock.snapshots[existingID] = &mockSnapshot{UUID: existingID, Name: snapName, VolUUID: parsed.lvolID, Size: 1 << 30}
+		mock.strictSnapshotNameConflict = true
+		mock.mu.Unlock()
+		cs := newTestControllerServer(t, mock)
+
+		resp, err := cs.CreateSnapshot(context.Background(), &csi.CreateSnapshotRequest{SourceVolumeId: src, Name: snapName})
+		if err != nil {
+			t.Fatalf("409 with the same source must be idempotent success, got: %v", err)
+		}
+		if id := resp.GetSnapshot().GetSnapshotId(); !strings.Contains(id, existingID) {
+			t.Fatalf("expected the existing snapshot %q returned, got %q", existingID, id)
+		}
+	})
+
+	// 409 with a DIFFERENT source is a genuine name conflict -> AlreadyExists.
+	t.Run("http_409_different_source_is_conflict", func(t *testing.T) {
+		mock := newMockSBCLI()
+		defer mock.Close()
+		src := seedSnapshotSource(mock)
+		existingID := uuid.New().String()
+		mock.mu.Lock()
+		mock.snapshots[existingID] = &mockSnapshot{UUID: existingID, Name: snapName, VolUUID: "88888888-8888-8888-8888-888888888888", Size: 1 << 30}
+		mock.strictSnapshotNameConflict = true
+		mock.mu.Unlock()
+		cs := newTestControllerServer(t, mock)
+
+		_, err := cs.CreateSnapshot(context.Background(), &csi.CreateSnapshotRequest{SourceVolumeId: src, Name: snapName})
+		if got := status.Code(err); got != codes.AlreadyExists {
+			t.Fatalf("409 with a different source: got %s, want AlreadyExists (err: %v)", got, err)
+		}
+	})
+}
+
+// TestDeleteSnapshot_ControlPlaneErrorMapping drives DeleteSnapshot through every
+// control-plane response (notably: 404 must be idempotent success).
+func TestDeleteSnapshot_ControlPlaneErrorMapping(t *testing.T) {
+	snapID := sanityClusterID + ":" + sanityPoolUUID + ":99999999-9999-9999-9999-999999999999"
+	assertControlPlaneErrorMapping(t, classifyDeleteSnapshotError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.DeleteSnapshot(ctx, &csi.DeleteSnapshotRequest{SnapshotId: snapID})
+			return err
+		})
+}
+
+// TestListSnapshots_ControlPlaneErrorMapping drives ListSnapshots through every
+// control-plane response.
+func TestListSnapshots_ControlPlaneErrorMapping(t *testing.T) {
+	assertControlPlaneErrorMapping(t, classifyListSnapshotsError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.ListSnapshots(ctx, &csi.ListSnapshotsRequest{})
+			return err
+		})
+}
+
+// seedSnapshotSource seeds a source volume directly in the mock (bypassing the
+// create/GET paths, which the ordering tests deliberately fail) and returns its
+// CSI volume ID.
+func seedSnapshotSource(m *mockSBCLI) string {
+	const srcLvolID = "77777777-7777-7777-7777-777777777777"
+	m.mu.Lock()
+	m.volumes[srcLvolID] = &mockVolume{UUID: srcLvolID, Name: "pvc-src", Size: 1 << 30}
+	m.mu.Unlock()
+	return sanityClusterID + ":" + sanityPoolUUID + ":" + srcLvolID
+}
+
+// assertNoOrphanOnFailure proves an RPC is atomic on failure: whenever it returns
+// an error, its mutating control-plane call (the create) must NOT have persisted.
+// Equivalently, the create must be ordered after every OTHER fallible call, so a
+// precondition/metadata failure aborts before creating anything — otherwise a
+// failure leaves an orphan that later retries can't reconcile.
+//
+// It is a positional matrix run in two phases:
+//
+//	Phase 1 — Discovery. Run the RPC once, fully successfully, with a mock whose
+//	failIf hook counts every API request but fails none. The count N is the total
+//	number of control-plane calls, and the loop bound — so the matrix never loops
+//	open-endedly and needs no hardcoded count.
+//
+//	Phase 2 — Matrix. For each k in 1..N, on a fresh mock, fail ONLY the k-th
+//	request. If the RPC then returns an error, the mutation must not have persisted.
+//
+// A best-effort call whose failure the RPC tolerates (e.g. a post-create info
+// read) is fine: the RPC succeeds and the mutation legitimately persists, so the
+// no-orphan check only applies when the RPC actually errors. Because N is
+// discovered at runtime, any precondition added later gets its own iteration.
+//
+//	seed:    seeds objects the RPC needs into the mock (nil if none).
+//	invoke:  performs the RPC and returns its error.
+//	mutated: reports whether the mutating side effect persisted on the mock.
+func assertNoOrphanOnFailure(
+	t *testing.T,
+	seed func(*mockSBCLI),
+	invoke func(t *testing.T, ctx context.Context, mock *mockSBCLI) error,
+	mutated func(*mockSBCLI) bool,
+) {
+	t.Helper()
+	if seed == nil {
+		seed = func(*mockSBCLI) {}
+	}
+
+	// Phase 1 — discover the number of API calls a successful RPC makes.
+	discover := newMockSBCLI()
+	defer discover.Close()
+	seed(discover)
+	calls := 0
+	discover.mu.Lock()
+	discover.failIf = func(*http.Request) bool { calls++; return false }
+	discover.mu.Unlock()
+	if err := invoke(t, context.Background(), discover); err != nil {
+		t.Fatalf("discovery invoke failed: %v", err)
+	}
+	if calls < 2 {
+		t.Fatalf("expected the RPC to make at least 2 API calls, got %d", calls)
+	}
+
+	// Phase 2 — fail the k-th call; if the RPC errors, no mutation may persist.
+	for k := 1; k <= calls; k++ {
+		target := k
+		t.Run(fmt.Sprintf("fail_call_%d_of_%d", k, calls), func(t *testing.T) {
+			mock := newMockSBCLI()
+			defer mock.Close()
+			seed(mock)
+			n := 0
+			mock.mu.Lock()
+			mock.failIf = func(*http.Request) bool { n++; return n == target }
+			mock.mu.Unlock()
+
+			if err := invoke(t, context.Background(), mock); err != nil && mutated(mock) {
+				t.Fatalf("API call #%d failed the RPC (%v), yet the mutation persisted (orphan); "+
+					"a failed RPC must leave no side effect — create only after every fallible call", target, err)
+			}
+		})
+	}
+}
+
+// TestCreateSnapshot_NoAPICallBeforeMetadataResolved: the snapshot must be created
+// only after all preconditions/metadata (e.g. the source volume size) resolve.
+func TestCreateSnapshot_NoAPICallBeforeMetadataResolved(t *testing.T) {
+	const srcLvolID = "77777777-7777-7777-7777-777777777777"
+	srcVolID := sanityClusterID + ":" + sanityPoolUUID + ":" + srcLvolID
+
+	assertNoOrphanOnFailure(t,
+		func(m *mockSBCLI) {
+			m.mu.Lock()
+			m.volumes[srcLvolID] = &mockVolume{UUID: srcLvolID, Name: "pvc-src", Size: 1 << 30}
+			m.mu.Unlock()
+		},
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.CreateSnapshot(ctx, &csi.CreateSnapshotRequest{SourceVolumeId: srcVolID, Name: "snap-ordering"})
+			return err
+		},
+		func(m *mockSBCLI) bool { m.mu.Lock(); defer m.mu.Unlock(); return len(m.snapshots) > 0 },
+	)
+}
+
+// TestCreateSnapshot_ReconcilesLeftoverOnRetry is the CreateSnapshot analog of
+// TestCreateVolume_ReconcilesLeftoverOnRetry — and it is RED, showing the retry
+// does NOT reconcile.
+//
+// Attempt 1 creates the snapshot but fails at GetVolumeSize, leaving a valid
+// snapshot of the correct source behind. On retry the real web API answers 409
+// for the duplicate name; CreateSnapshot detects ErrSnapshotExists but — unlike
+// CreateVolume, which lists and returns the existing volume — maps it straight to
+// AlreadyExists. So the retry never returns the existing snapshot as success,
+// even though it is ours (same source). Detecting the 409 is not the same as
+// reconciling it.
+func TestCreateSnapshot_ReconcilesLeftoverOnRetry(t *testing.T) {
+	mock := newMockSBCLI()
+	defer mock.Close()
+	// Real web API: a duplicate snapshot name yields 409 (not idempotent).
+	mock.mu.Lock()
+	mock.strictSnapshotNameConflict = true
+	mock.mu.Unlock()
+
+	cs := newTestControllerServer(t, mock)
+	ctx := context.Background()
+	srcVolID := seedSnapshotSource(mock)
+	req := &csi.CreateSnapshotRequest{SourceVolumeId: srcVolID, Name: "snap-reconcile"}
+
+	// Attempt 1: the snapshot is created, but GetVolumeSize fails → error, leaving
+	// a valid snapshot of the correct source behind.
+	mock.mu.Lock()
+	mock.failGetVolume = true
+	mock.mu.Unlock()
+	if _, err := cs.CreateSnapshot(ctx, req); err == nil {
+		t.Fatal("expected attempt 1 to fail at GetVolumeSize")
+	}
+	mock.mu.Lock()
+	leftover := len(mock.snapshots)
+	mock.mu.Unlock()
+	if leftover != 1 {
+		t.Fatalf("expected exactly 1 leftover snapshot after attempt 1, got %d", leftover)
+	}
+
+	// Attempt 2 (retry, same name + source): the control plane is healthy again.
+	// It must return the existing snapshot as success — same source, so it is ours.
+	mock.mu.Lock()
+	mock.failGetVolume = false
+	mock.mu.Unlock()
+	resp, err := cs.CreateSnapshot(ctx, req)
+	if err != nil {
+		t.Fatalf("retry did not reconcile the leftover snapshot: %v", err)
+	}
+	if resp.GetSnapshot().GetSnapshotId() == "" {
+		t.Fatal("retry returned no snapshot id")
+	}
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if got := len(mock.snapshots); got != 1 {
+		t.Fatalf("retry created a duplicate: %d snapshots, want 1", got)
+	}
+}
+
+// TestCreateVolumeFromSnapshot_CloneError_LeavesPVDangling proves that when the
+// clone-from-snapshot API call fails, the broken PersistentVolume is left
+// dangling — the same cleanup gap as the plain-create path, on the clone path.
+//
+// handleSnapshotSource returns the raw clone error, which CreateVolume wraps as
+// codes.Unavailable and returns. It neither repairs nor cleans up the dangling
+// PV left on the Kubernetes side. This test asserts the PV is cleaned up after
+// the clone error; it is RED today.
+func TestCreateVolumeFromSnapshot_CloneError_LeavesPVDangling(t *testing.T) {
+	mock := newMockSBCLI()
+	defer mock.Close()
+
+	cs := newTestControllerServer(t, mock)
+	ctx := context.Background()
+
+	// A source snapshot the clone will read from.
+	srcVolID := createSourceVolume(t, cs, "pvc-clone-source")
+	src, err := parseVolumeID(srcVolID)
+	if err != nil {
+		t.Fatalf("parse source volume ID: %v", err)
+	}
+	snapID := uuid.New().String()
+	mock.mu.Lock()
+	mock.snapshots[snapID] = &mockSnapshot{UUID: snapID, Name: "src-snap", VolUUID: src.lvolID, Size: 1 << 30}
+	mock.mu.Unlock()
+	csiSnapshotID := sanityClusterID + ":" + sanityPoolUUID + ":" + snapID
+
+	const pvName = "pvc-clone-target"
+	const orphanLvolID = "88888888-8888-8888-8888-888888888888"
+
+	// The Kubernetes side already holds a broken PV for this clone claim.
+	kube := fake.NewSimpleClientset(brokenPV(pvName, orphanLvolID))
+
+	// The control plane fails the clone create.
+	mock.failCreateOnce = true
+	req := basicCreateVolumeRequest(pvName)
+	req.VolumeContentSource = &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Snapshot{
+			Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: csiSnapshotID},
+		},
+	}
+	if _, err := cs.CreateVolume(ctx, req); err == nil {
+		t.Fatal("expected CreateVolume-from-snapshot to fail when the clone API errors")
+	}
+
+	pv, err := kube.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("failed PV %q was left dangling after the clone API error "+
+			"(volume handle %q); CreateVolume neither repaired nor cleaned it up",
+			pvName, pv.Spec.CSI.VolumeHandle)
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("unexpected error reading PV %q: %v", pvName, err)
+	}
+}

--- a/pkg/spdk/controllerserver_snapshot_test.go
+++ b/pkg/spdk/controllerserver_snapshot_test.go
@@ -269,22 +269,20 @@ func TestCreateSnapshot_NoAPICallBeforeMetadataResolved(t *testing.T) {
 }
 
 // TestCreateSnapshot_ReconcilesLeftoverOnRetry is the CreateSnapshot analog of
-// TestCreateVolume_ReconcilesLeftoverOnRetry — and it is RED, showing the retry
-// does NOT reconcile.
+// TestCreateVolume_ReconcilesLeftoverOnRetry: an ambiguous-timeout leftover must
+// be reconciled on retry, not dead-ended on AlreadyExists.
 //
-// Attempt 1 creates the snapshot but fails at GetVolumeSize, leaving a valid
-// snapshot of the correct source behind. On retry the real web API answers 409
-// for the duplicate name; CreateSnapshot detects ErrSnapshotExists but — unlike
-// CreateVolume, which lists and returns the existing volume — maps it straight to
-// AlreadyExists. So the retry never returns the existing snapshot as success,
-// even though it is ours (same source). Detecting the 409 is not the same as
-// reconciling it.
+// Attempt 1's create is persisted by the control plane but the response is lost,
+// so the client sees an error — a valid snapshot of the correct source is left
+// behind. On retry the real web API answers 409 for the duplicate name;
+// CreateSnapshot must list, see the same source, and return the existing snapshot
+// as success (CSI idempotency) — not a duplicate, not AlreadyExists.
 func TestCreateSnapshot_ReconcilesLeftoverOnRetry(t *testing.T) {
 	mock := newMockSBCLI()
 	defer mock.Close()
-	// Real web API: a duplicate snapshot name yields 409 (not idempotent).
 	mock.mu.Lock()
-	mock.strictSnapshotNameConflict = true
+	mock.strictSnapshotNameConflict = true        // real web API 409s on a duplicate name
+	mock.snapshotCreatePersistThenFail = true     // attempt 1: created server-side, response lost
 	mock.mu.Unlock()
 
 	cs := newTestControllerServer(t, mock)
@@ -292,13 +290,9 @@ func TestCreateSnapshot_ReconcilesLeftoverOnRetry(t *testing.T) {
 	srcVolID := seedSnapshotSource(mock)
 	req := &csi.CreateSnapshotRequest{SourceVolumeId: srcVolID, Name: "snap-reconcile"}
 
-	// Attempt 1: the snapshot is created, but GetVolumeSize fails → error, leaving
-	// a valid snapshot of the correct source behind.
-	mock.mu.Lock()
-	mock.failGetVolume = true
-	mock.mu.Unlock()
+	// Attempt 1: the snapshot is created but the client sees an error.
 	if _, err := cs.CreateSnapshot(ctx, req); err == nil {
-		t.Fatal("expected attempt 1 to fail at GetVolumeSize")
+		t.Fatal("expected attempt 1 to fail (create persisted but response lost)")
 	}
 	mock.mu.Lock()
 	leftover := len(mock.snapshots)
@@ -307,11 +301,8 @@ func TestCreateSnapshot_ReconcilesLeftoverOnRetry(t *testing.T) {
 		t.Fatalf("expected exactly 1 leftover snapshot after attempt 1, got %d", leftover)
 	}
 
-	// Attempt 2 (retry, same name + source): the control plane is healthy again.
-	// It must return the existing snapshot as success — same source, so it is ours.
-	mock.mu.Lock()
-	mock.failGetVolume = false
-	mock.mu.Unlock()
+	// Attempt 2 (retry, same name + source): must reconcile — return the existing
+	// snapshot as success, no duplicate.
 	resp, err := cs.CreateSnapshot(ctx, req)
 	if err != nil {
 		t.Fatalf("retry did not reconcile the leftover snapshot: %v", err)

--- a/pkg/spdk/controllerserver_volume_test.go
+++ b/pkg/spdk/controllerserver_volume_test.go
@@ -1,0 +1,282 @@
+package spdk
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	csicommon "github.com/spdk/spdk-csi/pkg/csi-common"
+	"github.com/spdk/spdk-csi/pkg/util"
+)
+
+const testDriverName = "test.csi.simplyblock.io"
+
+// writeMockSecret writes a SPDKCSI secret pointing at the mock control plane and
+// sets the SPDKCSI_SECRET env var to it.
+func writeMockSecret(t *testing.T, mock *mockSBCLI) {
+	t.Helper()
+	secretDir := t.TempDir()
+	secretFile := filepath.Join(secretDir, "secret.json")
+	secretData, _ := json.Marshal(util.ClustersInfo{
+		Clusters: []util.ClusterConfig{{
+			ClusterID:       sanityClusterID,
+			ClusterEndpoint: mock.URL(),
+			ClusterSecret:   sanitySecret,
+		}},
+	})
+	if err := os.WriteFile(secretFile, secretData, 0600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	t.Setenv("SPDKCSI_SECRET", secretFile)
+}
+
+// newTestControllerServer wires a controllerServer to the given mock control
+// plane, mirroring the setup used by TestSanity.
+func newTestControllerServer(t *testing.T, mock *mockSBCLI) *controllerServer {
+	t.Helper()
+
+	writeMockSecret(t, mock)
+
+	cd := csicommon.NewCSIDriver(testDriverName, "test", "test-node")
+	cd.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+	})
+	cd.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+	})
+
+	cs, err := newControllerServer(cd)
+	if err != nil {
+		t.Fatalf("newControllerServer: %v", err)
+	}
+	return cs
+}
+
+func basicCreateVolumeRequest(name string) *csi.CreateVolumeRequest {
+	return &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{{
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+		}},
+		CapacityRange: &csi.CapacityRange{RequiredBytes: 1 * 1024 * 1024 * 1024},
+		Parameters: map[string]string{
+			"cluster_id": sanityClusterID,
+			"pool_name":  sanityPoolName,
+		},
+	}
+}
+
+// brokenPV builds a PersistentVolume as the external-provisioner would leave
+// behind for a dynamically-provisioned claim: the PV name equals the CSI
+// volume name, and its volume handle points at an lvol on the control plane.
+// Used by teardown-side (DeleteVolume) reproducers where a PV genuinely exists.
+func brokenPV(name, lvolID string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       testDriverName,
+					VolumeHandle: sanityClusterID + ":" + sanityPoolUUID + ":" + lvolID,
+				},
+			},
+		},
+	}
+}
+
+// volMapID is a well-formed 3-part volume handle (UUID cluster/pool/lvol) whose
+// lvol does not exist — the RPC's first API call is injected with each response.
+const volMapID = sanityClusterID + ":" + sanityPoolUUID + ":99999999-9999-9999-9999-999999999999"
+
+// TestCreateVolume_ControlPlaneErrorMapping drives CreateVolume through every
+// control-plane response and asserts the gRPC code its classifier prescribes.
+// A UUID pool_name skips pool resolution, so the first API call is the create POST.
+func TestCreateVolume_ControlPlaneErrorMapping(t *testing.T) {
+	assertControlPlaneErrorMapping(t, classifyCreateVolumeError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			req := basicCreateVolumeRequest("pvc-vol-map")
+			req.Parameters["pool_name"] = sanityPoolUUID // UUID → no pool lookup; create POST is first
+			_, err := cs.CreateVolume(ctx, req)
+			return err
+		})
+}
+
+// TestDeleteVolume_ControlPlaneErrorMapping drives DeleteVolume through every
+// control-plane response (notably: 404 must be idempotent success).
+func TestDeleteVolume_ControlPlaneErrorMapping(t *testing.T) {
+	assertControlPlaneErrorMapping(t, classifyDeleteVolumeError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volMapID})
+			return err
+		})
+}
+
+// TestControllerExpandVolume_ControlPlaneErrorMapping drives ControllerExpandVolume
+// through every control-plane response.
+func TestControllerExpandVolume_ControlPlaneErrorMapping(t *testing.T) {
+	assertControlPlaneErrorMapping(t, classifyControllerExpandVolumeError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.ControllerExpandVolume(ctx, &csi.ControllerExpandVolumeRequest{
+				VolumeId:      volMapID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: 2 << 30},
+			})
+			return err
+		})
+}
+
+// TestValidateVolumeCapabilities_ControlPlaneErrorMapping drives
+// ValidateVolumeCapabilities through every control-plane response.
+func TestValidateVolumeCapabilities_ControlPlaneErrorMapping(t *testing.T) {
+	assertControlPlaneErrorMapping(t, classifyValidateVolumeCapabilitiesError,
+		func(t *testing.T, ctx context.Context, m *mockSBCLI) error {
+			cs := newTestControllerServer(t, m)
+			_, err := cs.ValidateVolumeCapabilities(ctx, &csi.ValidateVolumeCapabilitiesRequest{
+				VolumeId: volMapID,
+				VolumeCapabilities: []*csi.VolumeCapability{{
+					AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+				}},
+			})
+			return err
+		})
+}
+
+// TestCreateVolume_ReconcilesLeftoverOnRetry proves that CreateVolume's
+// create-before-publish ordering is safe *because it reconciles on retry* — as
+// long as the control plane dedupes by volume name (409 on a duplicate).
+//
+// Attempt 1 creates the volume on the control plane but fails at publish, leaving
+// a created, online volume behind. The retry (same name) must NOT create a
+// duplicate: the ErrVolumeExists list-by-name fallback finds the existing volume,
+// re-publishes it (now the control plane is healthy), and returns it. End state:
+// exactly one volume, success — no orphan, no duplicate.
+//
+// Contrast TestProvisioning_APIError_LeaksVolumesWhilePVCStaysPending, where a
+// control plane that does NOT dedupe by name makes the same ordering leak one
+// volume per retry. So this reconciliation holds only under name-uniqueness.
+func TestCreateVolume_ReconcilesLeftoverOnRetry(t *testing.T) {
+	mock := newMockSBCLI()
+	defer mock.Close()
+	cs := newTestControllerServer(t, mock)
+	ctx := context.Background()
+	req := basicCreateVolumeRequest("pvc-reconcile")
+
+	// Attempt 1: the create succeeds, but publish (a GET) fails → CreateVolume
+	// errors, leaving a created online volume behind.
+	mock.mu.Lock()
+	mock.failGetVolume = true
+	mock.mu.Unlock()
+	if _, err := cs.CreateVolume(ctx, req); err == nil {
+		t.Fatal("expected attempt 1 to fail at publish")
+	}
+	mock.mu.Lock()
+	leftover := len(mock.volumes)
+	mock.mu.Unlock()
+	if leftover != 1 {
+		t.Fatalf("expected exactly 1 leftover volume after attempt 1, got %d", leftover)
+	}
+
+	// Attempt 2 (retry, same name): the control plane is healthy again.
+	mock.mu.Lock()
+	mock.failGetVolume = false
+	mock.mu.Unlock()
+	resp, err := cs.CreateVolume(ctx, req)
+	if err != nil {
+		t.Fatalf("retry did not reconcile the leftover volume: %v", err)
+	}
+	if resp.GetVolume().GetVolumeId() == "" {
+		t.Fatal("retry returned no volume id")
+	}
+
+	// Exactly one volume must remain — the retry reused the leftover, no duplicate.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if got := len(mock.volumes); got != 1 {
+		t.Fatalf("retry created a duplicate: %d volumes on the control plane, want 1", got)
+	}
+}
+
+// TestCreateVolume_RetryRecoversFromBrokenVolume proves that CreateVolume gets
+// permanently stuck when a previous attempt left a non-online volume on the
+// control plane.
+//
+// Lifecycle: while a PVC is Pending, the external-provisioner calls CreateVolume
+// with the SAME name (pvc-<uid>) repeatedly until it succeeds; no PV object
+// exists yet. If an earlier attempt created a volume that never came online, the
+// retry hits the ErrVolumeExists fallback in createVolume, finds the volume is
+// not online, and returns codes.AlreadyExists — every time, forever. The
+// provisioner never gets a success, so the PVC never binds.
+//
+// The retry must instead recover: clean up the broken (non-online) volume and
+// create a fresh one, then stay idempotent across further retries. This test
+// asserts that; it is RED today.
+func TestCreateVolume_RetryRecoversFromBrokenVolume(t *testing.T) {
+	mock := newMockSBCLI()
+	defer mock.Close()
+
+	cs := newTestControllerServer(t, mock)
+	ctx := context.Background()
+
+	const pvName = "pvc-11111111-2222-3333-4444-555555555555"
+	const brokenLvolID = "99999999-9999-9999-9999-999999999999"
+
+	// An earlier provisioning attempt left a half-created, non-online volume on
+	// the control plane under this name.
+	mock.mu.Lock()
+	mock.volumes[brokenLvolID] = &mockVolume{
+		UUID:   brokenLvolID,
+		Name:   pvName,
+		Size:   1 << 30,
+		Status: "provisioning", // not "online"
+	}
+	mock.mu.Unlock()
+
+	req := basicCreateVolumeRequest(pvName)
+
+	// The provisioner re-issues the identical request until it succeeds.
+	var firstID string
+	for attempt := 1; attempt <= 3; attempt++ {
+		resp, err := cs.CreateVolume(ctx, req)
+		if err != nil {
+			t.Fatalf("attempt %d: CreateVolume never recovered from the broken volume; "+
+				"it must clean up the non-online volume and create a fresh one. err: %v", attempt, err)
+		}
+		id := resp.GetVolume().GetVolumeId()
+		if id == "" {
+			t.Fatalf("attempt %d: CreateVolume returned no volume id", attempt)
+		}
+		if firstID == "" {
+			firstID = id
+		} else if id != firstID {
+			t.Fatalf("attempt %d: CreateVolume is not idempotent: got %q, first returned %q",
+				attempt, id, firstID)
+		}
+	}
+
+	// Exactly one volume must remain for this name, and it must be online — no
+	// orphaned broken volume left behind.
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	matches := 0
+	for _, v := range mock.volumes {
+		if v.Name != pvName {
+			continue
+		}
+		matches++
+		if v.status() != "online" {
+			t.Errorf("volume %q remained non-online after recovery: status=%q", v.UUID, v.status())
+		}
+	}
+	if matches != 1 {
+		t.Errorf("expected exactly one volume named %q after recovery, found %d", pvName, matches)
+	}
+}

--- a/pkg/spdk/controllerserver_volume_test.go
+++ b/pkg/spdk/controllerserver_volume_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	csicommon "github.com/spdk/spdk-csi/pkg/csi-common"
 	"github.com/spdk/spdk-csi/pkg/util"
@@ -69,24 +67,6 @@ func basicCreateVolumeRequest(name string) *csi.CreateVolumeRequest {
 		Parameters: map[string]string{
 			"cluster_id": sanityClusterID,
 			"pool_name":  sanityPoolName,
-		},
-	}
-}
-
-// brokenPV builds a PersistentVolume as the external-provisioner would leave
-// behind for a dynamically-provisioned claim: the PV name equals the CSI
-// volume name, and its volume handle points at an lvol on the control plane.
-// Used by teardown-side (DeleteVolume) reproducers where a PV genuinely exists.
-func brokenPV(name, lvolID string) *corev1.PersistentVolume {
-	return &corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		Spec: corev1.PersistentVolumeSpec{
-			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				CSI: &corev1.CSIPersistentVolumeSource{
-					Driver:       testDriverName,
-					VolumeHandle: sanityClusterID + ":" + sanityPoolUUID + ":" + lvolID,
-				},
-			},
 		},
 	}
 }

--- a/pkg/spdk/errorclass.go
+++ b/pkg/spdk/errorclass.go
@@ -63,9 +63,8 @@ func classifyControlPlaneError(err error) controlPlaneErrorClass {
 		return controlPlaneErrorClass{Code: codes.OK}
 	}
 
-	var httpErr *util.HTTPError
-	if errors.As(err, &httpErr) {
-		return classifyHTTPStatus(httpErr.StatusCode)
+	if code := httpStatusOf(err); code != 0 {
+		return classifyHTTPStatus(code)
 	}
 
 	switch {
@@ -83,6 +82,25 @@ func classifyControlPlaneError(err error) controlPlaneErrorClass {
 
 	// Unknown, non-transport error — treat as an internal fault, not a retry.
 	return controlPlaneErrorClass{Code: codes.Internal}
+}
+
+// httpStatusOf returns the HTTP status a control-plane error represents, or 0 if
+// it is not an HTTP error. The client converts a few statuses to sentinel errors
+// (404 → Err*NotFound, 409 → Err*Exists) before they reach the RPC, so those are
+// mapped back to their status here — otherwise the 404/409 dispositions could
+// never fire.
+func httpStatusOf(err error) int {
+	switch {
+	case errors.Is(err, util.ErrVolumeNotFound), errors.Is(err, util.ErrSnapshotNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, util.ErrVolumeExists), errors.Is(err, util.ErrSnapshotExists):
+		return http.StatusConflict
+	}
+	var httpErr *util.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode
+	}
+	return 0
 }
 
 // classifyHTTPStatus applies the generic policy to a raw HTTP status code.

--- a/pkg/spdk/errorclass.go
+++ b/pkg/spdk/errorclass.go
@@ -1,0 +1,133 @@
+package spdk
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/spdk/spdk-csi/pkg/util"
+)
+
+// controlPlaneErrorClass is the CSI-level classification of a control-plane
+// error: the gRPC status code the RPC should return, whether the operation is
+// worth retrying, and whether the status is operation-specific.
+type controlPlaneErrorClass struct {
+	Code      codes.Code
+	Retryable bool
+
+	// RPCSpecific marks a control-plane status whose CSI meaning depends on the
+	// calling RPC and therefore cannot be classified generically — namely 404
+	// and 409. Example: a 404 means "already deleted, success" for DeleteVolume
+	// but "source not found, NotFound" for CreateVolume-from-snapshot; a 409
+	// means "idempotent, return the existing object" for a create with the same
+	// source but "AlreadyExists" for a different one. The generic classifier
+	// cannot resolve these — a per-RPC classifier (see errorclass_rpc.go) does.
+	// If one reaches generic classification unresolved, it is a driver bug: Code
+	// is codes.Internal so it surfaces rather than being silently mislabeled
+	// (e.g. as a retryable Unavailable).
+	RPCSpecific bool
+
+	// Success means the control-plane error is a no-op for this RPC and it should
+	// return success — e.g. a 404 on a delete: the object is already gone.
+	Success bool
+
+	// Idempotent means the RPC must resolve a conflict by looking up the existing
+	// object before deciding — e.g. a 409 on a create: same source/params →
+	// return the existing object as success, otherwise AlreadyExists. Pure
+	// classification cannot decide; the RPC performs the lookup.
+	Idempotent bool
+}
+
+// classifyControlPlaneError maps a simplyblock control-plane error to the gRPC
+// status a CSI RPC should return, and whether retrying can help. It handles only
+// the operation-INDEPENDENT ("generic") failures; operation-specific statuses
+// (404, 409) are flagged RPCSpecific and must be handled by the RPC itself.
+//
+// Generic policy:
+//   - Transport failures: timeout → DeadlineExceeded, cancel → Canceled,
+//     connection refused/reset/TLS/DNS → Unavailable (all retryable).
+//   - 500/502/503/504 and 408 → Unavailable (retryable).
+//   - 429 and 507 → ResourceExhausted (retryable backpressure/capacity).
+//   - 400/422 → InvalidArgument, 401 → Unauthenticated, 403 → PermissionDenied,
+//     412 → FailedPrecondition; other 4xx → FailedPrecondition (all permanent).
+//   - 501/505/508/511 and any other 5xx → Internal (permanent).
+//   - An unrecognized non-HTTP error (e.g. a secret-parse or unmarshal bug) is
+//     NOT a transient control-plane failure → Internal, not retryable. Mapping
+//     such errors to the retryable Unavailable is what let the sidecars retry
+//     permanent failures forever and collapse etcd.
+func classifyControlPlaneError(err error) controlPlaneErrorClass {
+	if err == nil {
+		return controlPlaneErrorClass{Code: codes.OK}
+	}
+
+	var httpErr *util.HTTPError
+	if errors.As(err, &httpErr) {
+		return classifyHTTPStatus(httpErr.StatusCode)
+	}
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return controlPlaneErrorClass{Code: codes.DeadlineExceeded, Retryable: true}
+	case errors.Is(err, context.Canceled):
+		return controlPlaneErrorClass{Code: codes.Canceled, Retryable: true}
+	}
+
+	// Recognized transport failure (connection refused/reset, TLS, DNS) → transient.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return controlPlaneErrorClass{Code: codes.Unavailable, Retryable: true}
+	}
+
+	// Unknown, non-transport error — treat as an internal fault, not a retry.
+	return controlPlaneErrorClass{Code: codes.Internal}
+}
+
+// classifyHTTPStatus applies the generic policy to a raw HTTP status code.
+func classifyHTTPStatus(status int) controlPlaneErrorClass {
+	switch status {
+	// Operation-specific — must be handled by the RPC, never generically.
+	case http.StatusNotFound, // 404
+		http.StatusConflict: // 409
+		return controlPlaneErrorClass{Code: codes.Internal, RPCSpecific: true}
+
+	// Retryable server errors + request timeout.
+	case http.StatusInternalServerError, // 500
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout,     // 504
+		http.StatusRequestTimeout:     // 408
+		return controlPlaneErrorClass{Code: codes.Unavailable, Retryable: true}
+
+	// Backpressure / capacity — retry with backoff.
+	case http.StatusTooManyRequests, // 429
+		http.StatusInsufficientStorage: // 507
+		return controlPlaneErrorClass{Code: codes.ResourceExhausted, Retryable: true}
+
+	// Permanent server errors.
+	case http.StatusNotImplemented, // 501
+		http.StatusHTTPVersionNotSupported,       // 505
+		http.StatusLoopDetected,                  // 508
+		http.StatusNetworkAuthenticationRequired: // 511
+		return controlPlaneErrorClass{Code: codes.Internal}
+
+	// Permanent client errors with specific gRPC codes.
+	case http.StatusBadRequest, http.StatusUnprocessableEntity: // 400, 422
+		return controlPlaneErrorClass{Code: codes.InvalidArgument}
+	case http.StatusUnauthorized: // 401
+		return controlPlaneErrorClass{Code: codes.Unauthenticated}
+	case http.StatusForbidden: // 403
+		return controlPlaneErrorClass{Code: codes.PermissionDenied}
+	case http.StatusPreconditionFailed: // 412
+		return controlPlaneErrorClass{Code: codes.FailedPrecondition}
+	}
+
+	switch {
+	case status >= 400 && status < 500:
+		return controlPlaneErrorClass{Code: codes.FailedPrecondition} // unlisted 4xx → permanent
+	default:
+		return controlPlaneErrorClass{Code: codes.Internal} // unlisted 5xx (and anything else) → permanent
+	}
+}

--- a/pkg/spdk/errorclass_rpc.go
+++ b/pkg/spdk/errorclass_rpc.go
@@ -1,0 +1,161 @@
+package spdk
+
+import (
+	"errors"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/spdk/spdk-csi/pkg/util"
+)
+
+// errorClassifier is a per-RPC control-plane response policy. Any HTTP status in
+// its overrides map is dispositioned RPC-specifically; every other status — and
+// every non-HTTP transport error — falls through to classifyControlPlaneError.
+//
+// In principle any status may be overridden; in practice only the
+// operation-specific ones (404, 409) are, because those are the statuses whose
+// CSI meaning depends on the operation. Each RPC has a preconfigured instance
+// below, so an operation's full response→disposition table lives in one
+// declarative place instead of being scattered through the RPC body.
+type errorClassifier struct {
+	overrides map[int]controlPlaneErrorClass
+}
+
+// Classify maps a control-plane error to this RPC's disposition.
+func (c errorClassifier) Classify(err error) controlPlaneErrorClass {
+	var httpErr *util.HTTPError
+	if errors.As(err, &httpErr) {
+		if d, ok := c.overrides[httpErr.StatusCode]; ok {
+			return d
+		}
+	}
+	return classifyControlPlaneError(err)
+}
+
+// classifiedError is a control-plane error already classified for a specific RPC
+// (produced by the classify*Error functions). It IS an error and carries a gRPC
+// status, so a handler can return it directly and the gRPC layer unwraps it to
+// the right code via status.FromError:
+//
+//	if err := sbclient.DeleteSnapshot(ctx, id); err != nil {
+//	    ce := classifyDeleteSnapshotError(err)
+//	    if ce.IsSuccess() { return &csi.DeleteSnapshotResponse{}, nil } // 404 → gone
+//	    return nil, ce                                                  // 500 → Unavailable, …
+//	}
+//
+// Handlers MUST branch on IsSuccess()/IsIdempotent() before returning it: those
+// dispositions are not terminal errors (return the success response, or perform
+// the idempotency lookup, respectively).
+type classifiedError struct {
+	class controlPlaneErrorClass
+	err   error
+}
+
+var _ interface {
+	error
+	GRPCStatus() *status.Status
+} = classifiedError{}
+
+// IsIdempotent reports that the handler must resolve a conflict by looking up the
+// existing object (e.g. a 409 on create) before returning.
+func (c classifiedError) IsIdempotent() bool { return c.class.Idempotent }
+
+// IsSuccess reports that the error is a no-op for this RPC and it should return
+// success (e.g. a 404 on delete).
+func (c classifiedError) IsSuccess() bool { return c.class.Success }
+
+// Retryable reports whether retrying the operation can help.
+func (c classifiedError) Retryable() bool { return c.class.Retryable }
+
+// Error implements error.
+func (c classifiedError) Error() string {
+	if c.err != nil {
+		return c.err.Error()
+	}
+	return c.class.Code.String()
+}
+
+// GRPCStatus lets the gRPC layer (status.FromError) map this error to the correct
+// status code with no interceptor. An unresolved idempotent disposition reaching
+// here is a caller bug and surfaces as Internal rather than a silent OK.
+func (c classifiedError) GRPCStatus() *status.Status {
+	if c.class.Idempotent {
+		return status.Newf(codes.Internal, "idempotent conflict not resolved by caller: %v", c.err)
+	}
+	return status.New(c.class.Code, c.Error())
+}
+
+// Per-RPC convenience: classify a control-plane error for one operation.
+func classifyCreateVolumeError(err error) classifiedError {
+	return classifiedError{CreateVolumeErrorClassifier.Classify(err), err}
+}
+func classifyDeleteVolumeError(err error) classifiedError {
+	return classifiedError{DeleteVolumeErrorClassifier.Classify(err), err}
+}
+func classifyCreateSnapshotError(err error) classifiedError {
+	return classifiedError{CreateSnapshotErrorClassifier.Classify(err), err}
+}
+func classifyDeleteSnapshotError(err error) classifiedError {
+	return classifiedError{DeleteSnapshotErrorClassifier.Classify(err), err}
+}
+func classifyControllerExpandVolumeError(err error) classifiedError {
+	return classifiedError{ControllerExpandVolumeErrorClassifier.Classify(err), err}
+}
+func classifyControllerGetVolumeError(err error) classifiedError {
+	return classifiedError{ControllerGetVolumeErrorClassifier.Classify(err), err}
+}
+func classifyValidateVolumeCapabilitiesError(err error) classifiedError {
+	return classifiedError{ValidateVolumeCapabilitiesErrorClassifier.Classify(err), err}
+}
+func classifyListSnapshotsError(err error) classifiedError {
+	return classifiedError{ListSnapshotsErrorClassifier.Classify(err), err}
+}
+
+// Dispositions reused across RPCs.
+var (
+	// alreadyGone: a 404 means the object no longer exists → the operation is a
+	// no-op and succeeds (idempotent delete).
+	alreadyGone = controlPlaneErrorClass{Code: codes.OK, Success: true}
+	// sourceNotFound: a 404 means a referenced object (source volume/snapshot,
+	// or the target being expanded/inspected) does not exist → NotFound.
+	sourceNotFound = controlPlaneErrorClass{Code: codes.NotFound}
+	// resolveConflict: a 409 must be resolved by looking up the existing object
+	// (same source/params → return it as success; otherwise AlreadyExists).
+	resolveConflict = controlPlaneErrorClass{Idempotent: true}
+)
+
+// Preconfigured per-RPC classifiers. Every RPC that talks to the control plane
+// has one; generic statuses (5xx, timeout, 429, 4xx…) come from the shared
+// classifier, and only the operation-specific statuses are overridden here.
+var (
+	CreateVolumeErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: sourceNotFound,
+		http.StatusConflict: resolveConflict,
+	}}
+	DeleteVolumeErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: alreadyGone,
+	}}
+	CreateSnapshotErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: sourceNotFound,
+		http.StatusConflict: resolveConflict,
+	}}
+	DeleteSnapshotErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: alreadyGone,
+	}}
+
+	ControllerExpandVolumeErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: sourceNotFound,
+	}}
+	ControllerGetVolumeErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: sourceNotFound,
+	}}
+	ValidateVolumeCapabilitiesErrorClassifier = errorClassifier{overrides: map[int]controlPlaneErrorClass{
+		http.StatusNotFound: sourceNotFound,
+	}}
+
+	// ListSnapshotsErrorClassifier has no operation-specific statuses — every
+	// status is handled generically.
+	ListSnapshotsErrorClassifier = errorClassifier{}
+)

--- a/pkg/spdk/errorclass_rpc.go
+++ b/pkg/spdk/errorclass_rpc.go
@@ -1,13 +1,10 @@
 package spdk
 
 import (
-	"errors"
 	"net/http"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/spdk/spdk-csi/pkg/util"
 )
 
 // errorClassifier is a per-RPC control-plane response policy. Any HTTP status in
@@ -25,9 +22,8 @@ type errorClassifier struct {
 
 // Classify maps a control-plane error to this RPC's disposition.
 func (c errorClassifier) Classify(err error) controlPlaneErrorClass {
-	var httpErr *util.HTTPError
-	if errors.As(err, &httpErr) {
-		if d, ok := c.overrides[httpErr.StatusCode]; ok {
+	if code := httpStatusOf(err); code != 0 {
+		if d, ok := c.overrides[code]; ok {
 			return d
 		}
 	}

--- a/pkg/spdk/errorclass_rpc_test.go
+++ b/pkg/spdk/errorclass_rpc_test.go
@@ -1,0 +1,192 @@
+package spdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/spdk/spdk-csi/pkg/util"
+)
+
+// outcome is what a handler observes from a classifiedError: the gRPC code the
+// framework would transmit (via status.FromError) plus the branch flags.
+type outcome struct {
+	code       codes.Code
+	success    bool
+	idempotent bool
+	retryable  bool
+}
+
+// observe derives the handler-observable outcome from a disposition, mirroring
+// classifiedError.GRPCStatus (an unresolved idempotent conflict surfaces as
+// Internal) and the IsSuccess/IsIdempotent/Retryable accessors.
+func observe(d controlPlaneErrorClass) outcome {
+	code := d.Code
+	if d.Idempotent {
+		code = codes.Internal
+	}
+	return outcome{code: code, success: d.Success, idempotent: d.Idempotent, retryable: d.Retryable}
+}
+
+// TestRPCErrorClassifiers pins the complete response→disposition table for every
+// RPC, grouped by RPC. For every status + transport case it asserts BOTH:
+//
+//   - the raw disposition from classifier.Classify (the internal contract), and
+//   - the handler-observable outcome from classify*Error → classifiedError (the
+//     gRPC code the framework transmits, plus the branch flags).
+//
+// Each RPC inherits the shared generic table and overrides only the statuses
+// whose meaning is operation-specific. The generic table is pinned as literals
+// (not derived from classifyControlPlaneError), so changing a generic mapping,
+// an operation-specific override, or adding a new RPC that breaks the contract
+// all fail the test.
+func TestRPCErrorClassifiers(t *testing.T) {
+	rpcSpecificBug := controlPlaneErrorClass{Code: codes.Internal, RPCSpecific: true}
+
+	// Generic dispositions every RPC must inherit for non-404/409 statuses.
+	generic := map[int]controlPlaneErrorClass{
+		400: {Code: codes.InvalidArgument},
+		401: {Code: codes.Unauthenticated},
+		403: {Code: codes.PermissionDenied},
+		405: {Code: codes.FailedPrecondition},
+		406: {Code: codes.FailedPrecondition},
+		408: {Code: codes.Unavailable, Retryable: true},
+		410: {Code: codes.FailedPrecondition},
+		411: {Code: codes.FailedPrecondition},
+		412: {Code: codes.FailedPrecondition},
+		413: {Code: codes.FailedPrecondition},
+		414: {Code: codes.FailedPrecondition},
+		415: {Code: codes.FailedPrecondition},
+		422: {Code: codes.InvalidArgument},
+		429: {Code: codes.ResourceExhausted, Retryable: true},
+		500: {Code: codes.Unavailable, Retryable: true},
+		501: {Code: codes.Internal},
+		502: {Code: codes.Unavailable, Retryable: true},
+		503: {Code: codes.Unavailable, Retryable: true},
+		504: {Code: codes.Unavailable, Retryable: true},
+		505: {Code: codes.Internal},
+		507: {Code: codes.ResourceExhausted, Retryable: true},
+		508: {Code: codes.Internal},
+		511: {Code: codes.Internal},
+		599: {Code: codes.Internal},
+	}
+
+	// Generic transport failures (no HTTP status) every RPC must inherit.
+	genericTransport := []struct {
+		label string
+		err   error
+		want  controlPlaneErrorClass
+	}{
+		{"timeout", fmt.Errorf("POST: %w", context.DeadlineExceeded), controlPlaneErrorClass{Code: codes.DeadlineExceeded, Retryable: true}},
+		{"canceled", fmt.Errorf("POST: %w", context.Canceled), controlPlaneErrorClass{Code: codes.Canceled, Retryable: true}},
+		{"conn_refused", fmt.Errorf("POST: %w", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}), controlPlaneErrorClass{Code: codes.Unavailable, Retryable: true}},
+		{"unknown", errors.New("secret parse failed"), controlPlaneErrorClass{Code: codes.Internal}},
+	}
+
+	// Per-RPC overrides — the only statuses allowed to differ from generic. Any
+	// HTTP status may be overridden in principle; today only 404/409 are. A status
+	// that is neither overridden nor generic (an unhandled 404/409) must surface
+	// as an Internal (RPCSpecific) bug.
+	rpcs := []struct {
+		name       string
+		classifier errorClassifier
+		classify   func(error) classifiedError
+		overrides  map[int]controlPlaneErrorClass
+	}{
+		{"CreateVolume", CreateVolumeErrorClassifier, classifyCreateVolumeError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.NotFound}, 409: {Idempotent: true}}},
+		{"DeleteVolume", DeleteVolumeErrorClassifier, classifyDeleteVolumeError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.OK, Success: true}}},
+		{"CreateSnapshot", CreateSnapshotErrorClassifier, classifyCreateSnapshotError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.NotFound}, 409: {Idempotent: true}}},
+		{"DeleteSnapshot", DeleteSnapshotErrorClassifier, classifyDeleteSnapshotError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.OK, Success: true}}},
+		{"ControllerExpandVolume", ControllerExpandVolumeErrorClassifier, classifyControllerExpandVolumeError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.NotFound}}},
+		{"ControllerGetVolume", ControllerGetVolumeErrorClassifier, classifyControllerGetVolumeError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.NotFound}}},
+		{"ValidateVolumeCapabilities", ValidateVolumeCapabilitiesErrorClassifier, classifyValidateVolumeCapabilitiesError, map[int]controlPlaneErrorClass{
+			404: {Code: codes.NotFound}}},
+		{"ListSnapshots", ListSnapshotsErrorClassifier, classifyListSnapshotsError, nil},
+	}
+
+	for _, rpc := range rpcs {
+		// assert both the raw disposition and the observable handler outcome.
+		assert := func(t *testing.T, err error, want controlPlaneErrorClass, label string) {
+			t.Helper()
+			if got := rpc.classifier.Classify(err); got != want {
+				t.Errorf("%s: Classify = %+v, want %+v", label, got, want)
+			}
+			ce := rpc.classify(err)
+			got := outcome{code: status.Code(ce), success: ce.IsSuccess(), idempotent: ce.IsIdempotent(), retryable: ce.Retryable()}
+			if want := observe(want); got != want {
+				t.Errorf("%s: handler outcome = %+v, want %+v", label, got, want)
+			}
+		}
+
+		t.Run(rpc.name, func(t *testing.T) {
+			// Every HTTP status: override wins; else generic; else unhandled 404/409 → bug.
+			statuses := map[int]bool{404: true, 409: true}
+			for s := range generic {
+				statuses[s] = true
+			}
+			for s := range rpc.overrides {
+				statuses[s] = true
+			}
+			for code := range statuses {
+				want, ok := rpc.overrides[code]
+				if !ok {
+					if want, ok = generic[code]; !ok {
+						want = rpcSpecificBug
+					}
+				}
+				assert(t, &util.HTTPError{StatusCode: code}, want, fmt.Sprintf("HTTP %d", code))
+			}
+
+			// Every generic transport failure, inherited unchanged.
+			for _, tr := range genericTransport {
+				assert(t, tr.err, tr.want, tr.label)
+			}
+		})
+	}
+}
+
+// TestClassifyRPCErrorFunctions checks every per-RPC classify function delegates
+// to its classifier (and thereby exercises all of them).
+func TestClassifyRPCErrorFunctions(t *testing.T) {
+	err := &util.HTTPError{StatusCode: 404}
+	cases := []struct {
+		name       string
+		fn         func(error) classifiedError
+		classifier errorClassifier
+	}{
+		{"CreateVolume", classifyCreateVolumeError, CreateVolumeErrorClassifier},
+		{"DeleteVolume", classifyDeleteVolumeError, DeleteVolumeErrorClassifier},
+		{"CreateSnapshot", classifyCreateSnapshotError, CreateSnapshotErrorClassifier},
+		{"DeleteSnapshot", classifyDeleteSnapshotError, DeleteSnapshotErrorClassifier},
+		{"ControllerExpandVolume", classifyControllerExpandVolumeError, ControllerExpandVolumeErrorClassifier},
+		{"ControllerGetVolume", classifyControllerGetVolumeError, ControllerGetVolumeErrorClassifier},
+		{"ValidateVolumeCapabilities", classifyValidateVolumeCapabilitiesError, ValidateVolumeCapabilitiesErrorClassifier},
+		{"ListSnapshots", classifyListSnapshotsError, ListSnapshotsErrorClassifier},
+	}
+	for _, tc := range cases {
+		got := tc.fn(err)
+		if got.class != tc.classifier.Classify(err) || got.err != err {
+			t.Errorf("%s: classify function does not delegate to its classifier", tc.name)
+		}
+	}
+}
+
+// TestClassifiedError_MessagePreserved checks the underlying message survives for
+// diagnostics.
+func TestClassifiedError_MessagePreserved(t *testing.T) {
+	underlying := &util.HTTPError{Method: "POST", StatusCode: 400, Message: "bad thing"}
+	if d := classifyCreateVolumeError(underlying); d.Error() != underlying.Error() {
+		t.Errorf("Error() = %q, want %q", d.Error(), underlying.Error())
+	}
+}

--- a/pkg/spdk/errorclass_test.go
+++ b/pkg/spdk/errorclass_test.go
@@ -1,0 +1,142 @@
+package spdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/spdk/spdk-csi/pkg/util"
+)
+
+func TestClassifyControlPlaneError_HTTPStatuses(t *testing.T) {
+	tests := []struct {
+		status      int
+		wantCode    codes.Code
+		retryable   bool
+		rpcSpecific bool
+	}{
+		// Retryable server errors + request timeout.
+		{500, codes.Unavailable, true, false},
+		{502, codes.Unavailable, true, false},
+		{503, codes.Unavailable, true, false},
+		{504, codes.Unavailable, true, false},
+		{408, codes.Unavailable, true, false},
+
+		// Backpressure / capacity.
+		{429, codes.ResourceExhausted, true, false},
+		{507, codes.ResourceExhausted, true, false},
+
+		// Operation-specific — the RPC must handle these, not generic classification.
+		{404, codes.Internal, false, true},
+		{409, codes.Internal, false, true},
+
+		// Permanent client errors — never retryable.
+		{400, codes.InvalidArgument, false, false},
+		{401, codes.Unauthenticated, false, false},
+		{403, codes.PermissionDenied, false, false},
+		{405, codes.FailedPrecondition, false, false}, // method not allowed
+		{406, codes.FailedPrecondition, false, false}, // not acceptable
+		{410, codes.FailedPrecondition, false, false}, // gone
+		{411, codes.FailedPrecondition, false, false}, // length required
+		{412, codes.FailedPrecondition, false, false}, // precondition failed
+		{413, codes.FailedPrecondition, false, false}, // payload too large
+		{414, codes.FailedPrecondition, false, false}, // URI too long
+		{415, codes.FailedPrecondition, false, false}, // unsupported media type
+		{422, codes.InvalidArgument, false, false},    // unprocessable entity
+
+		// Permanent server errors — never retryable.
+		{501, codes.Internal, false, false}, // not implemented
+		{505, codes.Internal, false, false}, // HTTP version not supported
+		{508, codes.Internal, false, false}, // loop detected
+		{511, codes.Internal, false, false}, // network auth required
+		{599, codes.Internal, false, false}, // unlisted 5xx → permanent
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("HTTP_%d", tc.status), func(t *testing.T) {
+			err := &util.HTTPError{Method: "POST", StatusCode: tc.status, Message: "boom"}
+			got := classifyControlPlaneError(err)
+			if got.Code != tc.wantCode {
+				t.Errorf("HTTP %d: code = %s, want %s", tc.status, got.Code, tc.wantCode)
+			}
+			if got.Retryable != tc.retryable {
+				t.Errorf("HTTP %d: retryable = %v, want %v", tc.status, got.Retryable, tc.retryable)
+			}
+			if got.RPCSpecific != tc.rpcSpecific {
+				t.Errorf("HTTP %d: rpcSpecific = %v, want %v", tc.status, got.RPCSpecific, tc.rpcSpecific)
+			}
+		})
+	}
+}
+
+func TestClassifyControlPlaneError_NoClientErrorIsRetryable(t *testing.T) {
+	// Guard rail: no 4xx except 408/429 may be classified as retryable. (404/409
+	// are RPCSpecific and non-retryable at the generic layer.)
+	retryable4xx := map[int]bool{408: true, 429: true}
+	for status := 400; status < 500; status++ {
+		got := classifyControlPlaneError(&util.HTTPError{StatusCode: status})
+		if got.Retryable && !retryable4xx[status] {
+			t.Errorf("HTTP %d must not be retryable (code %s)", status, got.Code)
+		}
+	}
+}
+
+func TestClassifyControlPlaneError_TransportErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantCode  codes.Code
+		retryable bool
+	}{
+		{
+			// The exact failure mode from the incident logs.
+			name:      "context deadline exceeded (wrapped, as jsonrpc do() returns it)",
+			err:       fmt.Errorf("POST: %w", context.DeadlineExceeded),
+			wantCode:  codes.DeadlineExceeded,
+			retryable: true,
+		},
+		{
+			name:      "context canceled",
+			err:       fmt.Errorf("POST: %w", context.Canceled),
+			wantCode:  codes.Canceled,
+			retryable: true,
+		},
+		{
+			name:      "connection refused (real net.Error)",
+			err:       fmt.Errorf("POST: %w", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}),
+			wantCode:  codes.Unavailable,
+			retryable: true,
+		},
+		{
+			// An unknown, non-transport error (e.g. secret parse / unmarshal bug)
+			// must NOT be mistaken for a retryable transport failure.
+			name:      "unknown non-transport error",
+			err:       fmt.Errorf("failed to parse secret file: %w", errors.New("unexpected end of JSON input")),
+			wantCode:  codes.Internal,
+			retryable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyControlPlaneError(tc.err)
+			if got.Code != tc.wantCode {
+				t.Errorf("code = %s, want %s", got.Code, tc.wantCode)
+			}
+			if got.Retryable != tc.retryable {
+				t.Errorf("retryable = %v, want %v", got.Retryable, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestClassifyControlPlaneError_Nil(t *testing.T) {
+	got := classifyControlPlaneError(nil)
+	if got.Code != codes.OK || got.Retryable {
+		t.Errorf("nil error: got %+v, want {OK false}", got)
+	}
+}

--- a/pkg/spdk/mock_sbcli_test.go
+++ b/pkg/spdk/mock_sbcli_test.go
@@ -14,16 +14,25 @@ import (
 )
 
 const (
-	sanityClusterID = "test-cluster"
+	sanityClusterID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	sanityPoolName  = "test-pool"
 	sanityPoolUUID  = "11111111-1111-1111-1111-111111111111"
 	sanitySecret    = "test-secret"
 )
 
 type mockVolume struct {
-	UUID string
-	Name string
-	Size int64
+	UUID   string
+	Name   string
+	Size   int64
+	Status string // defaults to "online" when empty
+}
+
+// status returns the volume's reported status, defaulting to "online".
+func (v *mockVolume) status() string {
+	if v.Status == "" {
+		return "online"
+	}
+	return v.Status
 }
 
 type mockSnapshot struct {
@@ -39,6 +48,46 @@ type mockSBCLI struct {
 	mu        sync.Mutex
 	volumes   map[string]*mockVolume
 	snapshots map[string]*mockSnapshot
+
+	// failCreateOnce, when true, makes the next createVolume call respond with
+	// HTTP 500 without persisting the lvol. This mimics the control plane
+	// failing volume creation: the lvol never comes into existence, yet a
+	// broken PersistentVolume can be left dangling on the Kubernetes side.
+	failCreateOnce bool
+
+	// snapshotCreateStatus, when non-zero, makes every snapshot POST respond
+	// with this HTTP status without persisting. Used to model permanent
+	// control-plane errors (e.g. HTTP 400) during snapshot creation.
+	snapshotCreateStatus int
+
+	// strictSnapshotNameConflict makes the snapshot POST return HTTP 409 for any
+	// existing snapshot that shares the requested name, regardless of its source
+	// volume — the non-idempotent behavior the real web API exhibits under load.
+	strictSnapshotNameConflict bool
+
+	// allowDuplicateNames disables the create-volume name-conflict check, modeling
+	// a control plane that does NOT enforce volume-name uniqueness. Under this
+	// mode a driver that relies on the control plane for idempotency leaks a new
+	// volume on every retry.
+	allowDuplicateNames bool
+
+	// failGetVolume makes GET .../volumes/{id}/ respond with HTTP 500. The
+	// controller's publishVolume step is a GET, so this fails CreateVolume
+	// *after* the volume has already been created.
+	failGetVolume bool
+
+	// failIf, when set, is consulted on every request before its handler runs;
+	// returning true makes the mock respond HTTP 500 without running the handler.
+	// It lets a test fail every API except a chosen one — a future-proof way to
+	// assert an RPC performs no ordering-sensitive call (e.g. that CreateSnapshot
+	// creates the snapshot only after every other API call has succeeded).
+	failIf func(r *http.Request) bool
+
+	// injectStatus, when set, is consulted before each handler; a non-zero return
+	// makes the mock respond with that HTTP status without running the handler.
+	// It lets a test drive an RPC through every control-plane response and assert
+	// the resulting gRPC code.
+	injectStatus func(r *http.Request) int
 }
 
 func newMockSBCLI() *mockSBCLI {
@@ -48,16 +97,16 @@ func newMockSBCLI() *mockSBCLI {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/",                                    m.locked(m.handleListPools))
-	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/",                   m.locked(m.handleListVolumes))
-	mux.HandleFunc("POST /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/",                  m.locked(m.createVolume))
-	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/",        m.locked(m.handleGetVolume))
-	mux.HandleFunc("DELETE /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/",     m.locked(m.handleDeleteVolume))
-	mux.HandleFunc("PUT /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/",        m.locked(m.handleResizeVolume))
+	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/", m.locked(m.handleListPools))
+	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/", m.locked(m.handleListVolumes))
+	mux.HandleFunc("POST /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/", m.locked(m.createVolume))
+	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/", m.locked(m.handleGetVolume))
+	mux.HandleFunc("DELETE /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/", m.locked(m.handleDeleteVolume))
+	mux.HandleFunc("PUT /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/", m.locked(m.handleResizeVolume))
 	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/connect", m.locked(m.handleVolumeConnect))
 	mux.HandleFunc("POST /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/snapshots", m.locked(m.handleCreateSnapshot))
-	mux.HandleFunc("POST /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/clone",  m.locked(m.handleCloneVolume))
-	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/snapshots/",                 m.locked(m.handleListSnapshots))
+	mux.HandleFunc("POST /api/v2/clusters/{clusterID}/storage-pools/{poolID}/volumes/{volumeID}/clone", m.locked(m.handleCloneVolume))
+	mux.HandleFunc("GET /api/v2/clusters/{clusterID}/storage-pools/{poolID}/snapshots/", m.locked(m.handleListSnapshots))
 	mux.HandleFunc("DELETE /api/v2/clusters/{clusterID}/storage-pools/{poolID}/snapshots/{snapshotID}/", m.locked(m.handleDeleteSnapshot))
 
 	m.srv = httptest.NewServer(mux)
@@ -72,6 +121,16 @@ func (m *mockSBCLI) locked(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
+		if m.failIf != nil && m.failIf(r) {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"detail": "injected failure"})
+			return
+		}
+		if m.injectStatus != nil {
+			if code := m.injectStatus(r); code != 0 {
+				writeJSON(w, code, map[string]string{"detail": "injected status"})
+				return
+			}
+		}
 		h(w, r)
 	}
 }
@@ -112,19 +171,23 @@ func (m *mockSBCLI) handleListVolumes(w http.ResponseWriter, _ *http.Request) {
 	list := make([]map[string]any, 0, len(m.volumes))
 	for _, volume := range m.volumes {
 		list = append(list, map[string]any{
-			"id": volume.UUID, "name": volume.Name, "size": volume.Size, "status": "online",
+			"id": volume.UUID, "name": volume.Name, "size": volume.Size, "status": volume.status(),
 		})
 	}
 	writeJSON(w, http.StatusOK, list)
 }
 
 func (m *mockSBCLI) handleGetVolume(w http.ResponseWriter, r *http.Request) {
+	if m.failGetVolume {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"detail": "get volume failed"})
+		return
+	}
 	volume := m.lookupVolume(w, r.PathValue("volumeID"))
 	if volume == nil {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"id": volume.UUID, "name": volume.Name, "size": volume.Size, "status": "online",
+		"id": volume.UUID, "name": volume.Name, "size": volume.Size, "status": volume.status(),
 	})
 }
 
@@ -179,19 +242,26 @@ func (m *mockSBCLI) handleCreateSnapshot(w http.ResponseWriter, r *http.Request)
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
 
+	// Simulate a permanent control-plane rejection (e.g. HTTP 400) without
+	// persisting anything.
+	if m.snapshotCreateStatus != 0 {
+		writeJSON(w, m.snapshotCreateStatus, map[string]string{"detail": "snapshot create rejected"})
+		return
+	}
+
 	// Idempotency: check if a snapshot with this name already exists.
 	for _, snapshot := range m.snapshots {
 		if snapshot.Name != body.Name {
 			continue
 		}
-		if snapshot.VolUUID == volumeID {
+		if snapshot.VolUUID == volumeID && !m.strictSnapshotNameConflict {
 			// Same source → idempotent success, return existing location.
 			w.Header().Set("Location", fmt.Sprintf("/api/v2/clusters/%s/storage-pools/%s/snapshots/%s/",
 				sanityClusterID, sanityPoolUUID, snapshot.UUID))
 			w.WriteHeader(http.StatusCreated)
 			return
 		}
-		// Different source → conflict.
+		// Different source (or strict mode: any duplicate name) → conflict.
 		writeJSON(w, http.StatusConflict, map[string]string{"detail": "snapshot name already exists"})
 		return
 	}
@@ -251,12 +321,14 @@ func (m *mockSBCLI) createVolume(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
 
-	for _, volume := range m.volumes {
-		if volume.Name == body.Name {
-			writeJSON(w, http.StatusConflict, map[string]string{
-				"detail": "Volume " + body.Name + " exists",
-			})
-			return
+	if !m.allowDuplicateNames {
+		for _, volume := range m.volumes {
+			if volume.Name == body.Name {
+				writeJSON(w, http.StatusConflict, map[string]string{
+					"detail": "Volume " + body.Name + " exists",
+				})
+				return
+			}
 		}
 	}
 
@@ -280,6 +352,15 @@ func (m *mockSBCLI) createVolume(w http.ResponseWriter, r *http.Request) {
 	}
 
 	newID := uuid.New().String()
+
+	// Simulate the control plane failing the create request without persisting
+	// the lvol: the client sees an error and no volume comes into existence.
+	if m.failCreateOnce {
+		m.failCreateOnce = false
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"detail": "internal error creating volume"})
+		return
+	}
+
 	m.volumes[newID] = &mockVolume{UUID: newID, Name: body.Name, Size: size}
 	w.Header().Set("Location", fmt.Sprintf("/api/v2/clusters/%s/storage-pools/%s/volumes/%s/",
 		sanityClusterID, sanityPoolUUID, newID))

--- a/pkg/spdk/mock_sbcli_test.go
+++ b/pkg/spdk/mock_sbcli_test.go
@@ -60,6 +60,11 @@ type mockSBCLI struct {
 	// control-plane errors (e.g. HTTP 400) during snapshot creation.
 	snapshotCreateStatus int
 
+	// snapshotCreatePersistThenFail, when true, makes the next snapshot POST
+	// persist the snapshot but respond HTTP 500 — the ambiguous timeout where the
+	// control plane created the snapshot but the client never saw success.
+	snapshotCreatePersistThenFail bool
+
 	// strictSnapshotNameConflict makes the snapshot POST return HTTP 409 for any
 	// existing snapshot that shares the requested name, regardless of its source
 	// volume — the non-idempotent behavior the real web API exhibits under load.
@@ -246,6 +251,15 @@ func (m *mockSBCLI) handleCreateSnapshot(w http.ResponseWriter, r *http.Request)
 	// persisting anything.
 	if m.snapshotCreateStatus != 0 {
 		writeJSON(w, m.snapshotCreateStatus, map[string]string{"detail": "snapshot create rejected"})
+		return
+	}
+
+	// Simulate an ambiguous timeout: persist the snapshot, then fail the response.
+	if m.snapshotCreatePersistThenFail {
+		m.snapshotCreatePersistThenFail = false
+		id := uuid.New().String()
+		m.snapshots[id] = &mockSnapshot{UUID: id, Name: body.Name, VolUUID: volumeID, Size: volume.Size, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"detail": "created but response lost"})
 		return
 	}
 


### PR DESCRIPTION
~200 unit tests added to ensure correct HTTP status code to GRPC error mapping and required fixes for green tests.

This PR adds a quite massive ~200 unit tests battery for correctness checks on HTTP status codes for all CreateXYZ, DeleteXYZ, ExpandVolume, VolumeCapabilities.

To unify error mapping between HTTP status codes (and errors such as timeout exceeded and connection refused from the control plane), this PR adds a general error classification with default mappings and specific overrides per RPC call where required.

Furthermore, this PR fixes issues found along the way, such as broken idempotency, wrong mappings, dangling snapshots if the volume size request failed after creating a snapshot, and more.

```
  ┌─────────────────────────────────────────────────────────┬──────────┬────────┐                                                                                                                                                        
  │                          Test                           │ Subtests │ Result │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ Classifier layer                                        │          │        │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestClassifyControlPlaneError_HTTPStatuses              │ 26       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestClassifyControlPlaneError_TransportErrors           │ 4        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestClassifyControlPlaneError_NoClientErrorIsRetryable  │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestClassifyControlPlaneError_Nil                       │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestRPCErrorClassifiers                                 │ 8        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestClassifyRPCErrorFunctions                           │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestClassifiedError_MessagePreserved                    │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ Response matrices (~27 each)                            │          │        │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateVolume_ControlPlaneErrorMapping               │ 27       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestDeleteVolume_ControlPlaneErrorMapping               │ 27       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestControllerExpandVolume_ControlPlaneErrorMapping     │ 27       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestValidateVolumeCapabilities_ControlPlaneErrorMapping │ 27       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateSnapshot_ControlPlaneErrorMapping             │ 29       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestDeleteSnapshot_ControlPlaneErrorMapping             │ 27       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestListSnapshots_ControlPlaneErrorMapping              │ 27       │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ Reconciliation / ordering                               │          │        │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateVolume_ReconcilesLeftoverOnRetry              │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateVolume_RetryRecoversFromBrokenVolume          │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateSnapshot_ReconcilesLeftoverOnRetry            │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateSnapshot_NoAPICallBeforeMetadataResolved      │ 2        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestCreateVolumeFromSnapshot_ReconcilesLeftoverOnRetry  │ —        │ ✅     │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ Provisioner (integration)                               │          │        │                                                                                                                                                        
  ├─────────────────────────────────────────────────────────┼──────────┼────────┤                                                                                                                                                        
  │ TestProvisioning_RetryIsIdempotentUnderNameUniqueness   │ —        │ ✅     │                                                                                                                                                        
  └─────────────────────────────────────────────────────────┴──────────┴────────┘                                                                                                                                                        
