### PR TITLE
change the json field name of NSID of LvolConnectResp

### DIFF
--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -113,7 +113,7 @@ type LvolConnectResp struct {
 	TargetType     string `json:"transport"`
 	IP             string `json:"ip"`
 	Connect        string `json:"connect"`
-	NSID           int    `json:"ns_id"`
+	NSID           int    `json:"ns-id"`
 	HostIface      string `json:"host-iface,omitempty"`
 }
 


### PR DESCRIPTION
PR https://github.com/simplyblock/sbcli/pull/1170 changes all the fields of Lvol connect response to snake case. 

because of this, `ns_id` is sent as `ns-id`

because of this all the namespaces volumes where using NSID as 0. 

So changing the json field name. 




