### PR TITLE
feat: skip Guardian auto-restart for volumes with shared NVMe subsystem

### DIFF
--- a/charts/spdk-csi/latest/spdk-csi/templates/node-rbac.yaml
+++ b/charts/spdk-csi/latest/spdk-csi/templates/node-rbac.yaml
@@ -33,6 +33,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/node-rbac.yaml
+++ b/deploy/kubernetes/node-rbac.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/pkg/util/guardian.go
+++ b/pkg/util/guardian.go
@@ -481,6 +481,19 @@ func (g *Guardian) tick(ctx context.Context) {
 					continue
 				}
 
+				// Suppress restart when the pod's volume uses a namespaced NVMe
+				// subsystem (max_namespace_per_subsys > 1 in the StorageClass).
+				// Restarting the pod would tear down the shared subsystem and
+				// knock out NVMe-oF paths of every other volume on it.
+				if g.podUsesNamespacedSubsystem(ctx, &pod) {
+					klog.Warningf("Guardian: suppressing auto-restart for pod %s/%s (uid=%s, lvol=%s): "+
+						"volume shares an NVMe subsystem (max_namespace_per_subsys > 1); "+
+						"restarting would disrupt other volumes on the same subsystem",
+						pod.Namespace, pod.Name, podUID, lvolID)
+					g.emitSharedSubsystemEvent(ctx, &pod)
+					continue
+				}
+
 				// if pod.Labels[g.cfg.OptOutLabelKey] == g.cfg.OptOutLabelValue {
 				// 	continue
 				// }
@@ -775,4 +788,109 @@ func (g *Guardian) podUsesOptedInSimplyBlockStorageClass(ctx context.Context, po
 	}
 
 	return false, nil
+}
+
+// podUsesNamespacedSubsystem returns true if any of the pod's simplyblock PVCs
+// use a StorageClass with max_namespace_per_subsys > 1. Such volumes share an
+// NVMe subsystem with other volumes, so restarting the pod would tear down the
+// shared subsystem and disrupt every other volume on it.
+func (g *Guardian) podUsesNamespacedSubsystem(ctx context.Context, pod *v1.Pod) bool {
+	seenPVCs := map[string]struct{}{}
+	seenSCs := map[string]struct{}{}
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.PersistentVolumeClaim == nil {
+			continue
+		}
+		pvcName := strings.TrimSpace(vol.PersistentVolumeClaim.ClaimName)
+		if pvcName == "" {
+			continue
+		}
+		pvcKey := pod.Namespace + "/" + pvcName
+		if _, seen := seenPVCs[pvcKey]; seen {
+			continue
+		}
+		seenPVCs[pvcKey] = struct{}{}
+
+		pvc, err := g.manager.PersistentVolumeClaimByNamespaceAndName(ctx, pod.Namespace, pvcName)
+		if err != nil {
+			klog.Warningf("Guardian: podUsesNamespacedSubsystem: PVC %s: %v", pvcKey, err)
+			continue
+		}
+
+		pvName := strings.TrimSpace(pvc.Spec.VolumeName)
+		if pvName == "" {
+			continue
+		}
+
+		pv, err := g.manager.PersistentVolumeByName(ctx, pvName)
+		if err != nil {
+			klog.Warningf("Guardian: podUsesNamespacedSubsystem: PV %s: %v", pvName, err)
+			continue
+		}
+		if pv.Spec.CSI == nil || strings.TrimSpace(pv.Spec.CSI.Driver) != g.cfg.CSIDriverName {
+			continue
+		}
+
+		scName := ""
+		if pvc.Spec.StorageClassName != nil {
+			scName = strings.TrimSpace(*pvc.Spec.StorageClassName)
+		}
+		if scName == "" {
+			scName = strings.TrimSpace(pvc.Annotations["volume.beta.kubernetes.io/storage-class"])
+		}
+		if scName == "" {
+			continue
+		}
+		if _, seen := seenSCs[scName]; seen {
+			continue
+		}
+		seenSCs[scName] = struct{}{}
+
+		sc, err := g.cs.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
+		if err != nil {
+			klog.Warningf("Guardian: podUsesNamespacedSubsystem: StorageClass %s: %v", scName, err)
+			continue
+		}
+
+		if v, ok := sc.Parameters["max_namespace_per_subsys"]; ok {
+			n := 0
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// emitSharedSubsystemEvent records a Warning event on the pod explaining that
+// auto-restart was skipped because the volume shares an NVMe subsystem.
+func (g *Guardian) emitSharedSubsystemEvent(ctx context.Context, pod *v1.Pod) {
+	now := metav1.Now()
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "guardian-shared-subsystem-",
+			Namespace:    pod.Namespace,
+		},
+		InvolvedObject: v1.ObjectReference{
+			Kind:       "Pod",
+			Namespace:  pod.Namespace,
+			Name:       pod.Name,
+			UID:        pod.UID,
+			APIVersion: "v1",
+		},
+		Reason:  "AutoRestartSuppressed",
+		Message: "Guardian auto-restart skipped: volume shares an NVMe subsystem (max_namespace_per_subsys > 1). Restarting this pod would tear down the shared NVMe-oF paths used by other volumes on the same subsystem. Resolve the pathloss manually.",
+		Type:    v1.EventTypeWarning,
+		Source: v1.EventSource{
+			Component: "guardian",
+		},
+		FirstTimestamp:      now,
+		LastTimestamp:       now,
+		Count: 1,
+	}
+	if _, err := g.cs.CoreV1().Events(pod.Namespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+		klog.Warningf("Guardian: failed to emit AutoRestartSuppressed event for pod %s/%s: %v",
+			pod.Namespace, pod.Name, err)
+	}
 }


