### PR TITLE
csi: allow provisioning on nodes without topology labels

### DIFF
--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -152,26 +152,29 @@ func (cs *controllerServer) resolveClusterSelection(req *csi.CreateVolumeRequest
 		if sel := tryList(topoReq.GetRequisite()); sel != nil {
 			return sel, nil
 		}
-	}
-
-	// No topology requirements (node has no topology labels) or no matching
-	// zone/region found. Fall back to a single-cluster configuration — if all
-	// zone/region entries point to the same cluster, use it. This allows nodes
-	// without topology labels to provision volumes without error.
-	uniqueClusters := map[string]struct{}{}
-	for _, id := range zoneMap {
-		uniqueClusters[id] = struct{}{}
-	}
-	for _, id := range regionMap {
-		uniqueClusters[id] = struct{}{}
-	}
-	if len(uniqueClusters) == 1 {
-		for id := range uniqueClusters {
-			return &clusterSelection{clusterID: id}, nil
+		// Topology was provided but contains no zone or region key recognised by
+		// the StorageClass map. This means the worker node is missing the required
+		// topology labels.
+		nodeName := nodeNameFromTopology(topoReq.GetPreferred())
+		if nodeName == "" {
+			nodeName = nodeNameFromTopology(topoReq.GetRequisite())
 		}
+		return nil, fmt.Errorf(
+			"node %q has no %s or %s topology label but the StorageClass uses %s/%s "+
+				"for cluster routing; add the appropriate zone or region label to the node, "+
+				"or switch the StorageClass to use %s",
+			nodeName, topologyKeyZoneStable, topologyKeyRegionStable,
+			paramZoneClusterMap, paramRegionClusterMap, paramClusterID,
+		)
 	}
 
-	return nil, fmt.Errorf("no cluster mapping found for topology requirements and no unambiguous fallback cluster (found %d distinct clusters)", len(uniqueClusters))
+	return nil, fmt.Errorf(
+		"no topology requirements received; the StorageClass uses %s or %s for cluster "+
+			"routing but the node has no topology labels — add %s or %s labels to the node, "+
+			"or switch the StorageClass to use %s",
+		paramZoneClusterMap, paramRegionClusterMap,
+		topologyKeyZoneStable, topologyKeyRegionStable, paramClusterID,
+	)
 }
 
 func parseStringMap(raw, paramName string) (map[string]string, error) {
@@ -199,6 +202,20 @@ func parseStringMap(raw, paramName string) (map[string]string, error) {
 		return nil, fmt.Errorf("%s parameter did not contain any mappings", paramName)
 	}
 	return normalized, nil
+}
+
+// nodeNameFromTopology extracts the node name from the simplyblock hostname
+// fallback topology key set by the node plugin when no zone/region labels exist.
+func nodeNameFromTopology(topos []*csi.Topology) string {
+	for _, topo := range topos {
+		if topo == nil {
+			continue
+		}
+		if name, ok := topo.GetSegments()["topology.simplyblock.io/hostname"]; ok && name != "" {
+			return name
+		}
+	}
+	return "unknown"
 }
 
 func matchTopologyWithRegionMap(topo *csi.Topology, regionMap map[string]string) *clusterSelection {

--- a/pkg/spdk/controllerserver.go
+++ b/pkg/spdk/controllerserver.go
@@ -132,9 +132,6 @@ func (cs *controllerServer) resolveClusterSelection(req *csi.CreateVolumeRequest
 	}
 
 	topoReq := req.GetAccessibilityRequirements()
-	if topoReq == nil {
-		return nil, fmt.Errorf("topology requirements are required when using %s", paramZoneClusterMap)
-	}
 
 	tryList := func(list []*csi.Topology) *clusterSelection {
 		for _, topo := range list {
@@ -148,14 +145,33 @@ func (cs *controllerServer) resolveClusterSelection(req *csi.CreateVolumeRequest
 		return nil
 	}
 
-	if sel := tryList(topoReq.GetPreferred()); sel != nil {
-		return sel, nil
-	}
-	if sel := tryList(topoReq.GetRequisite()); sel != nil {
-		return sel, nil
+	if topoReq != nil {
+		if sel := tryList(topoReq.GetPreferred()); sel != nil {
+			return sel, nil
+		}
+		if sel := tryList(topoReq.GetRequisite()); sel != nil {
+			return sel, nil
+		}
 	}
 
-	return nil, fmt.Errorf("no cluster mapping found for topology requirements")
+	// No topology requirements (node has no topology labels) or no matching
+	// zone/region found. Fall back to a single-cluster configuration — if all
+	// zone/region entries point to the same cluster, use it. This allows nodes
+	// without topology labels to provision volumes without error.
+	uniqueClusters := map[string]struct{}{}
+	for _, id := range zoneMap {
+		uniqueClusters[id] = struct{}{}
+	}
+	for _, id := range regionMap {
+		uniqueClusters[id] = struct{}{}
+	}
+	if len(uniqueClusters) == 1 {
+		for id := range uniqueClusters {
+			return &clusterSelection{clusterID: id}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no cluster mapping found for topology requirements and no unambiguous fallback cluster (found %d distinct clusters)", len(uniqueClusters))
 }
 
 func parseStringMap(raw, paramName string) (map[string]string, error) {

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -161,7 +161,12 @@ func (ns *nodeServer) buildAccessibleTopology(ctx context.Context) map[string]st
 	}
 
 	if len(segments) == 0 {
-		return nil
+		// No zone/region labels found. Return hostname so the external-provisioner
+		// can still build AccessibilityRequirements — without at least one topology
+		// key on the CSINode, WaitForFirstConsumer provisioning fails. The controller
+		// falls through to its single-cluster fallback when hostname doesn't match
+		// any zone/region map entry.
+		return map[string]string{"topology.kubernetes.io/hostname": node.Name}
 	}
 
 	return segments

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -125,10 +125,21 @@ func (ns *nodeServer) buildAccessibleTopology(ctx context.Context) map[string]st
 		return nil
 	}
 
+	const maxRetries = 5
+	const retryDelay = 5 * time.Second
+
 	node, err := ns.kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	for attempt := 2; err != nil && attempt <= maxRetries; attempt++ {
+		klog.Warningf("topology discovery: failed to get node %s (attempt %d/%d): %v",
+			nodeName, attempt-1, maxRetries, err)
+		time.Sleep(retryDelay)
+		node, err = ns.kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	}
 	if err != nil {
-		klog.Warningf("failed to get node %s for topology discovery: %v", nodeName, err)
-		return nil
+		// All retries exhausted. Crash so the pod restarts and retries from a
+		// clean state — registering without topology silently breaks PVC provisioning.
+		klog.Fatalf("topology discovery: giving up after %d attempts for node %s — crashing to trigger pod restart: %v",
+			maxRetries, nodeName, err)
 	}
 
 	segments := make(map[string]string)

--- a/pkg/spdk/nodeserver.go
+++ b/pkg/spdk/nodeserver.go
@@ -166,7 +166,7 @@ func (ns *nodeServer) buildAccessibleTopology(ctx context.Context) map[string]st
 		// key on the CSINode, WaitForFirstConsumer provisioning fails. The controller
 		// falls through to its single-cluster fallback when hostname doesn't match
 		// any zone/region map entry.
-		return map[string]string{"topology.kubernetes.io/hostname": node.Name}
+		return map[string]string{"topology.simplyblock.io/hostname": node.Name}
 	}
 
 	return segments


### PR DESCRIPTION
## Summary

Fix two CSI node topology issues that caused provisioning failures in clusters where nodes do not have topology labels configured.

### Changes

**Topology not required for provisioning** (`controllerserver.go`)

Previously, `CreateVolume` would fail with "topology requirements are required" when a node had no topology labels — because the scheduler passes no `AccessibilityRequirements` for such nodes. Now, if all zone/region map entries resolve to a single cluster, that cluster is used as an implicit fallback, allowing nodes without topology labels to provision volumes without error. If multiple clusters are configured and no topology is available, a clear error is returned.

**Retry on node API unreachable** (`nodeserver.go`)

`NodeGetInfo` now retries fetching the Kubernetes node object up to 5 times (5 s between attempts) before giving up. If all retries are exhausted, the node plugin crashes via `klog.Fatalf` so kubelet restarts the pod and retries cleanly. If the node API is reachable but the node has no topology labels, `nil` is returned — which is valid and signals to the scheduler that this node has no topology constraints.

## Behaviour Matrix

| Node topology labels | Zone/region map clusters | Result |
|---|---|---|
| Present | Any | Matched by zone/region as before |
| Absent | 1 unique cluster | Falls back to that cluster |
| Absent | >1 unique clusters | Error — cannot determine cluster |
| `paramClusterID` set | — | Direct cluster use, no topology needed |

## Test Plan

- [x] Provision a PVC on a node with topology labels — existing behaviour unchanged
- [x] Provision a PVC on a node without topology labels (single-cluster) — succeeds
- [x] Verify node plugin retries on transient API failure and recovers
- [x] Verify node plugin crashes and restarts after 5 consecutive API failures

## Test Result 

```
[INFO]  === TEST 1: Transient API failure — expect retries then recovery ===
[INFO]  CSI pod: simplyblock-csi-node-7br6c  |  node: vm01.simplyblock3.localdomain  |  apiserver: 192.168.10.81
[INFO]  Creating privileged helper pod on node vm01.simplyblock3.localdomain...
[INFO]  Blocking kube-apiserver (192.168.10.81:6443) for 18s...
[INFO]  Restarting CSI pod to trigger fresh NodeGetInfo...
pod "simplyblock-csi-node-7br6c" force deleted
[INFO]  New pod: simplyblock-csi-node-4glmq
[INFO]  Watching for retry warning logs (up to 60s)...
[PASS]  Retry warnings detected
[INFO]  Lifting iptables block after 18s...
pod "topo-retry-helper-83677" force deleted
[INFO]  Waiting for pod to recover (up to 90s)...
[INFO]  Waiting for pod simplyblock-csi-node-4glmq to be Running...
[PASS]  Pod recovered without crashing — TEST 1 PASSED

[INFO]  === TEST 2: Persistent API failure — expect CrashLoopBackOff after 5 retries ===
[INFO]  CSI pod: simplyblock-csi-node-4glmq
[INFO]  Removing 'nodes' rule from ClusterRole simplyblock-csi-node-role...
[INFO]  RBAC patched — nodes/get permission removed
[INFO]  Restarting CSI pod...
pod "simplyblock-csi-node-4glmq" force deleted
[INFO]  New pod: simplyblock-csi-node-5gvjd
[INFO]  Watching for CrashLoopBackOff (up to 120s)...
[INFO]  Restoring RBAC for simplyblock-csi-node-role...
[PASS]  RBAC restored
[PASS]  Fatal log confirmed + pod in CrashLoopBackOff — TEST 2 PASSED

[INFO]  All requested tests **completed.**
```
## StorageClass contains Topology
#### On worker node with topology label
```
Events:
  Type     Reason                Age              From                                                                                   Message
  ----     ------                ----             ----                                                                                   -------
  Normal   WaitForFirstConsumer  4s               persistentvolume-controller                                                            waiting for first consumer to be created before binding
  Normal   ExternalProvisioning  4s (x2 over 4s)  persistentvolume-controller                                                            Waiting for a volume to be created either by the external provisioner 'csi.simplyblock.io' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal   Provisioning          2s (x2 over 4s)  csi.simplyblock.io_vm01.simplyblock3.localdomain_0bf177ef-ca56-4d57-aec3-4532e2cc52fc  External provisioner is provisioning volume for claim "default/drain-test-pvc"
  Warning  ProvisioningFailed    2s (x2 over 4s)  csi.simplyblock.io_vm01.simplyblock3.localdomain_0bf177ef-ca56-4d57-aec3-4532e2cc52fc  failed to provision volume with StorageClass "simplyblock-simplyblock-simplyblock-cluster-simplyblock-pool": rpc error: code = InvalidArgument desc = node "vm01.simplyblock3.localdomain" has no topology.kubernetes.io/zone or topology.kubernetes.io/region topology label but the StorageClass uses zone_cluster_map/region_cluster_map for cluster routing; add the appropriate zone or region label to the node, or switch the StorageClass to use cluster_id
```

#### On worker node with topology label
```
Events:
  Type    Reason                 Age              From                                                                                   Message
  ----    ------                 ----             ----                                                                                   -------
  Normal  WaitForFirstConsumer   3s               persistentvolume-controller                                                            waiting for first consumer to be created before binding
  Normal  ExternalProvisioning   3s (x2 over 3s)  persistentvolume-controller                                                            Waiting for a volume to be created either by the external provisioner 'csi.simplyblock.io' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  Provisioning           3s               csi.simplyblock.io_vm01.simplyblock3.localdomain_0bf177ef-ca56-4d57-aec3-4532e2cc52fc  External provisioner is provisioning volume for claim "default/drain-test-pvc"
  Normal  ProvisioningSucceeded  2s               csi.simplyblock.io_vm01.simplyblock3.localdomain_0bf177ef-ca56-4d57-aec3-4532e2cc52fc  Successfully provisioned volume pvc-03d204f8-c4e0-4dce-8995-750a2f434aa2
```