### PR TITLE
add grype ignore for FIPS compliance vulnerabilies

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,20 @@
+# Grype ignore rules
+# https://github.com/anchore/grype#specifying-matches-to-ignore
+ignore:
+  # All entries below are FIPS-mode advisories (fixed-in version carries a _fips suffix).
+  # The installed non-FIPS packages (openssl 1:3.5.5-4.0.1.el9_8, gnutls 3.8.10-4.el9_8)
+  # are already at the latest OL9 non-FIPS release. Switching to a FIPS-enabled base image
+  # is a separate decision and out of scope for routine CVE patching.
+
+  # openssl / openssl-libs
+  - vulnerability: ELSA-2024-12675   # fixed only in 3.0.7-28.0.1.el9_4_fips
+  - vulnerability: ELSA-2025-28011   # fixed only in 3.5.1-4.0.2.el9_7_fips
+  - vulnerability: ELSA-2026-50345   # fixed only in 3.5.5-3.0.1.el9_8_fips
+  - vulnerability: ELSA-2026-50075   # fixed only in 3.5.1-7.0.1.el9_7_fips
+
+  # gnutls
+  - vulnerability: ELSA-2024-12336   # fixed only in 3.7.6-23.el9_3.4_fips
+  - vulnerability: ELSA-2026-50346   # fixed only in 3.8.10-4.el9_8_fips
+  - vulnerability: ELSA-2025-20606   # fixed only in 3.8.3-6.el9_6.2_fips
+  - vulnerability: ELSA-2024-12364   # fixed only in 3.8.3-4.el9_4_fips
+  - vulnerability: ELSA-2026-50149   # fixed only in 3.8.3-10.el9_7_fips


### PR DESCRIPTION
These vulnerabilities are already known and are false positives. So adding them to ignore rules. 

```

openssl       1:3.5.5-4.0.1.el9_8  10:3.0.7-28.0.1.el9_4_fips  rpm   ELSA-2024-12675  Medium    66.6% (99th)  33.3  
openssl-libs  1:3.5.5-4.0.1.el9_8  10:3.0.7-28.0.1.el9_4_fips  rpm   ELSA-2024-12675  Medium    66.6% (99th)  33.3  
openssl       1:3.5.5-4.0.1.el9_8  10:3.5.1-4.0.2.el9_7_fips   rpm   ELSA-2025-28011  Medium    1.7% (75th)   0.9   
openssl-libs  1:3.5.5-4.0.1.el9_8  10:3.5.1-4.0.2.el9_7_fips   rpm   ELSA-2025-28011  Medium    1.7% (75th)   0.9   
gnutls        3.8.10-4.el9_8       10:3.7.6-23.el9_3.4_fips    rpm   ELSA-2024-12336  Medium    1.6% (73rd)   0.8   
gnutls        3.8.10-4.el9_8       10:3.8.10-4.el9_8_fips      rpm   ELSA-2026-50346  High      0.8% (52nd)   0.6   
gnutls        3.8.10-4.el9_8       10:3.8.3-6.el9_6.2_fips     rpm   ELSA-2025-20606  Medium    1.2% (64th)   0.6   
openssl       1:3.5.5-4.0.1.el9_8  10:3.5.5-3.0.1.el9_8_fips   rpm   ELSA-2026-50345  Medium    0.8% (52nd)   0.4   
openssl-libs  1:3.5.5-4.0.1.el9_8  10:3.5.5-3.0.1.el9_8_fips   rpm   ELSA-2026-50345  Medium    0.8% (52nd)   0.4   
openssl       1:3.5.5-4.0.1.el9_8  10:3.5.1-7.0.1.el9_7_fips   rpm   ELSA-2026-50075  High      47.6% (98th)  0.4   
openssl-libs  1:3.5.5-4.0.1.el9_8  10:3.5.1-7.0.1.el9_7_fips   rpm   ELSA-2026-50075  High      47.6% (98th)  0.4   
gnutls        3.8.10-4.el9_8       10:3.8.3-4.el9_4_fips       rpm   ELSA-2024-12364  Medium    0.7% (49th)   0.4   
gnutls        3.8.10-4.el9_8       10:3.8.3-10.el9_7_fips      rpm   ELSA-2026-50149  Medium    0.6% (46th)   0.3  
```

successful scan
https://github.com/simplyblock/simplyblock-csi/actions/runs/28851066967/job/85566256822