### PR DESCRIPTION
fixes: [issue-299](https://github.com/simplyblock/simplyblock-operator/issues/299)

```
W0708 13:45:56.397089       1 guardian.go:420] Guardian: cluster=ca075f38-3856-491f-a3bc-ad8297f7870e transitioned to active; will evaluate pod restarts
W0708 13:45:56.418745       1 guardian.go:469] Guardian: cluster ca075f38-3856-491f-a3bc-ad8297f7870e active; attempting restarts for broken lvols=[1942f842-5af3-4f38-b2fc-440df2af2e1e]
W0708 13:45:56.418808       1 guardian.go:472] Guardian debug: lvol=1942f842-5af3-4f38-b2fc-440df2af2e1e podUIDs=[a44a7852-6cfe-4561-af13-b8180daa472e a8e689a1-6245-42fd-bc69-c3b357cf19d6]
I0708 13:45:56.425065       1 guardian.go:784] Guardian: pod default/spdkcsi-test2-564fcbf97d-hc9d6 opted in via Simplyblock StorageClass simplyblock-simplyblock-simplyblock-cluster-simplyblock-pool (driver=csi.simplyblock.io)
W0708 13:45:56.428610       1 guardian.go:489] Guardian: suppressing auto-restart for pod default/spdkcsi-test2-564fcbf97d-hc9d6 (uid=a44a7852-6cfe-4561-af13-b8180daa472e, lvol=1942f842-5af3-4f38-b2fc-440df2af2e1e): volume shares an NVMe subsystem (max_namespace_per_subsys > 1); restarting would disrupt other volumes on the same subsystem
I0708 13:45:56.440469       1 guardian.go:784] Guardian: pod default/spdkcsi-test-66cfbc8d68-5c6kh opted in via Simplyblock StorageClass simplyblock-simplyblock-simplyblock-cluster-simplyblock-pool (driver=csi.simplyblock.io)
W0708 13:45:56.443614       1 guardian.go:489] Guardian: suppressing auto-restart for pod default/spdkcsi-test-66cfbc8d68-5c6kh (uid=a8e689a1-6245-42fd-bc69-c3b357cf19d6, lvol=1942f842-5af3-4f38-b2fc-440df2af2e1e): volume shares an NVMe subsystem (max_namespace_per_subsys > 1); restarting would disrupt other volumes on the same subsystem
```
 the pod(workload) event 
 ```
 Events:
  Type     Reason                  Age   From                     Message
  ----     ------                  ----  ----                     -------
  Normal   Scheduled               20m   default-scheduler        Successfully assigned default/spdkcsi-test-66cfbc8d68-5c6kh to vm01.simplyblock3.localdomain
  Normal   SuccessfulAttachVolume  20m   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-e511fb78-f92e-4c7e-95cc-473fae54af81"
  Warning  FailedMount             20m   kubelet                  MountVolume.MountDevice failed for volume "pvc-e511fb78-f92e-4c7e-95cc-473fae54af81" : rpc error: code = Internal desc = failed to connect to any NVMe path for NQN nqn.2023-02.io.simplyblock:ca075f38-3856-491f-a3bc-ad8297f7870e:lvol:1942f842-5af3-4f38-b2fc-440df2af2e1e: error: exit status 1: already connected
  Normal   Pulled                  20m   kubelet                  Container image "simplyblock/alpine-tools:3.21.3" already present on machine and can be accessed by the pod
  Normal   Created                 20m   kubelet                  Container created
  Normal   Started                 20m   kubelet                  Container started
  Warning  AutoRestartSuppressed   74s   guardian                 Guardian auto-restart skipped: volume shares an NVMe subsystem (max_namespace_per_subsys > 1). Restarting this pod would tear down the shared NVMe-oF paths used by other volumes on the same subsystem. Resolve the pathloss manually.
 ```